### PR TITLE
feat(literature-grounding): add references table to synthesis report

### DIFF
--- a/backend/src/kestrel_backend/graph/nodes/literature_grounding.py
+++ b/backend/src/kestrel_backend/graph/nodes/literature_grounding.py
@@ -78,10 +78,12 @@ def build_references_table(hypotheses: list[Hypothesis]) -> str:
 
     for hypothesis in with_lit:
         hyp_title = hypothesis.title[:80] + "..." if len(hypothesis.title) > 80 else hypothesis.title
+        hyp_title = hyp_title.replace("|", "\\|")  # Escape pipes for markdown table
         for lit in hypothesis.literature_support:
             # Format citation: "Authors (Year) Title"
             title_truncated = lit.title[:100] + "..." if len(lit.title) > 100 else lit.title
             citation = f'{lit.authors} ({lit.year}) "{title_truncated}"'
+            citation = citation.replace("|", "\\|")  # Escape pipes for markdown table
 
             # Prefer DOI link, fall back to url
             if lit.doi:


### PR DESCRIPTION
## Summary

- Add `build_references_table()` function to generate a markdown table of literature citations
- Append the table to the synthesis report at the end of the literature grounding node
- Table format includes hypothesis title, citation (Authors, Year, Title), and clickable DOI/URL links

## Table Format Example

```markdown
## Literature References

Papers discovered via semantic search. 45 papers across 15 hypotheses.

| Hypothesis | Citation | Link |
|------------|----------|------|
| C1QTNF1–AMPK Convergence | Smith et al. (2023) "CTRP1 and AMPK signaling in metabolic disease..." | [DOI](https://doi.org/10.1234/example) |
| Hexadecanedioate metabolism | Barovic et al. (2025) "Proteomic and Metabolomic Signatures..." | [DOI](https://doi.org/10.2337/dc24-1412) |
```

## Test plan

- [x] Unit tests for `build_references_table()` added (7 new tests)
- [x] All 47 tests pass
- [ ] Manual verification: run benchmark prompt and verify "## Literature References" section appears at end of report

🤖 Generated with [Claude Code](https://claude.com/claude-code)