### PR TITLE
perf: bump SDK semaphore to 6 in direct_kg and cold_start

### DIFF
--- a/backend/src/kestrel_backend/graph/nodes/cold_start.py
+++ b/backend/src/kestrel_backend/graph/nodes/cold_start.py
@@ -37,8 +37,8 @@ except ImportError:
 KESTREL_COMMAND = "uvx"
 KESTREL_ARGS = ["mcp-client-kestrel"]
 
-# Semaphore to serialize SDK calls and prevent concurrent CLI spawn issues
-SDK_SEMAPHORE = asyncio.Semaphore(1)
+# Semaphore to limit concurrent SDK calls (increased from 1 to 6 for parallelism)
+SDK_SEMAPHORE = asyncio.Semaphore(6)
 
 # Batch size for parallel analysis
 BATCH_SIZE = 6

--- a/backend/src/kestrel_backend/graph/nodes/direct_kg.py
+++ b/backend/src/kestrel_backend/graph/nodes/direct_kg.py
@@ -37,8 +37,8 @@ except ImportError:
 KESTREL_COMMAND = "uvx"
 KESTREL_ARGS = ["mcp-client-kestrel"]
 
-# Semaphore to serialize SDK calls and prevent concurrent CLI spawn issues
-SDK_SEMAPHORE = asyncio.Semaphore(1)
+# Semaphore to limit concurrent SDK calls (increased from 1 to 6 for parallelism)
+SDK_SEMAPHORE = asyncio.Semaphore(6)
 
 # Batch size for parallel analysis
 BATCH_SIZE = 6


### PR DESCRIPTION
## Summary
- Increases parallelism for LLM-based nodes from 1 to 6 concurrent SDK sessions

## Context
Entity resolution and triage now use direct API calls (Tier 1) and only fall back to SDK for failures, so this change primarily affects:
- **direct_kg**: analyzes well-characterized/moderate entities
- **cold_start**: analyzes sparse/unknown entities

## Expected Impact
With 8 entities in direct_kg, this should reduce time from ~8x sequential to ~2x with 6-way parallelism.

🤖 Generated with [Claude Code](https://claude.ai/code)