### PR TITLE
fix(cold-start): use direct HTTP API instead of unavailable MCP package

### DIFF
--- a/backend/src/kestrel_backend/graph/nodes/cold_start.py
+++ b/backend/src/kestrel_backend/graph/nodes/cold_start.py
@@ -258,7 +258,6 @@ Requirements:
 def parse_inference_result(
     curie: str,
     raw_name: str,
-    analogues: list[dict],
     result_text: str
 ) -> tuple[list[InferredAssociation], list[Finding]]:
     """
@@ -508,7 +507,7 @@ async def analyze_cold_start_entity(
 
         # Parse inference results
         inferences, findings = parse_inference_result(
-            curie, raw_name, similar_entities, result_text
+            curie, raw_name, result_text
         )
 
         # If no inferences were parsed, still report the analogues


### PR DESCRIPTION
- Replace mcp-client-kestrel (doesn't exist on PyPI) with direct
  call_kestrel_tool() calls via HTTP API
- Query similar_nodes and one_hop_query directly for deterministic
  KG data retrieval
- Use SDK only for inference reasoning (no MCP tools needed)
- Matches entity_resolution pattern for reliability
- Agent now reasons over REAL KG data instead of hallucinating
  connections from training knowledge
- Reduced timeout from 300s to 120s since no tool calls needed
- Graceful degradation: returns analogues even if inference fails

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
