### PR TITLE
feat: add evidence attribution tags to classic agent

### DIFF
--- a/backend/src/kestrel_backend/agent.py
+++ b/backend/src/kestrel_backend/agent.py
@@ -214,28 +214,19 @@ When in discovery mode, apply these principles:
    upstream causes, downstream consequences, or parallel effects. The graph is static but
    the biology is dynamic.
 
-## Source Attribution (IMPORTANT)
+## Evidence Attribution (REQUIRED)
 
-You have two knowledge sources:
-1. **Knowledge Graph (KG)**: Retrieved via tools - cite with CURIEs and source databases
-2. **Training Knowledge**: Your pre-trained biomedical understanding
+Every factual claim in your response MUST be tagged with its evidence source:
+- **[KG Evidence]** — finding came from Kestrel knowledge graph query results (tool calls, CURIEs, edge data)
+- **[Model Knowledge]** — claim is from general biomedical knowledge, not backed by KG query results
+- **[Inferred]** — derived by combining KG evidence with model knowledge
 
-When providing context NOT retrieved from the KG, mark it with a compact inline tag:
+If a section has no KG-backed findings, state this explicitly: "No direct KG evidence was found for this connection. The following is based on [Model Knowledge]."
 
-**[Model Knowledge]** - Use this before statements from your training data
-
-Examples requiring the marker:
-- Clinical practice guidelines and standard-of-care statements
-- Drug mechanism explanations beyond what's in the KG
-- Epidemiological context or prevalence statistics
-- Historical developments in the field
-
-**First occurrence**: When you first use [Model Knowledge] in a response, briefly explain: "Note: [Model Knowledge] indicates information from my training data rather than the knowledge graph."
-
-**Subsequent uses**: Just use the inline marker without explanation.
+Do NOT present model knowledge as if it were KG-derived. Scientific integrity requires honest attribution.
 
 Example:
-"Metformin is a first-line treatment for T2D [KG: MONDO:0005148 → treats → CHEBI:6801]. **[Model Knowledge]** Current ADA guidelines recommend it alongside lifestyle modifications, with GLP-1 agonists increasingly preferred for patients with cardiovascular risk."
+"[KG Evidence] Metformin treats type 2 diabetes (MONDO:0005148 → treats → CHEBI:6801, source: DrugCentral). [Model Knowledge] Current ADA guidelines recommend it alongside lifestyle modifications. [Inferred] Given the shared pathway neighbors between metformin and GLP-1 agonists, combination therapy may offer synergistic benefits."
 
 ## Evidence Quality Tiers
 


### PR DESCRIPTION
## Summary

- Replace the single `[Model Knowledge]` tag with the three-tag attribution system from the discovery pipeline
- Add `[KG Evidence]` tag for findings from Kestrel knowledge graph queries
- Add `[Inferred]` tag for conclusions derived by combining KG evidence with model knowledge
- Update example to demonstrate all three tags in context

## Why

The classic agent previously only had `[Model Knowledge]`, leaving KG evidence implicit (just cited with CURIEs). This asymmetry made it unclear when something was truly KG-derived vs inferred. Matching tags across both operating modes (classic agent + discovery pipeline) ensures consistent scientific transparency.

## Test plan

- [ ] Verify the three tags appear in classic agent responses
- [ ] Confirm tag usage matches the discovery pipeline's synthesis.py semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)