### PR TITLE
feat: add pipeline baseline capture and assessment infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ backend/.env
 __pycache__/
 *.pyc
 .ruff_cache/
+
+# Assessment data — track queries and schema, ignore large cassettes and outputs
+backend/assessment_data/cassettes/
+backend/assessment_data/outputs/
+backend/assessment_data/canonical/
+backend/assessment_data/capture_summary.json

--- a/backend/assessment_data/queries.json
+++ b/backend/assessment_data/queries.json
@@ -1,0 +1,62 @@
+[
+  {
+    "query": "What is the relationship between NAD+ metabolism and cellular aging?",
+    "path_type": "well-characterized",
+    "expected_entities": ["NAD+", "aging"],
+    "notes": "Well-studied metabolite with extensive KG coverage"
+  },
+  {
+    "query": "How does the SIRT1 protein influence longevity pathways?",
+    "path_type": "well-characterized",
+    "expected_entities": ["SIRT1", "longevity"],
+    "notes": "Well-characterized sirtuin with many known associations"
+  },
+  {
+    "query": "What are the metabolic effects of berberine on glucose homeostasis?",
+    "path_type": "sparse",
+    "expected_entities": ["berberine", "glucose"],
+    "notes": "Natural compound with moderate KG coverage"
+  },
+  {
+    "query": "How does urolithin A affect mitochondrial function?",
+    "path_type": "sparse",
+    "expected_entities": ["urolithin A", "mitochondria"],
+    "notes": "Emerging metabolite with sparse KG edges"
+  },
+  {
+    "query": "What is the mechanism of action of pterostilbene in neuroprotection?",
+    "path_type": "cold-start",
+    "expected_entities": ["pterostilbene", "neuroprotection"],
+    "notes": "Resveratrol analogue — may trigger cold-start path"
+  },
+  {
+    "query": "How does ergothioneine protect against oxidative stress?",
+    "path_type": "cold-start",
+    "expected_entities": ["ergothioneine", "oxidative stress"],
+    "notes": "Rare amino acid — likely cold-start with analogue inference"
+  },
+  {
+    "query": "How do NAD+ levels change with age and what interventions restore them? Include longitudinal data.",
+    "path_type": "longitudinal",
+    "expected_entities": ["NAD+", "aging"],
+    "notes": "Explicit longitudinal framing should trigger temporal node"
+  },
+  {
+    "query": "Track the progression of insulin resistance markers over time in metabolic syndrome. Longitudinal analysis.",
+    "path_type": "longitudinal",
+    "expected_entities": ["insulin resistance", "metabolic syndrome"],
+    "notes": "Longitudinal query with clinical context"
+  },
+  {
+    "query": "What are the shared pathways between NMN supplementation, AMPK activation, and autophagy regulation?",
+    "path_type": "multi-entity",
+    "expected_entities": ["NMN", "AMPK", "autophagy"],
+    "notes": "Three entities — exercises integration node's cross-type bridging"
+  },
+  {
+    "query": "How do resveratrol, quercetin, and fisetin interact in senolytic therapy?",
+    "path_type": "multi-entity",
+    "expected_entities": ["resveratrol", "quercetin", "fisetin"],
+    "notes": "Multiple polyphenols — tests pathway enrichment across entities"
+  }
+]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -30,6 +30,8 @@ dev = [
     "pytest-asyncio>=0.23.0",
     "testcontainers[postgres]>=4.0.0",
     "httpx>=0.27.0",
+    "respx>=0.22.0",
+    "scipy>=1.14.0",
 ]
 
 [tool.pytest.ini_options]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -31,7 +31,7 @@ dev = [
     "testcontainers[postgres]>=4.0.0",
     "httpx>=0.27.0",
     "respx>=0.22.0",
-    "scipy>=1.14.0",
+    "scipy>=1.14.0",  # Used by PR5 scorer (Spearman correlation)
 ]
 
 [tool.pytest.ini_options]

--- a/backend/src/kestrel_backend/assessment/__init__.py
+++ b/backend/src/kestrel_backend/assessment/__init__.py
@@ -1,0 +1,5 @@
+"""Assessment infrastructure for the discovery pipeline.
+
+Provides tools for baseline capture, HTTP response recording/replay,
+structural regression checks, and LLM-as-judge quality scoring.
+"""

--- a/backend/src/kestrel_backend/assessment/capture.py
+++ b/backend/src/kestrel_backend/assessment/capture.py
@@ -17,6 +17,7 @@ import logging
 import time
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import httpx
 
@@ -90,10 +91,9 @@ class PipelineCapture:
             # Import here to avoid circular imports and heavy module loading at import time
             from ..graph.runner import run_discovery
 
-            # We need to intercept httpx calls during pipeline execution.
-            # respx works at the transport level, but for recording we need a
-            # passthrough approach: make real requests and capture the responses.
-            # We monkey-patch httpx.AsyncClient to wrap the send method.
+            # Intercept httpx calls during pipeline execution to record
+            # request/response pairs. Uses patch.object for safe, scoped
+            # patching (no global mutation, safe for concurrent use).
             original_send = httpx.AsyncClient.send
 
             async def recording_send(self_client, request, *args, **kwargs):
@@ -103,11 +103,8 @@ class PipelineCapture:
                     recorder.record_interaction(request, response)
                 return response
 
-            httpx.AsyncClient.send = recording_send
-            try:
+            with patch.object(httpx.AsyncClient, "send", recording_send):
                 state = await run_discovery(query, conversation_history)
-            finally:
-                httpx.AsyncClient.send = original_send
 
         except Exception as e:
             error = str(e)

--- a/backend/src/kestrel_backend/assessment/capture.py
+++ b/backend/src/kestrel_backend/assessment/capture.py
@@ -1,0 +1,218 @@
+"""Baseline capture infrastructure for the discovery pipeline.
+
+Records pipeline outputs and all external HTTP interactions (Kestrel KG,
+OpenAlex, Semantic Scholar, Exa, PubMed) for later replay during assessment
+runs. Uses the shared cassette module for transport-level HTTP interception.
+
+Usage:
+    python -m kestrel_backend.assessment.capture --query "NAD+ and aging" --output-dir assessment_data
+    python -m kestrel_backend.assessment.capture --queries assessment_data/queries.json --runs 5
+"""
+
+import argparse
+import asyncio
+import hashlib
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from .cassette import CassetteRecorder
+
+logger = logging.getLogger(__name__)
+
+
+def _serialize_state(state: dict[str, Any]) -> dict[str, Any]:
+    """Serialize a DiscoveryState dict to JSON-compatible format.
+
+    Handles Pydantic models (frozen BaseModel instances) by calling model_dump().
+    """
+    serialized = {}
+    for key, value in state.items():
+        serialized[key] = _serialize_value(value)
+    return serialized
+
+
+def _serialize_value(value: Any) -> Any:
+    """Recursively serialize a value to JSON-compatible format."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if hasattr(value, "model_dump"):
+        return value.model_dump()
+    if isinstance(value, list):
+        return [_serialize_value(item) for item in value]
+    if isinstance(value, dict):
+        return {k: _serialize_value(v) for k, v in value.items()}
+    if isinstance(value, tuple):
+        return [_serialize_value(item) for item in value]
+    # Fallback: convert to string
+    return str(value)
+
+
+def query_hash(query: str) -> str:
+    """Generate a short deterministic hash for a query string."""
+    return hashlib.md5(query.encode()).hexdigest()[:12]
+
+
+class PipelineCapture:
+    """Captures pipeline execution results and HTTP interactions."""
+
+    def __init__(self, output_dir: Path):
+        self.output_dir = output_dir
+        self.cassettes_dir = output_dir / "cassettes"
+        self.outputs_dir = output_dir / "outputs"
+        self.cassettes_dir.mkdir(parents=True, exist_ok=True)
+        self.outputs_dir.mkdir(parents=True, exist_ok=True)
+
+    async def capture_single(
+        self,
+        query: str,
+        run_number: int = 1,
+        conversation_history: list[tuple[str, str]] | None = None,
+    ) -> dict[str, Any]:
+        """Run the pipeline for a single query, recording HTTP interactions.
+
+        Returns a result dict with query, timing, output path, and cassette path.
+        """
+        qhash = query_hash(query)
+        cassette_path = self.cassettes_dir / f"{qhash}_run{run_number}.json"
+        output_path = self.outputs_dir / f"{qhash}_run{run_number}.json"
+
+        recorder = CassetteRecorder()
+        start_time = time.time()
+        error = None
+        state = None
+
+        try:
+            # Import here to avoid circular imports and heavy module loading at import time
+            from ..graph.runner import run_discovery
+
+            # We need to intercept httpx calls during pipeline execution.
+            # respx works at the transport level, but for recording we need a
+            # passthrough approach: make real requests and capture the responses.
+            # We monkey-patch httpx.AsyncClient to wrap the send method.
+            original_send = httpx.AsyncClient.send
+
+            async def recording_send(self_client, request, *args, **kwargs):
+                response = await original_send(self_client, request, *args, **kwargs)
+                # Only record external API calls, not localhost
+                if not str(request.url).startswith(("http://127.0.0.1", "http://localhost")):
+                    recorder.record_interaction(request, response)
+                return response
+
+            httpx.AsyncClient.send = recording_send
+            try:
+                state = await run_discovery(query, conversation_history)
+            finally:
+                httpx.AsyncClient.send = original_send
+
+        except Exception as e:
+            error = str(e)
+            logger.error("Pipeline execution failed for query '%s': %s", query[:50], e)
+
+        duration = time.time() - start_time
+
+        # Save cassette
+        metadata = {
+            "query": query,
+            "query_hash": qhash,
+            "run_number": run_number,
+            "duration_seconds": round(duration, 2),
+            "interaction_count": recorder.interaction_count,
+            "error": error,
+        }
+        recorder.save(cassette_path, metadata=metadata)
+
+        # Save pipeline output
+        if state is not None:
+            serialized = _serialize_state(state)
+            output_path.write_text(json.dumps(serialized, indent=2, default=str))
+            logger.info(
+                "Captured query '%s' run %d: %d interactions, %.1fs",
+                query[:50], run_number, recorder.interaction_count, duration,
+            )
+        else:
+            output_path.write_text(json.dumps({"error": error}, indent=2))
+
+        return {
+            "query": query,
+            "query_hash": qhash,
+            "run_number": run_number,
+            "duration_seconds": round(duration, 2),
+            "interaction_count": recorder.interaction_count,
+            "cassette_path": str(cassette_path),
+            "output_path": str(output_path),
+            "error": error,
+        }
+
+    async def capture_batch(
+        self,
+        queries: list[dict[str, Any]],
+        runs_per_query: int = 5,
+    ) -> list[dict[str, Any]]:
+        """Run batch capture: all queries x N runs.
+
+        Args:
+            queries: List of query dicts with at least a "query" key
+            runs_per_query: Number of runs per query for variance measurement
+
+        Returns:
+            List of result dicts, one per (query, run) pair
+        """
+        results = []
+        total = len(queries) * runs_per_query
+        completed = 0
+
+        for q in queries:
+            query_text = q["query"]
+            for run_num in range(1, runs_per_query + 1):
+                completed += 1
+                logger.info(
+                    "Capturing %d/%d: query='%s' run=%d",
+                    completed, total, query_text[:50], run_num,
+                )
+                result = await self.capture_single(query_text, run_number=run_num)
+                result["metadata"] = {k: v for k, v in q.items() if k != "query"}
+                results.append(result)
+
+        # Save batch summary
+        summary_path = self.output_dir / "capture_summary.json"
+        summary_path.write_text(json.dumps(results, indent=2, default=str))
+        logger.info("Batch capture complete: %d total runs", len(results))
+
+        return results
+
+
+async def main():
+    """CLI entry point for capture."""
+    parser = argparse.ArgumentParser(description="Capture pipeline baselines")
+    parser.add_argument("--query", type=str, help="Single query to capture")
+    parser.add_argument("--queries", type=str, help="Path to queries.json for batch mode")
+    parser.add_argument("--runs", type=int, default=5, help="Runs per query (default: 5)")
+    parser.add_argument(
+        "--output-dir", type=str, default="assessment_data",
+        help="Output directory (default: assessment_data)",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
+
+    capture = PipelineCapture(Path(args.output_dir))
+
+    if args.query:
+        result = await capture.capture_single(args.query)
+        print(json.dumps(result, indent=2))
+    elif args.queries:
+        queries_path = Path(args.queries)
+        queries = json.loads(queries_path.read_text())
+        results = await capture.capture_batch(queries, runs_per_query=args.runs)
+        print(f"Captured {len(results)} runs. Summary: {capture.output_dir / 'capture_summary.json'}")
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/src/kestrel_backend/assessment/cassette.py
+++ b/backend/src/kestrel_backend/assessment/cassette.py
@@ -129,32 +129,6 @@ class CassetteReplayer:
         return self._metadata
 
 
-def create_recording_transport(
-    recorder: CassetteRecorder,
-    base_transport: httpx.AsyncBaseTransport | None = None,
-) -> respx.MockRouter:
-    """Create a respx mock router that records all requests while passing them through.
-
-    This is used during baseline capture: real HTTP calls are made, but request/response
-    pairs are also recorded to the CassetteRecorder.
-
-    Returns a respx router configured to intercept all requests. The caller should
-    use it as a context manager or via respx.mock().
-    """
-    router = respx.MockRouter(assert_all_called=False)
-
-    def side_effect(request: httpx.Request) -> httpx.Response:
-        # This function is called by respx when a request matches.
-        # We can't make real network calls from inside respx side_effects easily,
-        # so recording mode uses a different approach — see the capture module.
-        raise NotImplementedError(
-            "Recording transport should not be used directly. "
-            "Use the capture module's record-then-save pattern instead."
-        )
-
-    return router
-
-
 def setup_replay(cassette_path: Path) -> tuple[respx.MockRouter, CassetteReplayer]:
     """Set up respx to replay cached responses from a cassette file.
 
@@ -180,7 +154,7 @@ def setup_replay(cassette_path: Path) -> tuple[respx.MockRouter, CassetteReplaye
                 "No cassette match for %s %s — passing through",
                 request.method, request.url,
             )
-            raise respx.errors.AllMockedResponsesSent(
+            raise RuntimeError(
                 f"No recorded response for {request.method} {request.url}"
             )
         return response

--- a/backend/src/kestrel_backend/assessment/cassette.py
+++ b/backend/src/kestrel_backend/assessment/cassette.py
@@ -111,7 +111,11 @@ class CassetteReplayer:
 
         idx = self._consumed.get(key, 0)
         if idx >= len(interactions):
-            # Wrap around if more requests than recorded (shouldn't happen in normal use)
+            # More requests than recorded — replay last response but warn
+            logger.warning(
+                "Over-consumption for key %s: recorded %d interaction(s), got request #%d; replaying last",
+                key, len(interactions), idx + 1,
+            )
             idx = len(interactions) - 1
 
         interaction = interactions[idx]

--- a/backend/src/kestrel_backend/assessment/cassette.py
+++ b/backend/src/kestrel_backend/assessment/cassette.py
@@ -1,0 +1,191 @@
+"""Shared HTTP cassette module for recording and replaying external API responses.
+
+Uses respx to intercept httpx calls at the transport level. Handles all 5 external
+API clients (Kestrel KG, OpenAlex, Semantic Scholar, Exa, PubMed) through a single
+mechanism.
+
+This module is the single point of respx integration for the entire assessment
+infrastructure — used by both the capture script (recording) and the assessment
+runner (replay).
+
+Key design constraint: Kestrel returns SSE-formatted responses (event: message\\ndata: {json}).
+respx intercepts at the transport level and returns the full response body, so SSE parsing
+via parse_sse_response(response.text) should work identically in replay mode.
+"""
+
+import hashlib
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import httpx
+import respx
+
+logger = logging.getLogger(__name__)
+
+
+class CassetteRecorder:
+    """Records HTTP request/response pairs during pipeline execution."""
+
+    def __init__(self):
+        self._interactions: list[dict[str, Any]] = []
+
+    def record_interaction(
+        self,
+        request: httpx.Request,
+        response: httpx.Response,
+    ) -> None:
+        """Capture a request/response pair."""
+        self._interactions.append({
+            "request": {
+                "method": request.method,
+                "url": str(request.url),
+                "headers": dict(request.headers),
+                "content": request.content.decode("utf-8") if request.content else None,
+            },
+            "response": {
+                "status_code": response.status_code,
+                "headers": dict(response.headers),
+                "text": response.text,
+            },
+        })
+
+    def save(self, path: Path, metadata: dict[str, Any] | None = None) -> None:
+        """Save recorded interactions to a JSON cassette file."""
+        cassette = {
+            "metadata": metadata or {},
+            "interactions": self._interactions,
+        }
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(cassette, indent=2))
+        logger.info("Saved cassette with %d interactions to %s", len(self._interactions), path)
+
+    @property
+    def interaction_count(self) -> int:
+        return len(self._interactions)
+
+
+def load_cassette(path: Path) -> dict[str, Any]:
+    """Load a cassette file from disk."""
+    return json.loads(path.read_text())
+
+
+def _request_key(method: str, url: str, content: str | None) -> str:
+    """Generate a deterministic key for matching requests during replay."""
+    # Hash the request body for POST requests (Kestrel JSON-RPC)
+    body_hash = hashlib.md5(content.encode()).hexdigest() if content else ""
+    return f"{method}:{url}:{body_hash}"
+
+
+class CassetteReplayer:
+    """Replays recorded HTTP responses during assessment runs.
+
+    Sets up respx routes that match recorded requests and return cached responses.
+    Unmatched requests pass through to the real network (for LLM/SDK calls that
+    don't use httpx).
+    """
+
+    def __init__(self, cassette_data: dict[str, Any]):
+        self._interactions = cassette_data["interactions"]
+        self._metadata = cassette_data.get("metadata", {})
+        # Index interactions by request key for fast lookup
+        self._lookup: dict[str, list[dict]] = {}
+        for interaction in self._interactions:
+            req = interaction["request"]
+            key = _request_key(req["method"], req["url"], req.get("content"))
+            self._lookup.setdefault(key, []).append(interaction)
+        # Track consumption index per key for sequential replay
+        self._consumed: dict[str, int] = {}
+
+    def get_response(self, request: httpx.Request) -> httpx.Response | None:
+        """Look up the recorded response for a given request."""
+        key = _request_key(
+            request.method,
+            str(request.url),
+            request.content.decode("utf-8") if request.content else None,
+        )
+        interactions = self._lookup.get(key, [])
+        if not interactions:
+            return None
+
+        idx = self._consumed.get(key, 0)
+        if idx >= len(interactions):
+            # Wrap around if more requests than recorded (shouldn't happen in normal use)
+            idx = len(interactions) - 1
+
+        interaction = interactions[idx]
+        self._consumed[key] = idx + 1
+
+        resp_data = interaction["response"]
+        return httpx.Response(
+            status_code=resp_data["status_code"],
+            headers=resp_data.get("headers", {}),
+            text=resp_data["text"],
+        )
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        return self._metadata
+
+
+def create_recording_transport(
+    recorder: CassetteRecorder,
+    base_transport: httpx.AsyncBaseTransport | None = None,
+) -> respx.MockRouter:
+    """Create a respx mock router that records all requests while passing them through.
+
+    This is used during baseline capture: real HTTP calls are made, but request/response
+    pairs are also recorded to the CassetteRecorder.
+
+    Returns a respx router configured to intercept all requests. The caller should
+    use it as a context manager or via respx.mock().
+    """
+    router = respx.MockRouter(assert_all_called=False)
+
+    def side_effect(request: httpx.Request) -> httpx.Response:
+        # This function is called by respx when a request matches.
+        # We can't make real network calls from inside respx side_effects easily,
+        # so recording mode uses a different approach — see the capture module.
+        raise NotImplementedError(
+            "Recording transport should not be used directly. "
+            "Use the capture module's record-then-save pattern instead."
+        )
+
+    return router
+
+
+def setup_replay(cassette_path: Path) -> tuple[respx.MockRouter, CassetteReplayer]:
+    """Set up respx to replay cached responses from a cassette file.
+
+    Returns (router, replayer) tuple. The router should be used as a context manager.
+    Unmatched requests will raise an error (all external APIs should be in the cassette).
+
+    Usage:
+        router, replayer = setup_replay(cassette_path)
+        with router:
+            # Pipeline runs here, all external HTTP calls served from cassette
+            result = await run_discovery(query)
+    """
+    cassette_data = load_cassette(cassette_path)
+    replayer = CassetteReplayer(cassette_data)
+
+    router = respx.MockRouter(assert_all_called=False)
+
+    def replay_handler(request: httpx.Request) -> httpx.Response:
+        response = replayer.get_response(request)
+        if response is None:
+            # Log unmatched request for debugging
+            logger.warning(
+                "No cassette match for %s %s — passing through",
+                request.method, request.url,
+            )
+            raise respx.errors.AllMockedResponsesSent(
+                f"No recorded response for {request.method} {request.url}"
+            )
+        return response
+
+    # Match all HTTP requests
+    router.route().mock(side_effect=replay_handler)
+
+    return router, replayer

--- a/backend/src/kestrel_backend/assessment/variance.py
+++ b/backend/src/kestrel_backend/assessment/variance.py
@@ -1,0 +1,261 @@
+"""Variance computation and tolerance band generation for baseline assessment.
+
+Computes per-metric statistics across multiple runs of the same query,
+producing tolerance bands that structural checks use to detect regressions.
+
+Tolerance bands are mean +/- 2 standard deviations per metric. Queries with
+coefficient of variation (CV) > 0.5 on finding counts are flagged as 'warning'
+rather than producing hard pass/fail boundaries.
+"""
+
+import json
+import logging
+import statistics
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Metrics extracted from pipeline output for variance analysis
+STRUCTURAL_METRICS = [
+    "resolved_entity_count",
+    "direct_finding_count",
+    "cold_start_finding_count",
+    "hypothesis_count",
+    "shared_neighbor_count",
+    "bridge_count",
+    "error_count",
+]
+
+# Pre-LLM deterministic fields — these should have zero variance across runs
+# with the same KG responses (useful for refactor verification)
+DETERMINISTIC_FIELDS = [
+    "resolved_curies",  # Set of CURIEs from entity resolution
+    "node_execution_set",  # Which nodes ran
+]
+
+CV_WARNING_THRESHOLD = 0.5
+
+
+def extract_metrics(state: dict[str, Any]) -> dict[str, Any]:
+    """Extract assessment metrics from a serialized DiscoveryState.
+
+    Returns a dict of metric_name -> value for variance analysis.
+    """
+    metrics = {}
+
+    # Count-based metrics
+    metrics["resolved_entity_count"] = len(state.get("resolved_entities", []))
+    metrics["direct_finding_count"] = len(state.get("direct_findings", []))
+    metrics["cold_start_finding_count"] = len(state.get("cold_start_findings", []))
+    metrics["hypothesis_count"] = len(state.get("hypotheses", []))
+    metrics["shared_neighbor_count"] = len(state.get("shared_neighbors", []))
+    metrics["bridge_count"] = len(state.get("bridges", []))
+    metrics["error_count"] = len(state.get("errors", []))
+
+    # Deterministic fields (for refactor verification)
+    resolved = state.get("resolved_entities", [])
+    if resolved:
+        curies = sorted(
+            e.get("curie", "") if isinstance(e, dict) else ""
+            for e in resolved
+            if (e.get("curie") if isinstance(e, dict) else None)
+        )
+        metrics["resolved_curies"] = curies
+    else:
+        metrics["resolved_curies"] = []
+
+    # Node execution detection (which nodes produced output)
+    node_indicators = {
+        "intake": "raw_entities",
+        "entity_resolution": "resolved_entities",
+        "triage": "novelty_scores",
+        "direct_kg": "direct_findings",
+        "cold_start": "cold_start_findings",
+        "pathway_enrichment": "shared_neighbors",
+        "integration": "bridges",
+        "temporal": "temporal_classifications",
+        "synthesis": "synthesis_report",
+        "literature_grounding": "hypotheses",
+    }
+    executed = sorted(
+        node for node, field in node_indicators.items()
+        if state.get(field) is not None and state.get(field) != []
+    )
+    metrics["node_execution_set"] = executed
+
+    return metrics
+
+
+def compute_tolerance_bands(
+    runs: list[dict[str, Any]],
+    query_metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Compute tolerance bands from multiple runs of the same query.
+
+    Args:
+        runs: List of metric dicts (one per run) from extract_metrics()
+        query_metadata: Optional metadata about the query (path_type, etc.)
+
+    Returns:
+        Tolerance band dict with per-metric statistics and warning flags.
+    """
+    if not runs:
+        return {"error": "No runs provided"}
+
+    bands = {}
+    warnings = []
+
+    for metric in STRUCTURAL_METRICS:
+        values = [r.get(metric, 0) for r in runs]
+        n = len(values)
+
+        if n < 2:
+            bands[metric] = {
+                "mean": values[0] if values else 0,
+                "stddev": 0,
+                "min": values[0] if values else 0,
+                "max": values[0] if values else 0,
+                "lower_bound": values[0] if values else 0,
+                "upper_bound": values[0] if values else 0,
+                "n": n,
+                "cv": 0,
+                "status": "insufficient_data",
+            }
+            continue
+
+        mean = statistics.mean(values)
+        stddev = statistics.stdev(values)
+        cv = stddev / mean if mean > 0 else 0
+
+        status = "ok"
+        if cv > CV_WARNING_THRESHOLD:
+            status = "warning"
+            warnings.append(f"{metric}: CV={cv:.3f} exceeds threshold {CV_WARNING_THRESHOLD}")
+
+        bands[metric] = {
+            "mean": round(mean, 4),
+            "stddev": round(stddev, 4),
+            "min": min(values),
+            "max": max(values),
+            "lower_bound": round(max(0, mean - 2 * stddev), 4),
+            "upper_bound": round(mean + 2 * stddev, 4),
+            "n": n,
+            "cv": round(cv, 4),
+            "status": status,
+        }
+
+    # Deterministic fields — check for consistency
+    for field in DETERMINISTIC_FIELDS:
+        field_values = [json.dumps(r.get(field, []), sort_keys=True) for r in runs]
+        unique = set(field_values)
+        bands[field] = {
+            "consistent": len(unique) == 1,
+            "unique_values": len(unique),
+            "canonical_value": json.loads(field_values[0]) if field_values else None,
+        }
+        if len(unique) > 1:
+            warnings.append(f"{field}: expected consistent but found {len(unique)} unique values")
+
+    result = {
+        "metric_bands": bands,
+        "warnings": warnings,
+        "run_count": len(runs),
+    }
+
+    if query_metadata:
+        result["query_metadata"] = query_metadata
+
+    return result
+
+
+def select_canonical_run(
+    runs: list[dict[str, Any]],
+    outputs: list[dict[str, Any]],
+) -> tuple[int, dict[str, Any]]:
+    """Select the canonical run (median finding count) for Tier 2 scoring.
+
+    Args:
+        runs: List of metric dicts from extract_metrics()
+        outputs: List of full pipeline output dicts (parallel to runs)
+
+    Returns:
+        (run_index, output_dict) of the canonical run
+    """
+    # Use total finding count as the selection metric
+    finding_counts = [
+        r.get("direct_finding_count", 0) + r.get("cold_start_finding_count", 0)
+        for r in runs
+    ]
+
+    # Find the run closest to the median
+    median_val = statistics.median(finding_counts)
+    closest_idx = min(
+        range(len(finding_counts)),
+        key=lambda i: abs(finding_counts[i] - median_val),
+    )
+
+    return closest_idx, outputs[closest_idx]
+
+
+def compute_all_tolerance_bands(
+    output_dir: Path,
+    queries: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Compute tolerance bands for all queries from stored outputs.
+
+    Reads pipeline outputs from output_dir, extracts metrics, computes
+    tolerance bands, and returns the full tolerance band dataset.
+
+    Args:
+        output_dir: Directory containing pipeline output JSON files
+        queries: List of query dicts with "query" key
+
+    Returns:
+        Dict mapping query_hash -> tolerance_band_data
+    """
+    from .capture import query_hash as qhash
+
+    all_bands = {}
+
+    for q in queries:
+        query_text = q["query"]
+        qh = qhash(query_text)
+
+        # Find all output files for this query
+        run_outputs = []
+        run_metrics = []
+        run_num = 1
+
+        while True:
+            output_path = output_dir / "outputs" / f"{qh}_run{run_num}.json"
+            if not output_path.exists():
+                break
+            output_data = json.loads(output_path.read_text())
+            if "error" not in output_data or output_data.get("error") is None:
+                metrics = extract_metrics(output_data)
+                run_metrics.append(metrics)
+                run_outputs.append(output_data)
+            else:
+                logger.warning("Skipping failed run %d for query '%s'", run_num, query_text[:50])
+            run_num += 1
+
+        if not run_metrics:
+            logger.warning("No successful runs for query '%s'", query_text[:50])
+            continue
+
+        bands = compute_tolerance_bands(run_metrics, query_metadata=q)
+
+        # Select canonical run
+        if run_outputs:
+            canonical_idx, canonical_output = select_canonical_run(run_metrics, run_outputs)
+            bands["canonical_run_index"] = canonical_idx + 1  # 1-indexed
+
+            # Save canonical output separately
+            canonical_path = output_dir / "canonical" / f"{qh}.json"
+            canonical_path.parent.mkdir(parents=True, exist_ok=True)
+            canonical_path.write_text(json.dumps(canonical_output, indent=2, default=str))
+
+        all_bands[qh] = bands
+
+    return all_bands

--- a/backend/tests/test_assessment_capture.py
+++ b/backend/tests/test_assessment_capture.py
@@ -1,0 +1,212 @@
+"""Tests for pipeline capture infrastructure.
+
+Tests the capture script's ability to record pipeline executions,
+serialize state, and produce valid cassette + output files.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from kestrel_backend.assessment.capture import (
+    PipelineCapture,
+    _serialize_state,
+    _serialize_value,
+    query_hash,
+)
+
+
+class MockPydanticModel:
+    """Minimal mock for frozen Pydantic BaseModel instances."""
+
+    def __init__(self, data: dict):
+        self._data = data
+
+    def model_dump(self):
+        return self._data
+
+
+class TestSerializeState:
+    """Test state serialization for JSON output."""
+
+    def test_serialize_primitives(self):
+        state = {"query": "NAD+", "count": 42, "score": 0.95, "active": True}
+        result = _serialize_state(state)
+        assert result == state
+
+    def test_serialize_pydantic_model(self):
+        model = MockPydanticModel({"name": "NAD+", "curie": "CHEBI:15422"})
+        state = {"entity": model}
+        result = _serialize_state(state)
+        assert result == {"entity": {"name": "NAD+", "curie": "CHEBI:15422"}}
+
+    def test_serialize_list_of_models(self):
+        models = [
+            MockPydanticModel({"name": "NAD+"}),
+            MockPydanticModel({"name": "SIRT1"}),
+        ]
+        state = {"entities": models}
+        result = _serialize_state(state)
+        assert result == {"entities": [{"name": "NAD+"}, {"name": "SIRT1"}]}
+
+    def test_serialize_nested_dict(self):
+        state = {"analysis": {"phase": "intake", "results": [1, 2, 3]}}
+        result = _serialize_state(state)
+        assert result == {"analysis": {"phase": "intake", "results": [1, 2, 3]}}
+
+    def test_serialize_none_values(self):
+        state = {"data": None, "items": [None, "value"]}
+        result = _serialize_state(state)
+        assert result == {"data": None, "items": [None, "value"]}
+
+    def test_serialize_empty_state(self):
+        assert _serialize_state({}) == {}
+
+    def test_serialize_tuple_to_list(self):
+        state = {"pair": ("a", "b")}
+        result = _serialize_state(state)
+        assert result == {"pair": ["a", "b"]}
+
+
+class TestQueryHash:
+    """Test deterministic query hashing."""
+
+    def test_same_query_same_hash(self):
+        assert query_hash("NAD+ and aging") == query_hash("NAD+ and aging")
+
+    def test_different_query_different_hash(self):
+        assert query_hash("NAD+ and aging") != query_hash("SIRT1 and longevity")
+
+    def test_hash_length(self):
+        assert len(query_hash("test query")) == 12
+
+
+class TestPipelineCapture:
+    """Test the capture workflow."""
+
+    async def test_capture_single_produces_files(self, tmp_path: Path):
+        """Capture should produce cassette and output JSON files."""
+        capture = PipelineCapture(tmp_path)
+
+        # Mock run_discovery to return a simple state dict
+        mock_state = {
+            "raw_query": "NAD+ and aging",
+            "resolved_entities": [
+                MockPydanticModel({"raw_name": "NAD+", "curie": "CHEBI:15422"})
+            ],
+            "synthesis_report": "Test report",
+            "hypotheses": [],
+            "errors": [],
+        }
+
+        # Patch at the source module since capture_single imports it locally
+        with patch(
+            "kestrel_backend.graph.runner.run_discovery",
+            new_callable=AsyncMock,
+            return_value=mock_state,
+        ):
+            result = await capture.capture_single("NAD+ and aging", run_number=1)
+
+        assert result["error"] is None
+        assert result["run_number"] == 1
+        assert result["query"] == "NAD+ and aging"
+
+        # Check cassette file exists and is valid JSON
+        cassette_path = Path(result["cassette_path"])
+        assert cassette_path.exists()
+        cassette_data = json.loads(cassette_path.read_text())
+        assert "metadata" in cassette_data
+        assert "interactions" in cassette_data
+        assert cassette_data["metadata"]["query"] == "NAD+ and aging"
+
+        # Check output file exists and is valid JSON
+        output_path = Path(result["output_path"])
+        assert output_path.exists()
+        output_data = json.loads(output_path.read_text())
+        assert output_data["raw_query"] == "NAD+ and aging"
+        assert output_data["synthesis_report"] == "Test report"
+        assert output_data["resolved_entities"] == [{"raw_name": "NAD+", "curie": "CHEBI:15422"}]
+
+    async def test_capture_handles_pipeline_failure(self, tmp_path: Path):
+        """Capture should handle pipeline failures gracefully."""
+        capture = PipelineCapture(tmp_path)
+
+        with patch(
+            "kestrel_backend.graph.runner.run_discovery",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("API timeout"),
+        ):
+            result = await capture.capture_single("failing query", run_number=1)
+
+        assert result["error"] is not None
+        assert "API timeout" in result["error"]
+
+        # Output file should contain the error
+        output_path = Path(result["output_path"])
+        assert output_path.exists()
+        output_data = json.loads(output_path.read_text())
+        assert "error" in output_data
+
+    async def test_capture_empty_findings(self, tmp_path: Path):
+        """Capture should produce valid JSON even with empty findings."""
+        capture = PipelineCapture(tmp_path)
+
+        mock_state = {
+            "raw_query": "unknown entity xyz",
+            "resolved_entities": [],
+            "direct_findings": [],
+            "hypotheses": [],
+            "errors": [],
+        }
+
+        with patch(
+            "kestrel_backend.graph.runner.run_discovery",
+            new_callable=AsyncMock,
+            return_value=mock_state,
+        ):
+            result = await capture.capture_single("unknown entity xyz", run_number=1)
+
+        assert result["error"] is None
+        output_data = json.loads(Path(result["output_path"]).read_text())
+        assert output_data["resolved_entities"] == []
+        assert output_data["hypotheses"] == []
+
+    async def test_capture_batch_runs_all_queries(self, tmp_path: Path):
+        """Batch capture should run each query the specified number of times."""
+        capture = PipelineCapture(tmp_path)
+
+        mock_state = {"raw_query": "test", "errors": []}
+        call_count = 0
+
+        async def mock_run(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return mock_state
+
+        queries = [
+            {"query": "query A", "path_type": "well-characterized"},
+            {"query": "query B", "path_type": "sparse"},
+        ]
+
+        with patch(
+            "kestrel_backend.graph.runner.run_discovery",
+            new_callable=AsyncMock,
+            side_effect=mock_run,
+        ):
+            results = await capture.capture_batch(queries, runs_per_query=2)
+
+        assert len(results) == 4  # 2 queries x 2 runs
+        assert call_count == 4
+
+        # Check summary file
+        summary_path = tmp_path / "capture_summary.json"
+        assert summary_path.exists()
+
+    async def test_capture_directory_structure(self, tmp_path: Path):
+        """Capture should create proper directory structure."""
+        capture = PipelineCapture(tmp_path)
+
+        assert (tmp_path / "cassettes").is_dir()
+        assert (tmp_path / "outputs").is_dir()

--- a/backend/tests/test_assessment_variance.py
+++ b/backend/tests/test_assessment_variance.py
@@ -1,0 +1,196 @@
+"""Tests for variance computation and tolerance band generation."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kestrel_backend.assessment.variance import (
+    CV_WARNING_THRESHOLD,
+    extract_metrics,
+    compute_tolerance_bands,
+    select_canonical_run,
+)
+
+
+class TestExtractMetrics:
+    """Test metric extraction from pipeline state."""
+
+    def test_extract_from_populated_state(self):
+        state = {
+            "resolved_entities": [
+                {"raw_name": "NAD+", "curie": "CHEBI:15422"},
+                {"raw_name": "SIRT1", "curie": "HGNC:14929"},
+            ],
+            "direct_findings": [{"text": "finding1"}, {"text": "finding2"}],
+            "cold_start_findings": [],
+            "hypotheses": [{"claim": "h1"}],
+            "shared_neighbors": [{"entity": "n1"}, {"entity": "n2"}, {"entity": "n3"}],
+            "bridges": [{"source": "a", "target": "b"}],
+            "errors": [],
+            "raw_entities": ["NAD+", "SIRT1"],
+            "novelty_scores": [{"curie": "CHEBI:15422"}],
+            "synthesis_report": "report text",
+        }
+        metrics = extract_metrics(state)
+
+        assert metrics["resolved_entity_count"] == 2
+        assert metrics["direct_finding_count"] == 2
+        assert metrics["cold_start_finding_count"] == 0
+        assert metrics["hypothesis_count"] == 1
+        assert metrics["shared_neighbor_count"] == 3
+        assert metrics["bridge_count"] == 1
+        assert metrics["error_count"] == 0
+        assert metrics["resolved_curies"] == ["CHEBI:15422", "HGNC:14929"]
+        assert "intake" in metrics["node_execution_set"]
+        assert "entity_resolution" in metrics["node_execution_set"]
+        assert "synthesis" in metrics["node_execution_set"]
+
+    def test_extract_from_empty_state(self):
+        metrics = extract_metrics({})
+
+        assert metrics["resolved_entity_count"] == 0
+        assert metrics["hypothesis_count"] == 0
+        assert metrics["resolved_curies"] == []
+        assert metrics["node_execution_set"] == []
+
+    def test_extract_curies_sorted(self):
+        state = {
+            "resolved_entities": [
+                {"raw_name": "B", "curie": "HGNC:999"},
+                {"raw_name": "A", "curie": "CHEBI:111"},
+            ],
+        }
+        metrics = extract_metrics(state)
+        assert metrics["resolved_curies"] == ["CHEBI:111", "HGNC:999"]
+
+    def test_extract_skips_none_curies(self):
+        state = {
+            "resolved_entities": [
+                {"raw_name": "NAD+", "curie": "CHEBI:15422"},
+                {"raw_name": "unknown", "curie": None},
+            ],
+        }
+        metrics = extract_metrics(state)
+        assert metrics["resolved_curies"] == ["CHEBI:15422"]
+
+
+class TestComputeToleranceBands:
+    """Test tolerance band computation."""
+
+    def test_basic_tolerance_bands(self):
+        runs = [
+            {"resolved_entity_count": 3, "direct_finding_count": 10, "cold_start_finding_count": 0,
+             "hypothesis_count": 5, "shared_neighbor_count": 8, "bridge_count": 2, "error_count": 0,
+             "resolved_curies": ["A", "B", "C"], "node_execution_set": ["intake", "synthesis"]},
+            {"resolved_entity_count": 3, "direct_finding_count": 12, "cold_start_finding_count": 0,
+             "hypothesis_count": 4, "shared_neighbor_count": 7, "bridge_count": 3, "error_count": 0,
+             "resolved_curies": ["A", "B", "C"], "node_execution_set": ["intake", "synthesis"]},
+            {"resolved_entity_count": 3, "direct_finding_count": 11, "cold_start_finding_count": 0,
+             "hypothesis_count": 5, "shared_neighbor_count": 9, "bridge_count": 2, "error_count": 0,
+             "resolved_curies": ["A", "B", "C"], "node_execution_set": ["intake", "synthesis"]},
+        ]
+        bands = compute_tolerance_bands(runs)
+
+        assert bands["run_count"] == 3
+        assert bands["metric_bands"]["resolved_entity_count"]["mean"] == 3.0
+        assert bands["metric_bands"]["resolved_entity_count"]["stddev"] == 0.0
+        assert bands["metric_bands"]["direct_finding_count"]["mean"] == 11.0
+        assert bands["metric_bands"]["direct_finding_count"]["status"] == "ok"
+
+        # Deterministic fields should be consistent
+        assert bands["metric_bands"]["resolved_curies"]["consistent"] is True
+        assert bands["metric_bands"]["node_execution_set"]["consistent"] is True
+
+    def test_high_variance_warning(self):
+        # CV > 0.5 triggers warning
+        runs = [
+            {"resolved_entity_count": 2, "direct_finding_count": 5, "cold_start_finding_count": 0,
+             "hypothesis_count": 1, "shared_neighbor_count": 0, "bridge_count": 0, "error_count": 0,
+             "resolved_curies": [], "node_execution_set": []},
+            {"resolved_entity_count": 2, "direct_finding_count": 20, "cold_start_finding_count": 0,
+             "hypothesis_count": 8, "shared_neighbor_count": 0, "bridge_count": 0, "error_count": 0,
+             "resolved_curies": [], "node_execution_set": []},
+        ]
+        bands = compute_tolerance_bands(runs)
+
+        # direct_finding_count has high variance (5 vs 20)
+        dfc = bands["metric_bands"]["direct_finding_count"]
+        assert dfc["cv"] > CV_WARNING_THRESHOLD
+        assert dfc["status"] == "warning"
+        assert any("direct_finding_count" in w for w in bands["warnings"])
+
+    def test_single_run_insufficient_data(self):
+        runs = [
+            {"resolved_entity_count": 5, "direct_finding_count": 10, "cold_start_finding_count": 0,
+             "hypothesis_count": 3, "shared_neighbor_count": 4, "bridge_count": 1, "error_count": 0,
+             "resolved_curies": [], "node_execution_set": []},
+        ]
+        bands = compute_tolerance_bands(runs)
+        assert bands["metric_bands"]["resolved_entity_count"]["status"] == "insufficient_data"
+
+    def test_empty_runs(self):
+        bands = compute_tolerance_bands([])
+        assert "error" in bands
+
+    def test_inconsistent_deterministic_fields(self):
+        runs = [
+            {"resolved_entity_count": 2, "direct_finding_count": 5, "cold_start_finding_count": 0,
+             "hypothesis_count": 1, "shared_neighbor_count": 0, "bridge_count": 0, "error_count": 0,
+             "resolved_curies": ["A", "B"], "node_execution_set": ["intake"]},
+            {"resolved_entity_count": 2, "direct_finding_count": 5, "cold_start_finding_count": 0,
+             "hypothesis_count": 1, "shared_neighbor_count": 0, "bridge_count": 0, "error_count": 0,
+             "resolved_curies": ["A", "C"], "node_execution_set": ["intake"]},
+        ]
+        bands = compute_tolerance_bands(runs)
+        assert bands["metric_bands"]["resolved_curies"]["consistent"] is False
+        assert any("resolved_curies" in w for w in bands["warnings"])
+
+    def test_query_metadata_included(self):
+        runs = [
+            {"resolved_entity_count": 3, "direct_finding_count": 10, "cold_start_finding_count": 0,
+             "hypothesis_count": 5, "shared_neighbor_count": 8, "bridge_count": 2, "error_count": 0,
+             "resolved_curies": [], "node_execution_set": []},
+        ] * 3
+        metadata = {"path_type": "well-characterized", "query": "test"}
+        bands = compute_tolerance_bands(runs, query_metadata=metadata)
+        assert bands["query_metadata"]["path_type"] == "well-characterized"
+
+
+class TestSelectCanonicalRun:
+    """Test canonical run selection."""
+
+    def test_selects_median_finding_count(self):
+        runs = [
+            {"direct_finding_count": 5, "cold_start_finding_count": 0},
+            {"direct_finding_count": 10, "cold_start_finding_count": 0},
+            {"direct_finding_count": 15, "cold_start_finding_count": 0},
+            {"direct_finding_count": 8, "cold_start_finding_count": 0},
+            {"direct_finding_count": 12, "cold_start_finding_count": 0},
+        ]
+        outputs = [{"run": i} for i in range(5)]
+
+        idx, output = select_canonical_run(runs, outputs)
+        # Median is 10, which is index 1
+        selected_count = runs[idx]["direct_finding_count"]
+        assert selected_count == 10
+
+    def test_includes_cold_start_findings(self):
+        runs = [
+            {"direct_finding_count": 0, "cold_start_finding_count": 5},
+            {"direct_finding_count": 0, "cold_start_finding_count": 10},
+            {"direct_finding_count": 0, "cold_start_finding_count": 7},
+        ]
+        outputs = [{"run": i} for i in range(3)]
+
+        idx, output = select_canonical_run(runs, outputs)
+        total = runs[idx]["direct_finding_count"] + runs[idx]["cold_start_finding_count"]
+        assert total == 7  # Median of [5, 10, 7] = 7
+
+    def test_single_run(self):
+        runs = [{"direct_finding_count": 5, "cold_start_finding_count": 2}]
+        outputs = [{"run": 0}]
+
+        idx, output = select_canonical_run(runs, outputs)
+        assert idx == 0
+        assert output == {"run": 0}

--- a/backend/tests/test_cassette_spike.py
+++ b/backend/tests/test_cassette_spike.py
@@ -1,0 +1,267 @@
+"""Spike test: Validate respx can intercept and replay Kestrel SSE responses.
+
+This is the Unit 0 gating test. If Kestrel SSE round-trips correctly through
+respx record/replay, we proceed with transport-level recording. If it fails,
+we fall back to function-level mocking.
+
+Decision gate: Binary on Kestrel SSE — parsed JSON must be byte-identical
+after round-trip through respx.
+"""
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+
+from kestrel_backend.assessment.cassette import (
+    CassetteRecorder,
+    CassetteReplayer,
+    load_cassette,
+    setup_replay,
+)
+from kestrel_backend.kestrel_client import parse_sse_response
+
+
+# --- Synthetic SSE responses for testing ---
+
+KESTREL_SSE_RESPONSE = (
+    'event: message\n'
+    'data: {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text",'
+    '"text":"{\\"entities\\":[{\\"name\\":\\"NAD+\\",\\"curie\\":\\"CHEBI:15422\\"}]}"}]}}\n'
+)
+
+KESTREL_SSE_PARSED = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "content": [
+            {
+                "type": "text",
+                "text": '{"entities":[{"name":"NAD+","curie":"CHEBI:15422"}]}',
+            }
+        ]
+    },
+}
+
+OPENALEX_JSON_RESPONSE = {
+    "results": [
+        {
+            "id": "https://openalex.org/W12345",
+            "title": "NAD+ metabolism in aging",
+            "publication_year": 2023,
+            "cited_by_count": 42,
+        }
+    ]
+}
+
+
+class TestRespxSSECompat:
+    """Validate that respx can record and replay SSE-formatted responses."""
+
+    @respx.mock
+    async def test_kestrel_sse_roundtrip_via_respx(self):
+        """Core spike test: SSE response round-trips through respx with identical parsed output."""
+        # Mock a Kestrel endpoint returning SSE-formatted text
+        respx.post("https://kestrel.nathanpricelab.com/mcp").mock(
+            return_value=httpx.Response(
+                status_code=200,
+                text=KESTREL_SSE_RESPONSE,
+                headers={"content-type": "text/event-stream"},
+            )
+        )
+
+        # Make request through httpx (as KestrelClient does)
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                "https://kestrel.nathanpricelab.com/mcp",
+                json={"jsonrpc": "2.0", "method": "tools/call", "id": 1},
+            )
+
+        # Parse SSE response (same as kestrel_client.py:151)
+        parsed = parse_sse_response(response.text)
+
+        # Verify parsed JSON matches expected output
+        assert parsed == KESTREL_SSE_PARSED
+        assert response.text == KESTREL_SSE_RESPONSE
+
+    @respx.mock
+    async def test_openalex_json_roundtrip_via_respx(self):
+        """Verify stateless JSON API round-trips through respx."""
+        respx.get("https://api.openalex.org/works").mock(
+            return_value=httpx.Response(
+                status_code=200,
+                json=OPENALEX_JSON_RESPONSE,
+            )
+        )
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.get(
+                "https://api.openalex.org/works",
+                params={"search": "NAD+ aging", "per_page": 5},
+            )
+
+        data = response.json()
+        assert data == OPENALEX_JSON_RESPONSE
+        assert len(data["results"]) == 1
+
+
+class TestCassetteRecordReplay:
+    """Test the full record -> save -> load -> replay cycle."""
+
+    async def test_record_and_replay_sse_response(self, tmp_path: Path):
+        """Full round-trip: record an SSE response, save to cassette, replay, verify identical parse."""
+        recorder = CassetteRecorder()
+
+        # Simulate recording an SSE interaction
+        request = httpx.Request(
+            "POST",
+            "https://kestrel.nathanpricelab.com/mcp",
+            json={"jsonrpc": "2.0", "method": "tools/call", "id": 1},
+        )
+        response = httpx.Response(
+            status_code=200,
+            text=KESTREL_SSE_RESPONSE,
+            headers={"content-type": "text/event-stream", "mcp-session-id": "test-session"},
+        )
+        recorder.record_interaction(request, response)
+
+        # Save cassette
+        cassette_path = tmp_path / "test_cassette.json"
+        recorder.save(cassette_path, metadata={"kestrel_api_version": "v1.16.0"})
+
+        assert cassette_path.exists()
+        assert recorder.interaction_count == 1
+
+        # Load and replay
+        cassette_data = load_cassette(cassette_path)
+        assert cassette_data["metadata"]["kestrel_api_version"] == "v1.16.0"
+        assert len(cassette_data["interactions"]) == 1
+
+        replayer = CassetteReplayer(cassette_data)
+
+        # Replay the same request
+        replay_request = httpx.Request(
+            "POST",
+            "https://kestrel.nathanpricelab.com/mcp",
+            json={"jsonrpc": "2.0", "method": "tools/call", "id": 1},
+        )
+        replayed_response = replayer.get_response(replay_request)
+
+        assert replayed_response is not None
+        assert replayed_response.status_code == 200
+        assert replayed_response.text == KESTREL_SSE_RESPONSE
+
+        # Parse the replayed SSE response — this is the critical test
+        parsed_from_replay = parse_sse_response(replayed_response.text)
+        parsed_from_original = parse_sse_response(KESTREL_SSE_RESPONSE)
+
+        assert parsed_from_replay == parsed_from_original
+        # Verify byte-identical JSON serialization
+        assert json.dumps(parsed_from_replay, sort_keys=True) == json.dumps(parsed_from_original, sort_keys=True)
+
+    async def test_record_and_replay_json_api(self, tmp_path: Path):
+        """Record and replay a standard JSON API response (OpenAlex-style)."""
+        recorder = CassetteRecorder()
+
+        request = httpx.Request(
+            "GET",
+            "https://api.openalex.org/works?search=NAD%2B+aging&per_page=5",
+        )
+        response = httpx.Response(
+            status_code=200,
+            json=OPENALEX_JSON_RESPONSE,
+        )
+        recorder.record_interaction(request, response)
+
+        cassette_path = tmp_path / "openalex_cassette.json"
+        recorder.save(cassette_path)
+
+        cassette_data = load_cassette(cassette_path)
+        replayer = CassetteReplayer(cassette_data)
+
+        replayed = replayer.get_response(
+            httpx.Request("GET", "https://api.openalex.org/works?search=NAD%2B+aging&per_page=5")
+        )
+
+        assert replayed is not None
+        assert replayed.json() == OPENALEX_JSON_RESPONSE
+
+    async def test_replay_unmatched_request_returns_none(self, tmp_path: Path):
+        """Unmatched requests should return None from the replayer."""
+        recorder = CassetteRecorder()
+        cassette_path = tmp_path / "empty_cassette.json"
+        recorder.save(cassette_path)
+
+        cassette_data = load_cassette(cassette_path)
+        replayer = CassetteReplayer(cassette_data)
+
+        result = replayer.get_response(
+            httpx.Request("GET", "https://unknown-api.com/endpoint")
+        )
+        assert result is None
+
+    async def test_setup_replay_creates_working_mock(self, tmp_path: Path):
+        """setup_replay() should create a respx router that serves cached responses."""
+        # Create a cassette with one interaction
+        recorder = CassetteRecorder()
+        request = httpx.Request(
+            "POST",
+            "https://kestrel.nathanpricelab.com/mcp",
+            json={"jsonrpc": "2.0", "method": "tools/call", "id": 1},
+        )
+        response = httpx.Response(status_code=200, text=KESTREL_SSE_RESPONSE)
+        recorder.record_interaction(request, response)
+
+        cassette_path = tmp_path / "replay_test.json"
+        recorder.save(cassette_path)
+
+        # Set up replay
+        router, replayer = setup_replay(cassette_path)
+
+        with router:
+            async with httpx.AsyncClient() as client:
+                resp = await client.post(
+                    "https://kestrel.nathanpricelab.com/mcp",
+                    json={"jsonrpc": "2.0", "method": "tools/call", "id": 1},
+                )
+
+        assert resp.status_code == 200
+        parsed = parse_sse_response(resp.text)
+        assert parsed == KESTREL_SSE_PARSED
+
+    async def test_multiple_interactions_same_endpoint(self, tmp_path: Path):
+        """Multiple calls to the same endpoint replay in order."""
+        recorder = CassetteRecorder()
+
+        for i in range(3):
+            request = httpx.Request(
+                "POST",
+                "https://kestrel.nathanpricelab.com/mcp",
+                json={"jsonrpc": "2.0", "method": "tools/call", "id": i + 1},
+            )
+            response = httpx.Response(
+                status_code=200,
+                text=f'event: message\ndata: {{"jsonrpc":"2.0","id":{i + 1},"result":{{"index":{i}}}}}\n',
+            )
+            recorder.record_interaction(request, response)
+
+        cassette_path = tmp_path / "multi_cassette.json"
+        recorder.save(cassette_path)
+
+        cassette_data = load_cassette(cassette_path)
+        replayer = CassetteReplayer(cassette_data)
+
+        # Each replay should return the next interaction in sequence
+        for i in range(3):
+            req = httpx.Request(
+                "POST",
+                "https://kestrel.nathanpricelab.com/mcp",
+                json={"jsonrpc": "2.0", "method": "tools/call", "id": i + 1},
+            )
+            resp = replayer.get_response(req)
+            assert resp is not None
+            parsed = parse_sse_response(resp.text)
+            assert parsed["id"] == i + 1
+            assert parsed["result"]["index"] == i

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -768,6 +768,8 @@ dev = [
     { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "respx" },
+    { name = "scipy" },
     { name = "testcontainers" },
 ]
 
@@ -797,6 +799,8 @@ dev = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
+    { name = "respx", specifier = ">=0.22.0" },
+    { name = "scipy", specifier = ">=1.14.0" },
     { name = "testcontainers", extras = ["postgres"], specifier = ">=4.0.0" },
 ]
 
@@ -1014,6 +1018,67 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615 },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/05/32396bec30fb2263770ee910142f49c1476d08e8ad41abf8403806b520ce/numpy-2.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15716cfef24d3a9762e3acdf87e27f58dc823d1348f765bbea6bef8c639bfa1b", size = 16689272 },
+    { url = "https://files.pythonhosted.org/packages/c5/f3/a983d28637bfcd763a9c7aafdb6d5c0ebf3d487d1e1459ffdb57e2f01117/numpy-2.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23cbfd4c17357c81021f21540da84ee282b9c8fba38a03b7b9d09ba6b951421e", size = 14699573 },
+    { url = "https://files.pythonhosted.org/packages/9b/fd/e5ecca1e78c05106d98028114f5c00d3eddb41207686b2b7de3e477b0e22/numpy-2.4.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:8b3b60bb7cba2c8c81837661c488637eee696f59a877788a396d33150c35d842", size = 5204782 },
+    { url = "https://files.pythonhosted.org/packages/de/2f/702a4594413c1a8632092beae8aba00f1d67947389369b3777aed783fdca/numpy-2.4.4-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:e4a010c27ff6f210ff4c6ef34394cd61470d01014439b192ec22552ee867f2a8", size = 6552038 },
+    { url = "https://files.pythonhosted.org/packages/7f/37/eed308a8f56cba4d1fdf467a4fc67ef4ff4bf1c888f5fc980481890104b1/numpy-2.4.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9e75681b59ddaa5e659898085ae0eaea229d054f2ac0c7e563a62205a700121", size = 15670666 },
+    { url = "https://files.pythonhosted.org/packages/0a/0d/0e3ecece05b7a7e87ab9fb587855548da437a061326fff64a223b6dcb78a/numpy-2.4.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:81f4a14bee47aec54f883e0cad2d73986640c1590eb9bfaaba7ad17394481e6e", size = 16645480 },
+    { url = "https://files.pythonhosted.org/packages/34/49/f2312c154b82a286758ee2f1743336d50651f8b5195db18cdb63675ff649/numpy-2.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:62d6b0f03b694173f9fcb1fb317f7222fd0b0b103e784c6549f5e53a27718c44", size = 17020036 },
+    { url = "https://files.pythonhosted.org/packages/7b/e9/736d17bd77f1b0ec4f9901aaec129c00d59f5d84d5e79bba540ef12c2330/numpy-2.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbc356aae7adf9e6336d336b9c8111d390a05df88f1805573ebb0807bd06fd1d", size = 18368643 },
+    { url = "https://files.pythonhosted.org/packages/63/f6/d417977c5f519b17c8a5c3bc9e8304b0908b0e21136fe43bf628a1343914/numpy-2.4.4-cp312-cp312-win32.whl", hash = "sha256:0d35aea54ad1d420c812bfa0385c71cd7cc5bcf7c65fed95fc2cd02fe8c79827", size = 5961117 },
+    { url = "https://files.pythonhosted.org/packages/2d/5b/e1deebf88ff431b01b7406ca3583ab2bbb90972bbe1c568732e49c844f7e/numpy-2.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:b5f0362dc928a6ecd9db58868fca5e48485205e3855957bdedea308f8672ea4a", size = 12320584 },
+    { url = "https://files.pythonhosted.org/packages/58/89/e4e856ac82a68c3ed64486a544977d0e7bdd18b8da75b78a577ca31c4395/numpy-2.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:846300f379b5b12cc769334464656bc882e0735d27d9726568bc932fdc49d5ec", size = 10221450 },
+    { url = "https://files.pythonhosted.org/packages/14/1d/d0a583ce4fefcc3308806a749a536c201ed6b5ad6e1322e227ee4848979d/numpy-2.4.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:08f2e31ed5e6f04b118e49821397f12767934cfdd12a1ce86a058f91e004ee50", size = 16684933 },
+    { url = "https://files.pythonhosted.org/packages/c1/62/2b7a48fbb745d344742c0277f01286dead15f3f68e4f359fbfcf7b48f70f/numpy-2.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e823b8b6edc81e747526f70f71a9c0a07ac4e7ad13020aa736bb7c9d67196115", size = 14694532 },
+    { url = "https://files.pythonhosted.org/packages/e5/87/499737bfba066b4a3bebff24a8f1c5b2dee410b209bc6668c9be692580f0/numpy-2.4.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4a19d9dba1a76618dd86b164d608566f393f8ec6ac7c44f0cc879011c45e65af", size = 5199661 },
+    { url = "https://files.pythonhosted.org/packages/cd/da/464d551604320d1491bc345efed99b4b7034143a85787aab78d5691d5a0e/numpy-2.4.4-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d2a8490669bfe99a233298348acc2d824d496dee0e66e31b66a6022c2ad74a5c", size = 6547539 },
+    { url = "https://files.pythonhosted.org/packages/7d/90/8d23e3b0dafd024bf31bdec225b3bb5c2dbfa6912f8a53b8659f21216cbf/numpy-2.4.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45dbed2ab436a9e826e302fcdcbe9133f9b0006e5af7168afb8963a6520da103", size = 15668806 },
+    { url = "https://files.pythonhosted.org/packages/d1/73/a9d864e42a01896bb5974475438f16086be9ba1f0d19d0bb7a07427c4a8b/numpy-2.4.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c901b15172510173f5cb310eae652908340f8dede90fff9e3bf6c0d8dfd92f83", size = 16632682 },
+    { url = "https://files.pythonhosted.org/packages/34/fb/14570d65c3bde4e202a031210475ae9cde9b7686a2e7dc97ee67d2833b35/numpy-2.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:99d838547ace2c4aace6c4f76e879ddfe02bb58a80c1549928477862b7a6d6ed", size = 17019810 },
+    { url = "https://files.pythonhosted.org/packages/8a/77/2ba9d87081fd41f6d640c83f26fb7351e536b7ce6dd9061b6af5904e8e46/numpy-2.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0aec54fd785890ecca25a6003fd9a5aed47ad607bbac5cd64f836ad8666f4959", size = 18357394 },
+    { url = "https://files.pythonhosted.org/packages/a2/23/52666c9a41708b0853fa3b1a12c90da38c507a3074883823126d4e9d5b30/numpy-2.4.4-cp313-cp313-win32.whl", hash = "sha256:07077278157d02f65c43b1b26a3886bce886f95d20aabd11f87932750dfb14ed", size = 5959556 },
+    { url = "https://files.pythonhosted.org/packages/57/fb/48649b4971cde70d817cf97a2a2fdc0b4d8308569f1dd2f2611959d2e0cf/numpy-2.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:5c70f1cc1c4efbe316a572e2d8b9b9cc44e89b95f79ca3331553fbb63716e2bf", size = 12317311 },
+    { url = "https://files.pythonhosted.org/packages/ba/d8/11490cddd564eb4de97b4579ef6bfe6a736cc07e94c1598590ae25415e01/numpy-2.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:ef4059d6e5152fa1a39f888e344c73fdc926e1b2dd58c771d67b0acfbf2aa67d", size = 10222060 },
+    { url = "https://files.pythonhosted.org/packages/99/5d/dab4339177a905aad3e2221c915b35202f1ec30d750dd2e5e9d9a72b804b/numpy-2.4.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4bbc7f303d125971f60ec0aaad5e12c62d0d2c925f0ab1273debd0e4ba37aba5", size = 14822302 },
+    { url = "https://files.pythonhosted.org/packages/eb/e4/0564a65e7d3d97562ed6f9b0fd0fb0a6f559ee444092f105938b50043876/numpy-2.4.4-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:4d6d57903571f86180eb98f8f0c839fa9ebbfb031356d87f1361be91e433f5b7", size = 5327407 },
+    { url = "https://files.pythonhosted.org/packages/29/8d/35a3a6ce5ad371afa58b4700f1c820f8f279948cca32524e0a695b0ded83/numpy-2.4.4-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:4636de7fd195197b7535f231b5de9e4b36d2c440b6e566d2e4e4746e6af0ca93", size = 6647631 },
+    { url = "https://files.pythonhosted.org/packages/f4/da/477731acbd5a58a946c736edfdabb2ac5b34c3d08d1ba1a7b437fa0884df/numpy-2.4.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ad2e2ef14e0b04e544ea2fa0a36463f847f113d314aa02e5b402fdf910ef309e", size = 15727691 },
+    { url = "https://files.pythonhosted.org/packages/e6/db/338535d9b152beabeb511579598418ba0212ce77cf9718edd70262cc4370/numpy-2.4.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a285b3b96f951841799528cd1f4f01cd70e7e0204b4abebac9463eecfcf2a40", size = 16681241 },
+    { url = "https://files.pythonhosted.org/packages/e2/a9/ad248e8f58beb7a0219b413c9c7d8151c5d285f7f946c3e26695bdbbe2df/numpy-2.4.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f8474c4241bc18b750be2abea9d7a9ec84f46ef861dbacf86a4f6e043401f79e", size = 17085767 },
+    { url = "https://files.pythonhosted.org/packages/b5/1a/3b88ccd3694681356f70da841630e4725a7264d6a885c8d442a697e1146b/numpy-2.4.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4e874c976154687c1f71715b034739b45c7711bec81db01914770373d125e392", size = 18403169 },
+    { url = "https://files.pythonhosted.org/packages/c2/c9/fcfd5d0639222c6eac7f304829b04892ef51c96a75d479214d77e3ce6e33/numpy-2.4.4-cp313-cp313t-win32.whl", hash = "sha256:9c585a1790d5436a5374bac930dad6ed244c046ed91b2b2a3634eb2971d21008", size = 6083477 },
+    { url = "https://files.pythonhosted.org/packages/d5/e3/3938a61d1c538aaec8ed6fd6323f57b0c2d2d2219512434c5c878db76553/numpy-2.4.4-cp313-cp313t-win_amd64.whl", hash = "sha256:93e15038125dc1e5345d9b5b68aa7f996ec33b98118d18c6ca0d0b7d6198b7e8", size = 12457487 },
+    { url = "https://files.pythonhosted.org/packages/97/6a/7e345032cc60501721ef94e0e30b60f6b0bd601f9174ebd36389a2b86d40/numpy-2.4.4-cp313-cp313t-win_arm64.whl", hash = "sha256:0dfd3f9d3adbe2920b68b5cd3d51444e13a10792ec7154cd0a2f6e74d4ab3233", size = 10292002 },
+    { url = "https://files.pythonhosted.org/packages/6e/06/c54062f85f673dd5c04cbe2f14c3acb8c8b95e3384869bb8cc9bff8cb9df/numpy-2.4.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f169b9a863d34f5d11b8698ead99febeaa17a13ca044961aa8e2662a6c7766a0", size = 16684353 },
+    { url = "https://files.pythonhosted.org/packages/4c/39/8a320264a84404c74cc7e79715de85d6130fa07a0898f67fb5cd5bd79908/numpy-2.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2483e4584a1cb3092da4470b38866634bafb223cbcd551ee047633fd2584599a", size = 14704914 },
+    { url = "https://files.pythonhosted.org/packages/91/fb/287076b2614e1d1044235f50f03748f31fa287e3dbe6abeb35cdfa351eca/numpy-2.4.4-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:2d19e6e2095506d1736b7d80595e0f252d76b89f5e715c35e06e937679ea7d7a", size = 5210005 },
+    { url = "https://files.pythonhosted.org/packages/63/eb/fcc338595309910de6ecabfcef2419a9ce24399680bfb149421fa2df1280/numpy-2.4.4-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:6a246d5914aa1c820c9443ddcee9c02bec3e203b0c080349533fae17727dfd1b", size = 6544974 },
+    { url = "https://files.pythonhosted.org/packages/44/5d/e7e9044032a716cdfaa3fba27a8e874bf1c5f1912a1ddd4ed071bf8a14a6/numpy-2.4.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:989824e9faf85f96ec9c7761cd8d29c531ad857bfa1daa930cba85baaecf1a9a", size = 15684591 },
+    { url = "https://files.pythonhosted.org/packages/98/7c/21252050676612625449b4807d6b695b9ce8a7c9e1c197ee6216c8a65c7c/numpy-2.4.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:27a8d92cd10f1382a67d7cf4db7ce18341b66438bdd9f691d7b0e48d104c2a9d", size = 16637700 },
+    { url = "https://files.pythonhosted.org/packages/b1/29/56d2bbef9465db24ef25393383d761a1af4f446a1df9b8cded4fe3a5a5d7/numpy-2.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e44319a2953c738205bf3354537979eaa3998ed673395b964c1176083dd46252", size = 17035781 },
+    { url = "https://files.pythonhosted.org/packages/e3/2b/a35a6d7589d21f44cea7d0a98de5ddcbb3d421b2622a5c96b1edf18707c3/numpy-2.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e892aff75639bbef0d2a2cfd55535510df26ff92f63c92cd84ef8d4ba5a5557f", size = 18362959 },
+    { url = "https://files.pythonhosted.org/packages/64/c9/d52ec581f2390e0f5f85cbfd80fb83d965fc15e9f0e1aec2195faa142cde/numpy-2.4.4-cp314-cp314-win32.whl", hash = "sha256:1378871da56ca8943c2ba674530924bb8ca40cd228358a3b5f302ad60cf875fc", size = 6008768 },
+    { url = "https://files.pythonhosted.org/packages/fa/22/4cc31a62a6c7b74a8730e31a4274c5dc80e005751e277a2ce38e675e4923/numpy-2.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:715d1c092715954784bc79e1174fc2a90093dc4dc84ea15eb14dad8abdcdeb74", size = 12449181 },
+    { url = "https://files.pythonhosted.org/packages/70/2e/14cda6f4d8e396c612d1bf97f22958e92148801d7e4f110cabebdc0eef4b/numpy-2.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:2c194dd721e54ecad9ad387c1d35e63dce5c4450c6dc7dd5611283dda239aabb", size = 10496035 },
+    { url = "https://files.pythonhosted.org/packages/b1/e8/8fed8c8d848d7ecea092dc3469643f9d10bc3a134a815a3b033da1d2039b/numpy-2.4.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2aa0613a5177c264ff5921051a5719d20095ea586ca88cc802c5c218d1c67d3e", size = 14824958 },
+    { url = "https://files.pythonhosted.org/packages/05/1a/d8007a5138c179c2bf33ef44503e83d70434d2642877ee8fbb230e7c0548/numpy-2.4.4-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:42c16925aa5a02362f986765f9ebabf20de75cdefdca827d14315c568dcab113", size = 5330020 },
+    { url = "https://files.pythonhosted.org/packages/99/64/ffb99ac6ae93faf117bcbd5c7ba48a7f45364a33e8e458545d3633615dda/numpy-2.4.4-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:874f200b2a981c647340f841730fc3a2b54c9d940566a3c4149099591e2c4c3d", size = 6650758 },
+    { url = "https://files.pythonhosted.org/packages/6e/6e/795cc078b78a384052e73b2f6281ff7a700e9bf53bcce2ee579d4f6dd879/numpy-2.4.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9b39d38a9bd2ae1becd7eac1303d031c5c110ad31f2b319c6e7d98b135c934d", size = 15729948 },
+    { url = "https://files.pythonhosted.org/packages/5f/86/2acbda8cc2af5f3d7bfc791192863b9e3e19674da7b5e533fded124d1299/numpy-2.4.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b268594bccac7d7cf5844c7732e3f20c50921d94e36d7ec9b79e9857694b1b2f", size = 16679325 },
+    { url = "https://files.pythonhosted.org/packages/bc/59/cafd83018f4aa55e0ac6fa92aa066c0a1877b77a615ceff1711c260ffae8/numpy-2.4.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ac6b31e35612a26483e20750126d30d0941f949426974cace8e6b5c58a3657b0", size = 17084883 },
+    { url = "https://files.pythonhosted.org/packages/f0/85/a42548db84e65ece46ab2caea3d3f78b416a47af387fcbb47ec28e660dc2/numpy-2.4.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8e3ed142f2728df44263aaf5fb1f5b0b99f4070c553a0d7f033be65338329150", size = 18403474 },
+    { url = "https://files.pythonhosted.org/packages/ed/ad/483d9e262f4b831000062e5d8a45e342166ec8aaa1195264982bca267e62/numpy-2.4.4-cp314-cp314t-win32.whl", hash = "sha256:dddbbd259598d7240b18c9d87c56a9d2fb3b02fe266f49a7c101532e78c1d871", size = 6155500 },
+    { url = "https://files.pythonhosted.org/packages/c7/03/2fc4e14c7bd4ff2964b74ba90ecb8552540b6315f201df70f137faa5c589/numpy-2.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:a7164afb23be6e37ad90b2f10426149fd75aee07ca55653d2aa41e66c4ef697e", size = 12637755 },
+    { url = "https://files.pythonhosted.org/packages/58/78/548fb8e07b1a341746bfbecb32f2c268470f45fa028aacdbd10d9bc73aab/numpy-2.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:ba203255017337d39f89bdd58417f03c4426f12beed0440cfd933cb15f8669c7", size = 10566643 },
 ]
 
 [[package]]
@@ -1617,6 +1682,18 @@ wheels = [
 ]
 
 [[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557 },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1707,6 +1784,67 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696 },
+]
+
+[[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/48/b992b488d6f299dbe3f11a20b24d3dda3d46f1a635ede1c46b5b17a7b163/scipy-1.17.1-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:35c3a56d2ef83efc372eaec584314bd0ef2e2f0d2adb21c55e6ad5b344c0dcb8", size = 31610954 },
+    { url = "https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:fcb310ddb270a06114bb64bbe53c94926b943f5b7f0842194d585c65eb4edd76", size = 28172662 },
+    { url = "https://files.pythonhosted.org/packages/cf/a9/599c28631bad314d219cf9ffd40e985b24d603fc8a2f4ccc5ae8419a535b/scipy-1.17.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cc90d2e9c7e5c7f1a482c9875007c095c3194b1cfedca3c2f3291cdc2bc7c086", size = 20344366 },
+    { url = "https://files.pythonhosted.org/packages/35/f5/906eda513271c8deb5af284e5ef0206d17a96239af79f9fa0aebfe0e36b4/scipy-1.17.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:c80be5ede8f3f8eded4eff73cc99a25c388ce98e555b17d31da05287015ffa5b", size = 22704017 },
+    { url = "https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e19ebea31758fac5893a2ac360fedd00116cbb7628e650842a6691ba7ca28a21", size = 32927842 },
+    { url = "https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458", size = 35235890 },
+    { url = "https://files.pythonhosted.org/packages/c5/5c/9d7f4c88bea6e0d5a4f1bc0506a53a00e9fcb198de372bfe4d3652cef482/scipy-1.17.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8a604bae87c6195d8b1045eddece0514d041604b14f2727bbc2b3020172045eb", size = 35003557 },
+    { url = "https://files.pythonhosted.org/packages/65/94/7698add8f276dbab7a9de9fb6b0e02fc13ee61d51c7c3f85ac28b65e1239/scipy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f590cd684941912d10becc07325a3eeb77886fe981415660d9265c4c418d0bea", size = 37625856 },
+    { url = "https://files.pythonhosted.org/packages/a2/84/dc08d77fbf3d87d3ee27f6a0c6dcce1de5829a64f2eae85a0ecc1f0daa73/scipy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:41b71f4a3a4cab9d366cd9065b288efc4d4f3c0b37a91a8e0947fb5bd7f31d87", size = 36549682 },
+    { url = "https://files.pythonhosted.org/packages/bc/98/fe9ae9ffb3b54b62559f52dedaebe204b408db8109a8c66fdd04869e6424/scipy-1.17.1-cp312-cp312-win_arm64.whl", hash = "sha256:f4115102802df98b2b0db3cce5cb9b92572633a1197c77b7553e5203f284a5b3", size = 24547340 },
+    { url = "https://files.pythonhosted.org/packages/76/27/07ee1b57b65e92645f219b37148a7e7928b82e2b5dbeccecb4dff7c64f0b/scipy-1.17.1-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:5e3c5c011904115f88a39308379c17f91546f77c1667cea98739fe0fccea804c", size = 31590199 },
+    { url = "https://files.pythonhosted.org/packages/ec/ae/db19f8ab842e9b724bf5dbb7db29302a91f1e55bc4d04b1025d6d605a2c5/scipy-1.17.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6fac755ca3d2c3edcb22f479fceaa241704111414831ddd3bc6056e18516892f", size = 28154001 },
+    { url = "https://files.pythonhosted.org/packages/5b/58/3ce96251560107b381cbd6e8413c483bbb1228a6b919fa8652b0d4090e7f/scipy-1.17.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7ff200bf9d24f2e4d5dc6ee8c3ac64d739d3a89e2326ba68aaf6c4a2b838fd7d", size = 20325719 },
+    { url = "https://files.pythonhosted.org/packages/b2/83/15087d945e0e4d48ce2377498abf5ad171ae013232ae31d06f336e64c999/scipy-1.17.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4b400bdc6f79fa02a4d86640310dde87a21fba0c979efff5248908c6f15fad1b", size = 22683595 },
+    { url = "https://files.pythonhosted.org/packages/b4/e0/e58fbde4a1a594c8be8114eb4aac1a55bcd6587047efc18a61eb1f5c0d30/scipy-1.17.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b64ca7d4aee0102a97f3ba22124052b4bd2152522355073580bf4845e2550b6", size = 32896429 },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464", size = 35203952 },
+    { url = "https://files.pythonhosted.org/packages/8d/a5/9afd17de24f657fdfe4df9a3f1ea049b39aef7c06000c13db1530d81ccca/scipy-1.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:beeda3d4ae615106d7094f7e7cef6218392e4465cc95d25f900bebabfded0950", size = 34979063 },
+    { url = "https://files.pythonhosted.org/packages/8b/13/88b1d2384b424bf7c924f2038c1c409f8d88bb2a8d49d097861dd64a57b2/scipy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6609bc224e9568f65064cfa72edc0f24ee6655b47575954ec6339534b2798369", size = 37598449 },
+    { url = "https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:37425bc9175607b0268f493d79a292c39f9d001a357bebb6b88fdfaff13f6448", size = 36510943 },
+    { url = "https://files.pythonhosted.org/packages/2a/fd/3be73c564e2a01e690e19cc618811540ba5354c67c8680dce3281123fb79/scipy-1.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5cf36e801231b6a2059bf354720274b7558746f3b1a4efb43fcf557ccd484a87", size = 24545621 },
+    { url = "https://files.pythonhosted.org/packages/6f/6b/17787db8b8114933a66f9dcc479a8272e4b4da75fe03b0c282f7b0ade8cd/scipy-1.17.1-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:d59c30000a16d8edc7e64152e30220bfbd724c9bbb08368c054e24c651314f0a", size = 31936708 },
+    { url = "https://files.pythonhosted.org/packages/38/2e/524405c2b6392765ab1e2b722a41d5da33dc5c7b7278184a8ad29b6cb206/scipy-1.17.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:010f4333c96c9bb1a4516269e33cb5917b08ef2166d5556ca2fd9f082a9e6ea0", size = 28570135 },
+    { url = "https://files.pythonhosted.org/packages/fd/c3/5bd7199f4ea8556c0c8e39f04ccb014ac37d1468e6cfa6a95c6b3562b76e/scipy-1.17.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2ceb2d3e01c5f1d83c4189737a42d9cb2fc38a6eeed225e7515eef71ad301dce", size = 20741977 },
+    { url = "https://files.pythonhosted.org/packages/d9/b8/8ccd9b766ad14c78386599708eb745f6b44f08400a5fd0ade7cf89b6fc93/scipy-1.17.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:844e165636711ef41f80b4103ed234181646b98a53c8f05da12ca5ca289134f6", size = 23029601 },
+    { url = "https://files.pythonhosted.org/packages/6d/a0/3cb6f4d2fb3e17428ad2880333cac878909ad1a89f678527b5328b93c1d4/scipy-1.17.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:158dd96d2207e21c966063e1635b1063cd7787b627b6f07305315dd73d9c679e", size = 33019667 },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/2d834a5ac7bf3a0c806ad1508efc02dda3c8c61472a56132d7894c312dea/scipy-1.17.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cbb80d93260fe2ffa334efa24cb8f2f0f622a9b9febf8b483c0b865bfb3475", size = 35264159 },
+    { url = "https://files.pythonhosted.org/packages/4d/77/d3ed4becfdbd217c52062fafe35a72388d1bd82c2d0ba5ca19d6fcc93e11/scipy-1.17.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dbc12c9f3d185f5c737d801da555fb74b3dcfa1a50b66a1a93e09190f41fab50", size = 35102771 },
+    { url = "https://files.pythonhosted.org/packages/bd/12/d19da97efde68ca1ee5538bb261d5d2c062f0c055575128f11a2730e3ac1/scipy-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94055a11dfebe37c656e70317e1996dc197e1a15bbcc351bcdd4610e128fe1ca", size = 37665910 },
+    { url = "https://files.pythonhosted.org/packages/06/1c/1172a88d507a4baaf72c5a09bb6c018fe2ae0ab622e5830b703a46cc9e44/scipy-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e30bdeaa5deed6bc27b4cc490823cd0347d7dae09119b8803ae576ea0ce52e4c", size = 36562980 },
+    { url = "https://files.pythonhosted.org/packages/70/b0/eb757336e5a76dfa7911f63252e3b7d1de00935d7705cf772db5b45ec238/scipy-1.17.1-cp313-cp313t-win_arm64.whl", hash = "sha256:a720477885a9d2411f94a93d16f9d89bad0f28ca23c3f8daa521e2dcc3f44d49", size = 24856543 },
+    { url = "https://files.pythonhosted.org/packages/cf/83/333afb452af6f0fd70414dc04f898647ee1423979ce02efa75c3b0f2c28e/scipy-1.17.1-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:a48a72c77a310327f6a3a920092fa2b8fd03d7deaa60f093038f22d98e096717", size = 31584510 },
+    { url = "https://files.pythonhosted.org/packages/ed/a6/d05a85fd51daeb2e4ea71d102f15b34fedca8e931af02594193ae4fd25f7/scipy-1.17.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:45abad819184f07240d8a696117a7aacd39787af9e0b719d00285549ed19a1e9", size = 28170131 },
+    { url = "https://files.pythonhosted.org/packages/db/7b/8624a203326675d7746a254083a187398090a179335b2e4a20e2ddc46e83/scipy-1.17.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3fd1fcdab3ea951b610dc4cef356d416d5802991e7e32b5254828d342f7b7e0b", size = 20342032 },
+    { url = "https://files.pythonhosted.org/packages/c9/35/2c342897c00775d688d8ff3987aced3426858fd89d5a0e26e020b660b301/scipy-1.17.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:7bdf2da170b67fdf10bca777614b1c7d96ae3ca5794fd9587dce41eb2966e866", size = 22678766 },
+    { url = "https://files.pythonhosted.org/packages/ef/f2/7cdb8eb308a1a6ae1e19f945913c82c23c0c442a462a46480ce487fdc0ac/scipy-1.17.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:adb2642e060a6549c343603a3851ba76ef0b74cc8c079a9a58121c7ec9fe2350", size = 32957007 },
+    { url = "https://files.pythonhosted.org/packages/0b/2e/7eea398450457ecb54e18e9d10110993fa65561c4f3add5e8eccd2b9cd41/scipy-1.17.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eee2cfda04c00a857206a4330f0c5e3e56535494e30ca445eb19ec624ae75118", size = 35221333 },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5b8509d03b77f093a0d52e606d3c4f79e8b06d1d38c441dacb1e26cacf46/scipy-1.17.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d2650c1fb97e184d12d8ba010493ee7b322864f7d3d00d3f9bb97d9c21de4068", size = 35042066 },
+    { url = "https://files.pythonhosted.org/packages/f9/df/18f80fb99df40b4070328d5ae5c596f2f00fffb50167e31439e932f29e7d/scipy-1.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:08b900519463543aa604a06bec02461558a6e1cef8fdbb8098f77a48a83c8118", size = 37612763 },
+    { url = "https://files.pythonhosted.org/packages/4b/39/f0e8ea762a764a9dc52aa7dabcfad51a354819de1f0d4652b6a1122424d6/scipy-1.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:3877ac408e14da24a6196de0ddcace62092bfc12a83823e92e49e40747e52c19", size = 37290984 },
+    { url = "https://files.pythonhosted.org/packages/7c/56/fe201e3b0f93d1a8bcf75d3379affd228a63d7e2d80ab45467a74b494947/scipy-1.17.1-cp314-cp314-win_arm64.whl", hash = "sha256:f8885db0bc2bffa59d5c1b72fad7a6a92d3e80e7257f967dd81abb553a90d293", size = 25192877 },
+    { url = "https://files.pythonhosted.org/packages/96/ad/f8c414e121f82e02d76f310f16db9899c4fcde36710329502a6b2a3c0392/scipy-1.17.1-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:1cc682cea2ae55524432f3cdff9e9a3be743d52a7443d0cba9017c23c87ae2f6", size = 31949750 },
+    { url = "https://files.pythonhosted.org/packages/7c/b0/c741e8865d61b67c81e255f4f0a832846c064e426636cd7de84e74d209be/scipy-1.17.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:2040ad4d1795a0ae89bfc7e8429677f365d45aa9fd5e4587cf1ea737f927b4a1", size = 28585858 },
+    { url = "https://files.pythonhosted.org/packages/ed/1b/3985219c6177866628fa7c2595bfd23f193ceebbe472c98a08824b9466ff/scipy-1.17.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:131f5aaea57602008f9822e2115029b55d4b5f7c070287699fe45c661d051e39", size = 20757723 },
+    { url = "https://files.pythonhosted.org/packages/c0/19/2a04aa25050d656d6f7b9e7b685cc83d6957fb101665bfd9369ca6534563/scipy-1.17.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:9cdc1a2fcfd5c52cfb3045feb399f7b3ce822abdde3a193a6b9a60b3cb5854ca", size = 23043098 },
+    { url = "https://files.pythonhosted.org/packages/86/f1/3383beb9b5d0dbddd030335bf8a8b32d4317185efe495374f134d8be6cce/scipy-1.17.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e3dcd57ab780c741fde8dc68619de988b966db759a3c3152e8e9142c26295ad", size = 33030397 },
+    { url = "https://files.pythonhosted.org/packages/41/68/8f21e8a65a5a03f25a79165ec9d2b28c00e66dc80546cf5eb803aeeff35b/scipy-1.17.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9956e4d4f4a301ebf6cde39850333a6b6110799d470dbbb1e25326ac447f52a", size = 35281163 },
+    { url = "https://files.pythonhosted.org/packages/84/8d/c8a5e19479554007a5632ed7529e665c315ae7492b4f946b0deb39870e39/scipy-1.17.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a4328d245944d09fd639771de275701ccadf5f781ba0ff092ad141e017eccda4", size = 35116291 },
+    { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317 },
+    { url = "https://files.pythonhosted.org/packages/11/2f/b29eafe4a3fbc3d6de9662b36e028d5f039e72d345e05c250e121a230dd4/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484", size = 37345327 },
+    { url = "https://files.pythonhosted.org/packages/07/39/338d9219c4e87f3e708f18857ecd24d22a0c3094752393319553096b98af/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21", size = 25489165 },
 ]
 
 [[package]]

--- a/docs/brainstorms/pipeline-cleanup-evals-requirements.md
+++ b/docs/brainstorms/pipeline-cleanup-evals-requirements.md
@@ -1,0 +1,101 @@
+---
+date: 2026-04-28
+topic: pipeline-cleanup-formalization-evals
+---
+
+# Discovery Pipeline: Cleanup, Formalization, and Evaluation Infrastructure
+
+## Problem Frame
+
+The LangGraph discovery pipeline (~8,100 lines across 10 nodes) is functionally complete and produces research-grade output, but has accumulated technical debt that makes it harder to maintain, extend, and validate. Repeated SDK boilerplate across 8 nodes, legacy state fields, undocumented threshold choices, and zero evaluation infrastructure mean that changes are risky (no regression detection) and output quality is unmeasured (no scoring framework). Additionally, the literature grounding node hardcodes all relationship classifications to "supporting" (see TODO in `state.py:223`), producing inaccurate metadata that degrades hypothesis quality. This effort brings the pipeline to production-grade engineering standards and establishes the measurement foundation needed for confident iteration.
+
+## Requirements
+
+**Baseline Capture**
+
+- R1. Capture pipeline outputs from at least 10 representative queries (minimum 2 per pipeline path: well-characterized, sparse, cold-start, longitudinal, multi-entity) before any code changes. Run each query 5 times to establish variance baselines. Store the pipeline outputs, all external API responses (Kestrel KG, OpenAlex, Semantic Scholar, Exa, PubMed), and per-run variance data. Cached API responses enable eval runs without any live API dependency; LLM non-determinism across the 8 nodes that use Claude SDK calls remains and is handled by tolerance bands in R9. After R1 completes, compute tolerance bands (e.g., mean +/- 2 standard deviations per metric) and persist them alongside the baseline for R9 consumption.
+
+**Code Cleanup**
+
+- R2. Extract shared SDK setup (try/except imports, `HAS_SDK`, `McpStdioServerConfig`) into a single shared module, eliminating the 8-node duplication.
+- R3. Consolidate repeated SDK boilerplate and common patterns across nodes into shared utilities. The primary (HTTP API) / fallback (SDK) pattern varies meaningfully across nodes (entity_resolution does per-entity fallback, triage does batch fallback, cold_start has no SDK fallback at all), so consolidation should target the genuinely duplicated parts (SDK imports, MCP config, semaphore setup) rather than forcing a single abstraction over divergent fallback logic.
+- R4. Parameterize currently hardcoded values into a central configuration with documented rationale for each default. Hub edge thresholds must remain per-node (pathway_enrichment uses 1000 for shared-neighbor filtering; direct_kg uses 5000 for entity-level hub bias — these serve different purposes). Semaphore concurrency values must remain per-node with documented constraints (entity_resolution/triage use `Semaphore(1)` to prevent CLI spawn conflicts; direct_kg/cold_start use higher values for batch parallelism). Entity limits (top 5 sparse + top 3 cold-start) should be configurable.
+- R5. Remove legacy/deprecated state fields (`NoveltyTriage`, `well_characterized_ids`, `sparse_ids`, `kg_results`, `predictions`, `pathway_enrichment`, `legacy_bridges`, `gap_analysis`) after verifying they are unused in active code paths. Verification must cover: (a) no node reads the field, (b) no node writes to the field, (c) `node_detail_extractors.py` — the `_extract_pathway_enrichment` function (line 197) and its registration (line 394) must be updated or removed when the legacy `pathway_enrichment` dict field is removed. Note: `pathway_enrichment` as a state field (legacy dict) is distinct from the active `pathway_enrichment` node. Also remove `.bak` and `.phase4b` files from the graph directory.
+
+**State Formalization**
+
+- R6. Add inter-node state validation that verifies required fields are present and correctly typed after each node executes, catching contract violations at the node boundary rather than downstream.
+- R7. Document the state contract for each node (reads/writes/requires) in a format that is both human-readable and machine-checkable.
+
+**Eval Infrastructure — Regression (Eval Tier 1)**
+
+- R8. Build an eval runner that: (a) accepts a dataset of queries with optional cached API responses, (b) executes the pipeline in either live or replay mode — replay intercepts all external HTTP calls (Kestrel, OpenAlex, Semantic Scholar, Exa, PubMed) and serves cached responses, but LLM calls (Claude SDK `query()`) still execute normally — this eliminates external API dependency, not LLM non-determinism, (c) runs the structural checks from R9, and (d) produces a JSON report per R10. Must be invocable with a single command.
+- R9. Implement structural checks using tolerance bands computed from R1 baseline variance data (R1 must complete before R9 tolerance bands can be finalized): pipeline completion (all expected nodes executed), output schema conformance, entity resolution recall against known CURIEs, finding count stability (tolerance band from R1 variance, not a fixed percentage), hypothesis structural completeness (all required fields present).
+- R10. Eval results must be serializable to JSON for storage, diffing across runs, and future ingestion by expert-in-the-loop tooling.
+
+**Eval Infrastructure — Quality (Eval Tier 2)**
+
+- R11. Implement LLM-as-judge scoring for hypothesis biological plausibility, finding relevance to query intent, and hypothesis novelty (non-obviousness given input). Scorer must use temperature 0 and fixed prompts. Scorer operates on frozen pipeline outputs (one selected baseline run per query), not re-executed pipeline runs, to isolate scorer variance from pipeline variance. Stability criterion: run the scorer 5 times on frozen outputs from the full baseline query set and compute Spearman correlation between each pair of score vectors. Mean pairwise correlation must be >= 0.80 before the scorer is considered calibrated.
+- R12. Design a preliminary eval dataset format (query + pipeline output + scores) documented with JSON schema and at least one example. Format is forward-looking for expert-in-the-loop consumption and should be versioned to allow breaking changes if expert-in-the-loop requirements diverge from initial assumptions.
+- R13. The eval dataset format must include a `human_judgment` field per hypothesis that is initially null and can be populated when expert-in-the-loop is ready. No ingestion pipeline needs to be built now — the format compatibility is sufficient.
+
+**Refinement (Measured)**
+
+- R14. Improve the literature relationship classification beyond the current hardcoded "supporting" default (see `state.py:223` TODO), validated by eval quality scores before and after. This addresses a known accuracy deficiency in pipeline output, not a new feature. Changes must be scoped to the literature grounding node; if implementation requires new nodes or cross-node architectural changes, escalate to scope review.
+- R15. Add observability for primary (HTTP) → fallback (SDK) events so it is clear which entities required SDK fallback and why, without disrupting the user-facing output.
+- R16. Any refinement to node logic must demonstrate non-regression on Eval Tier 1 checks and improvement (or neutrality) on Eval Tier 2 quality scores. For the first refinement (R14), treat eval results as informational rather than gating, since the eval infrastructure itself is new and uncalibrated. After the first refinement validates that evals produce sensible signals, subsequent refinements should treat eval results as gating.
+
+## Success Criteria
+
+- All existing unit tests continue to pass after cleanup/formalization (zero behavior change in refactor phases).
+- State validation (R6) catches contract violations at node boundaries; state contracts (R7) are documented for all 10 nodes.
+- Eval Tier 1 (structural/regression) runs locally with a single command and produces a pass/fail report. Supports both live and replay modes. Tolerance bands derived from empirical baseline variance.
+- Eval Tier 2 (quality) produces numeric scores per hypothesis and per query on frozen baseline outputs. Stability validated: mean pairwise Spearman correlation >= 0.80 across 5 scorer runs on the full baseline query set.
+- Baseline snapshot exists for at least 10 representative queries (minimum 2 per pipeline path), each run 5 times for variance measurement, with cached API responses (Kestrel + literature sources) for replay mode.
+- Eval output format is documented with JSON schema, includes `human_judgment` field for future expert-in-the-loop use, and has at least one complete example.
+- Hub threshold and concurrency parameters are configurable per-node with documented rationale for each default value and its constraints.
+
+## Scope Boundaries
+
+- **In scope**: Pipeline code cleanup, state formalization, eval framework, quality scoring, measured refinements (including R14 literature classification fix as a known deficiency, scoped to the literature grounding node).
+- **Out of scope**: Expert-in-the-loop UI development or ingestion pipeline (eval format compatibility is sufficient). Frontend changes. New pipeline nodes. Kestrel API changes.
+- **Out of scope**: Performance optimization beyond what falls out naturally from cleanup. Dedicated performance benchmarking infrastructure.
+
+## Key Decisions
+
+- **Sequence: Snapshot → Cleanup → Evals → Refine**: Capturing baseline before any changes ensures regression detection. Cleaning up before building evals means instrumentation targets stable code. Refinements come last because they require evals to validate.
+- **Five isolated PRs**: Each phase is a standalone PR for Greptile review. Pure refactors are separated from new infrastructure to keep reviews focused.
+- **Cached API replay for external-API-independent evals**: Baseline capture records all external HTTP responses (Kestrel KG, OpenAlex, Semantic Scholar, Exa, PubMed) alongside pipeline outputs. Eval runner replays these to eliminate external API dependency and data churn. LLM non-determinism (8/10 nodes use Claude SDK `query()`) is inherent and handled by empirically calibrated tolerance bands, not by replay.
+- **Scorer operates on frozen outputs**: Eval Tier 2 quality scoring runs on fixed pipeline outputs (one selected baseline run), not re-executed pipeline runs, to isolate scorer variance from pipeline variance.
+- **LLM-as-judge for quality**: No human-labeled ground truth exists yet. LLM scoring bootstraps the quality signal. Expert-in-the-loop will progressively upgrade this as it comes online.
+- **Eval dataset is append-only**: New queries and expert judgments add to the dataset; existing entries are never deleted, only supplemented.
+- **Consolidate boilerplate, not fallback logic**: R3 targets genuinely duplicated code (SDK imports, MCP config) rather than forcing a single abstraction over the primary/fallback pattern, which varies meaningfully across nodes.
+- **First refinement is informational, not gating**: R16 eval gating bootstraps gradually — the first refinement (R14) validates that evals produce sensible signals before subsequent refinements are gated by them.
+- **Terminology**: "Primary (HTTP) / fallback (SDK)" refers to the API resilience pattern in pipeline nodes. "Eval Tier 1 / Eval Tier 2" refers to eval categories (structural vs. quality). These are unrelated concepts.
+
+## Dependencies / Assumptions
+
+- Kestrel API and literature APIs (OpenAlex, Semantic Scholar, Exa, PubMed) must be accessible for baseline capture (one-time, 5 runs per query). After baseline is captured, eval runs can use replay mode without any external API access.
+- Claude Agent SDK must be available for pipeline execution during eval runs (LLM calls cannot be replayed).
+- Expert-in-the-loop project (`projects/expert-in-the-loop/`) is not yet ready — eval format includes `human_judgment` placeholder field but no ingestion pipeline is needed now.
+- LLM-as-judge scoring requires API access to a capable model (Claude or equivalent) with temperature 0 support.
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+(None — all product decisions are captured above.)
+
+### Deferred to Planning
+
+- [Affects R3][Needs research] Which parts of the SDK boilerplate are truly identical across nodes vs. which have meaningful per-node variation? Determines what gets extracted vs. left in place.
+- [Affects R4][Technical] Document the rationale for each per-node hub threshold and semaphore value by reading the code comments and commit history.
+- [Affects R5][Technical] Verify whether the pathway_enrichment node writes to the `pathway_enrichment` state field or only to `shared_neighbors` and `biological_themes`. Also verify that `_extract_pathway_enrichment` in `node_detail_extractors.py` reads from the legacy dict field vs. the node's active output fields.
+- [Affects R6][Technical] Should state validation be a LangGraph middleware/callback or explicit checks at node entry/exit?
+- [Affects R7][Technical] What format should state contracts use? Options: Python docstrings with structured fields, separate YAML/JSON schema files, or inline type annotations with runtime validation.
+- [Affects R8][Technical] Should cached API responses use VCR-style HTTP-layer recording (captures all external calls in one mechanism) or custom per-client serialization? VCR-style is recommended given 5 distinct external APIs.
+- [Affects R11][Needs research] Which LLM and prompt strategy produces the most stable/calibrated quality scores for biomedical hypothesis evaluation? Should a different model judge to avoid self-evaluation bias (pipeline uses Claude, judge could use a different model)?
+
+## Next Steps
+
+-> `/ce:plan` for structured implementation planning across the five PR phases.

--- a/docs/plans/2026-04-28-001-refactor-pipeline-cleanup-evals-plan.md
+++ b/docs/plans/2026-04-28-001-refactor-pipeline-cleanup-evals-plan.md
@@ -1,0 +1,787 @@
+---
+title: "refactor: Discovery Pipeline Cleanup, Formalization, and Evaluation Infrastructure"
+type: refactor
+status: active
+date: 2026-04-28
+origin: docs/brainstorms/pipeline-cleanup-evals-requirements.md
+deepened: 2026-04-29
+---
+
+# Discovery Pipeline Cleanup, Formalization, and Evaluation Infrastructure
+
+## Overview
+
+Bring the LangGraph discovery pipeline (~8,100 lines, 10 nodes) from functional prototype to production-grade engineering standards. This involves four coordinated workstreams: extracting duplicated SDK boilerplate into shared modules, parameterizing hardcoded thresholds, adding inter-node state validation, and building assessment infrastructure (structural regression + LLM-as-judge quality scoring) that enables measured refinement of pipeline behavior.
+
+## Problem Frame
+
+The pipeline produces research-grade biomedical discovery output but has accumulated technical debt: SDK setup code duplicated across 8 nodes, inconsistent-but-intentional threshold values with no documented rationale, legacy state fields, and zero assessment infrastructure. Changes are risky (no regression detection) and output quality is unmeasured. The literature grounding node hardcodes all relationship classifications to "supporting" (see TODO at `graph/state.py:223`). (see origin: `docs/brainstorms/pipeline-cleanup-evals-requirements.md`)
+
+## Requirements Trace
+
+### Baseline Capture (Phase 1)
+- R1. Baseline capture: 10+ queries, 5 runs each, cached API responses, variance computation
+
+### Code Cleanup (Phase 2)
+- R2. Extract shared SDK setup into single module
+- R3. Consolidate boilerplate (not fallback logic) into shared utilities
+- R4. Parameterize hardcoded values with per-node config and documented rationale
+- R5. Remove legacy state fields after verification
+- R15. Fallback observability (primary HTTP to SDK events)
+
+### State Formalization (Phase 3)
+- R6. Inter-node state validation at node boundaries
+- R7. Document state contracts per node
+
+### Assessment Regression (Phase 4)
+- R8. Assessment runner with live/replay modes
+- R9. Structural checks with empirical tolerance bands
+- R10. JSON-serializable assessment results
+
+### Assessment Quality & Refinement (Phase 5)
+- R11. LLM-as-judge scoring with Spearman stability >= 0.80
+- R12. Assessment dataset format with JSON schema
+- R13. `human_judgment` placeholder field for expert-in-the-loop
+- R14. Literature relationship classification improvement (config-flagged)
+- R16. Assessment-gated refinement (informational for first pass, gating thereafter)
+
+## Scope Boundaries
+
+- **In scope**: Pipeline code cleanup, state formalization, assessment framework, quality scoring, measured refinements (including R14 literature classification fix behind config flag)
+- **Out of scope**: Expert-in-the-loop UI or ingestion pipeline. Frontend changes. New pipeline nodes. Kestrel API changes. Dedicated performance benchmarking
+
+### Deferred to Separate Tasks
+
+- Expert-in-the-loop UI and judgment ingestion pipeline: separate project (`projects/expert-in-the-loop/`)
+- CI test integration: no automated tests in current GitHub Actions workflow; adding test step to CI is a separate effort
+- Flipping the literature classifier config flag to enable LLM classification by default: separate follow-up PR after quality measurement confirms improvement
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+**Pipeline entry point:** `graph/runner.py` -- `run_discovery()` returns full `DiscoveryState` dict. Use this for baseline capture.
+
+**SDK boilerplate (identical across 8 nodes):**
+```
+try:
+    from claude_agent_sdk import query, ClaudeAgentOptions
+    from claude_agent_sdk.types import McpStdioServerConfig
+    HAS_SDK = True
+except ImportError:
+    HAS_SDK = False
+KESTREL_COMMAND = "uvx"
+KESTREL_ARGS = ["mcp-client-kestrel"]
+```
+Nodes: entity_resolution, triage, direct_kg, cold_start, pathway_enrichment, integration, temporal, synthesis. McpStdioServerConfig imported by 6 of 8 (synthesis and cold_start use SDK without MCP config). `chunk()` utility duplicated in 4 nodes. Unlike the 8 SDK nodes, intake and literature_grounding do not have SDK boilerplate (10 total pipeline nodes).
+
+**HTTP clients (all httpx):**
+- `kestrel_client.py` -- persistent `httpx.AsyncClient` with connection pooling + session management. Uses custom SSE parsing (`parse_sse_response()`) on `response.text` (not streaming)
+- `openalex.py`, `semantic_scholar.py`, `exa_client.py`, `pubmed_client.py` -- ephemeral per-request clients
+
+**Configuration pattern:** `config.py` uses Pydantic `Settings` with `@lru_cache`. Pipeline constants are module-level globals, not centralized.
+
+**Test patterns:** pytest-asyncio with `asyncio_mode="auto"`, function-scoped event loops. `conftest.py` provides `mock_kestrel_client`, `mock_stream_discovery` fixtures. Tests construct `DiscoveryState` dicts directly and call `node.run(state)`. 300+ tests collected (282 non-integration).
+
+**State schema:** `DiscoveryState` is `TypedDict(total=False)` with ~40 fields. Legacy fields explicitly commented. Pydantic models (frozen) for structured data within state.
+
+**Pipeline conditional paths:** Triage routes to direct_kg (well-characterized/moderate) and/or cold_start (sparse/unknown). Temporal is conditional on `is_longitudinal`. This means downstream nodes (integration, synthesis) may receive different state field populations depending on the path taken.
+
+### Institutional Learnings
+
+- **CURIE deduplication in direct_kg.py:688 is load-bearing** -- refactoring must preserve this pattern. The original bug (PR #6) used `asyncio.sleep(0)` as placeholder for duplicates, returning `None` instead of empty tuple
+- **Kestrel API parameter instability** -- 4+ commits fixed parameter name mismatches. VCR cassettes should include API version metadata
+- **Greptile reviews are more actionable with single-concern PRs** -- validates the 5-PR structure
+- **No `docs/solutions/` knowledge base exists** -- consider documenting learnings after this effort
+
+## Key Technical Decisions
+
+- **respx for HTTP recording**: All 5 external API clients use httpx. `respx` provides transport-level interception without per-client custom mocking. Add as dev dependency. Requires a gating spike (Unit 0) to validate SSE compatibility before committing (see origin: R8 deferred question)
+- **Shared cassette module**: A single `assessment/cassette.py` module handles both recording (Unit 1) and replay (Unit 7), solving the respx-SSE compatibility question once rather than twice
+- **State validation via decorator with path-conditional awareness**: A `@validate_state` decorator on each node's `run()` function, using per-node Pydantic input/output models. Input models distinguish always-required fields from path-conditional fields (using `Optional` with pipeline path context) to avoid false-positive validation errors on legitimate sparse-path runs (see origin: R6 deferred question)
+- **Per-node Pydantic config model**: Create `graph/pipeline_config.py` with a `PipelineConfig` Pydantic model containing per-node sub-models. Pipeline constants don't need env vars -- they need to be testable/overridable per-run (see origin: R4 deferred question)
+- **State contracts as Pydantic models**: Each node gets an input/output Pydantic model that serves dual purpose -- runtime validation (R6) and documentation (R7). More machine-checkable than YAML files, co-located with the code (see origin: R7 deferred question)
+- **Scorer on frozen outputs with explicit stability computation**: LLM-as-judge scores fixed pipeline outputs. Stability measured as per-dimension pairwise Spearman across all hypotheses in the canonical set (mean of 10 pairwise comparisons from 5 runs). 1-10 scale for better discrimination. Fallback to Krippendorff's alpha if Spearman is degenerate (see origin: R11)
+- **Literature classifier behind config flag**: LLM-based classification ships in PR5 but defaults to current "supporting" behavior. Flag flip in a separate follow-up PR after quality measurement confirms improvement. Fits R16's "informational first, gating later" pattern
+- **pathway_enrichment state field confirmed safe to remove**: Node writes to `shared_neighbors`/`biological_themes`, not the legacy dict. `_extract_pathway_enrichment` reads from active fields. No read/write references to legacy field in active code (see origin: R5 deferred question)
+- **Deterministic refactor verification**: For PR2 specifically, compare pre- and post-refactor structural fields (CURIE sets, finding counts before LLM-touched stages) using cassette replay, not just tolerance-band checks. This is a tighter check for pure refactors than measuring within LLM variance
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Q1 (R3)**: SDK boilerplate is identical across 8 nodes for imports/HAS_SDK/command/args. McpStdioServerConfig setup identical across 6 nodes. Semaphores and batch sizes vary by node. `chunk()` duplicated in 4 nodes. -> Extract imports + config factory + chunk to shared module. Leave semaphores and fallback orchestration per-node.
+- **Q2 (R4)**: Hub thresholds documented -- direct_kg=5000 (entity hub bias), pathway_enrichment=1000 (shared-neighbor filtering). Semaphores -- 1 for entity_resolution/triage (CLI spawn prevention), 6 for direct_kg, 8 for cold_start. Rationale captured in code comments and commit `0899452`.
+- **Q3 (R5)**: pathway_enrichment node does NOT write to legacy dict field. Returns `shared_neighbors`, `biological_themes`, `errors`. Extractor reads from `shared_neighbors`/`biological_themes`. Safe to remove.
+- **Q4 (R6)**: LangGraph has no built-in validation hooks in current usage. Decorator approach on `run()` is cleanest. Path-conditional fields must use `Optional` to avoid false positives on sparse/cold-start paths.
+- **Q5 (R7)**: Node docstrings document Returns but not Inputs. No structured contract exists. Per-node input/output Pydantic models are the best format.
+- **Q6 (R8)**: All HTTP clients use httpx. `respx` is the natural transport-level interception library. Kestrel SSE parsing uses `response.text` (not streaming), which respx should handle -- but requires spike validation.
+- **Q7 (R11)**: LLM-as-judge feasible via `query()` with `allowed_tools=[]`. synthesis.py pattern is the template. Temperature support must be verified before scorer design is committed (Unit 9 Step 0).
+
+### Deferred to Implementation
+
+- **Exact tolerance band values**: Computed from R1 baseline variance data. Cannot be known until baselines are captured.
+- **Scorer model selection**: Whether to use the same Claude model for judging or a different model to avoid self-assessment bias. Depends on API access and cost analysis during implementation.
+- **respx recording format details**: Whether to use built-in cassette format or custom JSON serialization. Best determined after spike (Unit 0) validates SSE compatibility.
+- **Kestrel API version pinning strategy**: How to detect and handle version drift between recorded cassettes and live API. Depends on Kestrel's versioning scheme.
+- **Baseline run cost/time budget**: Each full pipeline run invokes Claude SDK across 8 nodes plus external APIs. 50 runs (10 queries x 5) may take hours and cost $100+. Estimate during Unit 0 spike by timing one full run.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+graph TD
+    subgraph "PR1: Baseline Capture"
+        Z0[Unit 0: respx SSE Spike] --> A[Capture Script + Cassette Module]
+        A --> B[10 queries x 5 runs]
+        B --> C[Cached API Responses via respx]
+        B --> D[Pipeline Outputs JSON]
+        C --> E[Variance Computation]
+        D --> E
+        E --> F[Tolerance Bands JSON]
+    end
+
+    subgraph "PR2: Code Cleanup"
+        G[graph/sdk_utils.py] --> H[SDK imports + config factory + chunk]
+        I[graph/pipeline_config.py] --> J[Per-node thresholds + semaphores]
+        K[state.py cleanup] --> L[Remove 9 legacy fields]
+        LL[Fallback observability logging]
+        MM[Deterministic refactor diff check]
+    end
+
+    subgraph "PR3: State Formalization"
+        M[Per-node Pydantic I/O models] --> N[validate_state decorator]
+        M --> O[Path-conditional field handling]
+    end
+
+    subgraph "PR4: Assessment Tier 1"
+        P[Assessment Runner] --> Q[Live mode]
+        P --> R[Replay mode via shared cassette module]
+        P --> S[Structural Checks]
+        S --> T[Tolerance Bands from PR1]
+        P --> U[JSON Report]
+    end
+
+    subgraph "PR5: Assessment Tier 2 + Refinement"
+        V[LLM-as-Judge Scorer] --> W[Score frozen outputs, 1-10 scale]
+        X[Dataset Format] --> Y[Pydantic-generated schema + human_judgment]
+        ZZ[Literature Classifier behind config flag]
+    end
+
+    F --> T
+    D --> W
+```
+
+## Implementation Units
+
+### Phase 1: Baseline Capture (PR1: `feat/pipeline-baseline-capture`)
+
+- [ ] **Unit 0: respx + Kestrel SSE spike**
+
+**Goal:** Validate that respx can intercept and replay Kestrel client's SSE-formatted HTTP responses before committing to the respx-based architecture. Also time one full pipeline run to estimate baseline capture cost/duration.
+
+**Requirements:** R1, R8 (gating prerequisite)
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `backend/pyproject.toml` (add `respx` and `scipy` to `[dependency-groups] dev`)
+- Create: `backend/src/kestrel_backend/assessment/__init__.py`
+- Create: `backend/src/kestrel_backend/assessment/cassette.py`
+- Create: `backend/tests/test_cassette_spike.py`
+
+**Approach:**
+- Create `assessment/cassette.py` -- shared module for both recording and replaying HTTP interactions via respx. This is the single point of respx integration for the entire assessment infrastructure
+- Write a spike test that: (1) makes a real Kestrel API call via `call_kestrel_tool()`, (2) records the SSE-formatted response via respx, (3) replays it and verifies `parse_sse_response()` produces identical parsed output
+- Test with one literature API call (e.g., OpenAlex) to validate ephemeral-client recording
+- Time one full pipeline run end-to-end to estimate 50-run baseline capture cost and duration
+- **Decision gate with pre-committed threshold**: The spike passes if Kestrel SSE responses round-trip correctly through respx record/replay (parsed JSON is byte-identical). If Kestrel SSE fails, fall back to function-level mocking of the 5 external API choke points (`call_kestrel_tool`, `search_openalex`, `search_s2`, `search_exa`, `search_pubmed`). The threshold is binary on Kestrel specifically -- if the primary KG source doesn't work with respx, transport-level recording loses its main value. Literature API clients (stateless GET/POST) are expected to work; if any of those fail, debug before falling back. Document the decision in this unit's PR description
+
+**Test scenarios:**
+- Happy path: Kestrel SSE response round-trips through respx record/replay with identical parsed JSON
+- Happy path: OpenAlex GET response round-trips correctly
+- Error path: respx fails on SSE format -- test documents the failure mode and recommends function-level fallback
+- Integration: full pipeline run timing captured and logged
+
+**Verification:**
+- Spike test passes, confirming respx SSE compatibility (or documents the fallback decision)
+- Pipeline run timing estimate documented in PR description
+
+---
+
+- [ ] **Unit 1: Capture infrastructure with cassette recording**
+
+**Goal:** Build a script that runs the discovery pipeline against specified queries, recording all external HTTP interactions via the shared cassette module, and serializing pipeline outputs to JSON.
+
+**Requirements:** R1
+
+**Dependencies:** Unit 0 (respx compatibility confirmed)
+
+**Files:**
+- Create: `backend/src/kestrel_backend/assessment/capture.py`
+- Create: `backend/tests/test_assessment_capture.py`
+
+**Approach:**
+- Use `cassette.py` (from Unit 0) to intercept all httpx calls at the transport level during pipeline execution
+- Record request/response pairs to JSON cassette files keyed by (query_hash, run_number)
+- Call `run_discovery()` from `runner.py` as the execution entry point
+- Serialize the returned `DiscoveryState` dict to JSON, handling Pydantic model serialization
+- Store cassettes in `backend/assessment_data/cassettes/` and outputs in `backend/assessment_data/outputs/`
+- Include Kestrel API version metadata in cassette headers for drift detection
+
+**Patterns to follow:**
+- `runner.py:run_discovery()` for pipeline invocation
+- `conftest.py:mock_kestrel_client` for existing mock patterns
+- Pydantic `.model_dump()` for serializing frozen models in state
+
+**Test scenarios:**
+- Happy path: capture script runs a single query, produces cassette file and output JSON with expected structure
+- Happy path: cassette file contains entries for Kestrel + literature API calls
+- Edge case: pipeline produces empty findings for a query -- output JSON still valid with empty arrays
+- Error path: external API timeout during capture -- script logs error and continues to next query
+
+**Verification:**
+- Running capture script against one query produces valid JSON output and cassette file
+- Cassette file is replayable via the shared cassette module
+
+---
+
+- [ ] **Unit 2: Query dataset definition and baseline execution**
+
+**Goal:** Define 10+ representative queries, execute 5 runs each, compute per-metric variance, and persist tolerance bands.
+
+**Requirements:** R1
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `backend/assessment_data/queries.json`
+- Create: `backend/src/kestrel_backend/assessment/variance.py`
+- Modify: `backend/src/kestrel_backend/assessment/capture.py`
+- Create: `backend/tests/test_assessment_variance.py`
+
+**Approach:**
+- Define queries in `queries.json` with metadata: query text, expected pipeline path (well-characterized/sparse/cold-start/longitudinal/multi-entity), expected entities
+- Extend capture script to run batch mode: iterate all queries x 5 runs
+- Variance computation: for each query, compute per-metric stats across 5 runs (finding counts, entity counts, hypothesis counts, node execution flags). Persist as `backend/assessment_data/tolerance_bands.json`
+- Select one "canonical" run per query (median finding count) as the frozen output for Tier 2 scoring
+- High-variance handling: queries with coefficient of variation (CV) > 0.5 on finding counts are marked as `warning` in the tolerance bands file (assessment still runs but results are flagged, not failed)
+
+**Patterns to follow:**
+- JSON dataset format consistent with existing `docs/ark_demo_data.json`
+
+**Test scenarios:**
+- Happy path: variance computation on 5 runs produces mean/stddev per metric
+- Happy path: tolerance band JSON contains entries for all 10 queries with per-metric bounds
+- Edge case: one run of a query fails -- variance computed from remaining 4 runs with warning
+- Edge case: CV > 0.5 on finding counts -- tolerance band entry marked `warning` with explanation
+
+**Verification:**
+- `assessment_data/queries.json` contains 10+ queries covering all 5 pipeline paths
+- `assessment_data/tolerance_bands.json` contains computed bounds per query per metric
+- At least one canonical output per query selected and stored
+
+---
+
+### Phase 2: Code Cleanup (PR2: `refactor/pipeline-code-cleanup`)
+
+- [ ] **Unit 3: Shared SDK utilities module**
+
+**Goal:** Extract duplicated SDK imports, MCP config factory, and `chunk()` utility into a shared module. Update all 8 SDK-using nodes to import from shared module.
+
+**Requirements:** R2, R3
+
+**Dependencies:** Unit 2 (baseline captured before code changes)
+
+**Files:**
+- Create: `backend/src/kestrel_backend/graph/sdk_utils.py`
+- Modify: `backend/src/kestrel_backend/graph/nodes/entity_resolution.py`
+- Modify: `backend/src/kestrel_backend/graph/nodes/triage.py`
+- Modify: `backend/src/kestrel_backend/graph/nodes/direct_kg.py`
+- Modify: `backend/src/kestrel_backend/graph/nodes/cold_start.py`
+- Modify: `backend/src/kestrel_backend/graph/nodes/pathway_enrichment.py`
+- Modify: `backend/src/kestrel_backend/graph/nodes/integration.py`
+- Modify: `backend/src/kestrel_backend/graph/nodes/temporal.py`
+- Modify: `backend/src/kestrel_backend/graph/nodes/synthesis.py`
+- Create: `backend/tests/test_sdk_utils.py`
+
+**Approach:**
+- `sdk_utils.py` provides:
+  - `HAS_SDK` flag (single try/except import)
+  - `get_kestrel_mcp_config()` -- returns `McpStdioServerConfig` instance
+  - `create_agent_options(system_prompt, allowed_tools, max_turns, ...)` -- factory for `ClaudeAgentOptions`. Must support both MCP-tool-enabled and pure-reasoning (`allowed_tools=[]`) use cases (synthesis and cold_start use SDK without MCP config)
+  - `chunk(items, size)` -- extracted from the 4 nodes that duplicate it
+- Each node replaces its local SDK import block with `from ..sdk_utils import HAS_SDK, get_kestrel_mcp_config, create_agent_options, chunk`
+- Semaphore definitions STAY per-node (intentionally different values)
+- Fallback orchestration logic STAYS per-node (divergent patterns)
+- **Critical**: Preserve CURIE deduplication at `direct_kg.py:688` -- this is load-bearing (PR #6 fix)
+
+**Patterns to follow:**
+- Current import pattern in each node for replacement targets
+- `config.py` module structure for shared utility organization
+
+**Test scenarios:**
+- Happy path: `get_kestrel_mcp_config()` returns valid config with correct command/args
+- Happy path: `create_agent_options()` returns options with specified system prompt and tools
+- Happy path: `create_agent_options()` works with `allowed_tools=[]` (pure reasoning, no MCP config)
+- Happy path: `chunk([1,2,3,4,5], 2)` returns `[[1,2], [3,4], [5]]`
+- Edge case: `HAS_SDK` is False when claude_agent_sdk not installed -- no import errors
+- Edge case: `chunk([], 3)` returns empty list
+- Integration: each modified node still passes its existing unit tests
+
+**Verification:**
+- All 300+ existing unit tests pass with zero behavior change
+- `grep -r "from claude_agent_sdk" backend/src/kestrel_backend/graph/nodes/` returns only `sdk_utils.py`
+- Deterministic refactor check: replay baseline cassettes pre- and post-refactor, diff structural fields (CURIE sets, finding counts at entity_resolution and triage stages) to confirm zero behavioral drift in deterministic pipeline stages
+
+---
+
+- [ ] **Unit 4: Pipeline configuration module**
+
+**Goal:** Centralize hardcoded thresholds, semaphore values, entity limits, and batch sizes into a per-node configuration model with documented rationale.
+
+**Requirements:** R4
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Create: `backend/src/kestrel_backend/graph/pipeline_config.py`
+- Modify: `backend/src/kestrel_backend/graph/nodes/direct_kg.py`
+- Modify: `backend/src/kestrel_backend/graph/nodes/cold_start.py`
+- Modify: `backend/src/kestrel_backend/graph/nodes/entity_resolution.py`
+- Modify: `backend/src/kestrel_backend/graph/nodes/triage.py`
+- Modify: `backend/src/kestrel_backend/graph/nodes/pathway_enrichment.py`
+- Modify: `backend/src/kestrel_backend/graph/nodes/literature_grounding.py`
+- Create: `backend/tests/test_pipeline_config.py`
+
+**Approach:**
+- `PipelineConfig` Pydantic model with per-node sub-models. Each sub-model documents the rationale for its defaults inline via `Field(description=...)`:
+  - `direct_kg`: hub_threshold=5000 (entity-level hub bias detection), sdk_semaphore=6, batch_size=6, preset_limit=25
+  - `pathway_enrichment`: hub_threshold=1000 (shared-neighbor filtering -- different purpose than direct_kg)
+  - `entity_resolution`: sdk_semaphore=1 (prevent CLI spawn conflicts), batch_size=6, tier1_min_score=0.6
+  - `triage`: sdk_semaphore=1 (prevent CLI spawn conflicts), batch_size=6
+  - `cold_start`: sdk_semaphore=8 (batch parallelism), batch_size=5, inference_timeout=60, analogue_limit=3
+  - `literature_grounding`: papers_per_hypothesis=3, max_hypotheses=15, parallel_fetch_limit=6, use_llm_classifier=False (config flag for R14, defaults to current behavior)
+- Global config instance via `@lru_cache` pattern (consistent with existing `config.py`)
+- Nodes read from config at module level: `config = get_pipeline_config()`
+- Config is overridable for testing: `get_pipeline_config.cache_clear()` + set new instance
+
+**Patterns to follow:**
+- `config.py` Pydantic Settings pattern with `@lru_cache`
+- Existing `SCREAMING_SNAKE_CASE` constant naming at replacement targets
+
+**Test scenarios:**
+- Happy path: default config produces expected values for each node
+- Happy path: config override changes direct_kg hub_threshold from 5000 to 3000
+- Happy path: `use_llm_classifier` defaults to False
+- Edge case: invalid semaphore value (0) raises validation error
+- Integration: nodes read from config and produce same behavior as before
+
+**Verification:**
+- All existing unit tests pass -- config defaults produce identical behavior
+- `grep -rn "HUB_THRESHOLD\|SDK_SEMAPHORE\|BATCH_SIZE\|PRESET_LIMIT" backend/src/kestrel_backend/graph/nodes/` shows values coming from config, not module-level constants
+
+---
+
+- [ ] **Unit 5: Legacy state cleanup**
+
+**Goal:** Remove 9 legacy state fields, the `NoveltyTriage` class alias, update `node_detail_extractors.py`, and delete backup files.
+
+**Requirements:** R5
+
+**Dependencies:** Unit 2 (baseline captured before state changes). Unit 3 and Unit 5 are independent; Unit 3 is sequenced first for organizational clarity.
+
+**Files:**
+- Modify: `backend/src/kestrel_backend/graph/state.py`
+- Modify: `backend/src/kestrel_backend/graph/node_detail_extractors.py`
+- Delete: `backend/src/kestrel_backend/graph/state.py.bak`
+- Delete: `backend/src/kestrel_backend/graph/state.py.phase4b`
+- Delete: `backend/src/kestrel_backend/graph/nodes/synthesis.py.phase4b`
+- Delete: `backend/tests/test_langgraph_prototype.py.bak`
+- Delete: `backend/tests/test_langgraph_prototype.py.phase4b`
+- Modify: `backend/tests/conftest.py`
+- Modify: `backend/tests/test_langgraph_prototype.py` (if legacy fields referenced)
+
+**Approach:**
+- Remove from `DiscoveryState` TypedDict: `novelty_triage` (legacy field), `well_characterized_ids`, `sparse_ids`, `kg_results`, `predictions`, `pathway_enrichment` (legacy dict -- NOT the node), `legacy_bridges`, `gap_analysis`
+- Remove `NoveltyTriage = NoveltyScore` class alias from `state.py`
+- Update `_extract_pathway_enrichment` in `node_detail_extractors.py` -- this function already reads from `shared_neighbors`/`biological_themes` (confirmed in research), but verify the dispatch dict key at line 394 still maps correctly after the state field is removed
+- Update `conftest.py` mock stream fixture at approximately line 401 -- the `('direct_kg', {'kg_results': [...]})` tuple uses legacy output format and should be updated to reflect current direct_kg output structure (`direct_findings`, `disease_associations`, `pathway_memberships`, `hub_flags`)
+- Audit test files for references to any removed field names
+- Delete all `.bak` and `.phase4b` files
+- **Expanded grep scope**: verify removal across all directories, not just `backend/src/`:
+  `grep -rn "kg_results\|predictions\|legacy_bridges\|gap_analysis\|NoveltyTriage\|novelty_triage\|well_characterized_ids\|sparse_ids" backend/ client/ docs/ assessment_data/`
+
+**Patterns to follow:**
+- Existing test patterns for state construction in `test_langgraph_prototype.py`
+
+**Test scenarios:**
+- Happy path: pipeline execution produces valid state without legacy fields
+- Happy path: `_extract_pathway_enrichment` still returns correct data from `shared_neighbors`/`biological_themes`
+- Edge case: test that previously set `kg_results` in state dict still works after field removal (TypedDict with `total=False` allows extra keys)
+- Integration: full pipeline path through pathway_enrichment node produces same `shared_neighbors` output
+- Integration: frontend build succeeds (`npm run build`) to verify no frontend references to removed field names via WebSocket payloads
+
+**Verification:**
+- All existing tests pass
+- Expanded grep returns zero matches across backend/, client/, docs/, assessment_data/ (except comments explaining removal)
+- No `.bak` or `.phase4b` files remain
+- Frontend builds without errors
+
+---
+
+- [ ] **Unit 5b: Fallback observability**
+
+**Goal:** Add structured logging for primary (HTTP) to fallback (SDK) transitions so operators can see which entities needed SDK fallback and why. Placed in PR2 to provide monitoring during the refactor PRs most likely to introduce subtle fallback regressions.
+
+**Requirements:** R15
+
+**Dependencies:** Unit 3 (shared SDK module must exist)
+
+**Files:**
+- Modify: `backend/src/kestrel_backend/graph/sdk_utils.py`
+- Modify: `backend/src/kestrel_backend/graph/nodes/entity_resolution.py`
+- Modify: `backend/src/kestrel_backend/graph/nodes/triage.py`
+- Modify: `backend/src/kestrel_backend/graph/nodes/direct_kg.py`
+- Create: `backend/tests/test_fallback_observability.py`
+
+**Approach:**
+- Add structured fallback event logging in nodes that have primary/fallback pattern:
+  - `entity_resolution`: log entity name, CURIE, primary failure reason, fallback result
+  - `triage`: log batch size, failed entity count, fallback trigger
+  - `direct_kg`: log entity CURIE, failed API call type, fallback result
+- Use existing `logger` pattern with structured fields (node name, entity, reason, tier)
+- Events are logged at INFO level -- visible in `journalctl` on production, no user-facing output change
+- Accumulate fallback event counts in state `errors` list for inclusion in assessment reports
+
+**Patterns to follow:**
+- Existing `logger.info()`/`logger.warning()` patterns in each node
+
+**Test scenarios:**
+- Happy path: primary API success -> no fallback event logged
+- Happy path: primary API failure -> fallback event logged with entity, reason, tier
+- Edge case: both primary and fallback fail -> both events logged, error added to state
+
+**Verification:**
+- Running pipeline with a query that triggers fallback produces structured log entries
+- Log entries contain: node name, entity identifier, failure reason, fallback outcome
+
+---
+
+### Phase 3: State Formalization (PR3: `refactor/pipeline-state-formalization`)
+
+- [ ] **Unit 6: State validation decorator with per-node I/O models**
+
+**Goal:** Create input/output Pydantic models for each node and a `@validate_state` decorator that validates state at node entry and exit. Models must handle path-conditional fields correctly to avoid false-positive validation errors on legitimate sparse/cold-start pipeline paths.
+
+**Requirements:** R6, R7
+
+**Dependencies:** Unit 5 (state schema must be clean before formalizing). Unit 4's changes to the same node files are upstream in PR2; Unit 6 applies the decorator after config consumption patterns are in place.
+
+**Files:**
+- Create: `backend/src/kestrel_backend/graph/state_contracts.py`
+- Modify: `backend/src/kestrel_backend/graph/nodes/intake.py`
+- Modify: `backend/src/kestrel_backend/graph/nodes/entity_resolution.py`
+- Modify: `backend/src/kestrel_backend/graph/nodes/triage.py`
+- Modify: `backend/src/kestrel_backend/graph/nodes/direct_kg.py`
+- Modify: `backend/src/kestrel_backend/graph/nodes/cold_start.py`
+- Modify: `backend/src/kestrel_backend/graph/nodes/pathway_enrichment.py`
+- Modify: `backend/src/kestrel_backend/graph/nodes/integration.py`
+- Modify: `backend/src/kestrel_backend/graph/nodes/temporal.py`
+- Modify: `backend/src/kestrel_backend/graph/nodes/synthesis.py`
+- Modify: `backend/src/kestrel_backend/graph/nodes/literature_grounding.py`
+- Create: `backend/tests/test_state_contracts.py`
+
+**Approach:**
+- `state_contracts.py` defines per-node input/output Pydantic models with three field categories:
+  - **Always-required**: fields populated by all upstream paths (e.g., `raw_query` for all nodes, `resolved_entities` for post-entity-resolution nodes)
+  - **Path-conditional**: fields populated only on certain routes (e.g., `direct_findings` only on direct_kg path, `analogues_found` only on cold_start path). These use `Optional[list[...]] = None` with validation that at least one path's fields are populated where needed
+  - **Output fields**: what the node must return
+- Example: `IntegrationInput` requires `resolved_entities` (always-required) but has `direct_findings: Optional[list[Finding]] = None` and `cold_start_findings: Optional[list[Finding]] = None` with a `@model_validator(mode='after')` that raises on the both-empty case. Do not rely on `Optional` alone -- Pydantic doesn't express OR-semantics natively, so `Optional[X] | Optional[Y]` silently accepts both-None. The same `model_validator` pattern applies to any downstream node that consumes path-conditional output (e.g., SynthesisInput consuming integration results)
+- `@validate_state` decorator wraps `run()`:
+  - On entry: construct InputModel from state dict, raise `StateValidationError` on failure
+  - On exit: construct OutputModel from returned dict, raise on failure
+  - Validation errors include node name, missing/invalid fields, and actual vs. expected types
+- Each node's `run()` gets decorated: `@validate_state(IntakeInput, IntakeOutput)`
+- Unlike Unit 3 (which touches the 8 SDK nodes), Unit 6 covers all 10 nodes including intake and literature_grounding
+- The Pydantic model docstrings serve as the machine-checkable state contract documentation (R7)
+
+**Patterns to follow:**
+- Existing Pydantic models in `state.py` (frozen=True, Field descriptions)
+- Existing decorator patterns in Python stdlib
+
+**Test scenarios:**
+- Happy path: valid state passes intake validation without error
+- Happy path: node produces output matching its OutputModel
+- Error path: missing required field in state -> `StateValidationError` with clear message naming the field
+- Error path: wrong type in state field -> `StateValidationError` with expected vs. actual type
+- Edge case: optional fields absent -> validation passes (TypedDict with `total=False` semantics)
+- Edge case: extra fields in state beyond what InputModel expects -> validation passes (open schema)
+- **Edge case: cold-start-only path** -> IntegrationInput validates with `direct_findings=None` and `cold_start_findings` populated
+- **Edge case: direct-kg-only path** -> IntegrationInput validates with `cold_start_findings=None` and `direct_findings` populated
+- Integration: full pipeline run on each of the 5 pipeline paths with validation enabled succeeds
+
+**Verification:**
+- All existing tests pass with validation enabled
+- Running a baseline query for each pipeline path (well-characterized, sparse, cold-start, longitudinal, multi-entity) with validation enabled produces no validation errors
+- `StateValidationError` messages are clear enough to diagnose the problem without reading source
+
+---
+
+### Phase 4: Assessment Infrastructure -- Regression (PR4: `feat/pipeline-assessment-framework`)
+
+- [ ] **Unit 7: Assessment runner with replay mode**
+
+**Goal:** Build an assessment runner that executes the pipeline against a query dataset in either live or replay mode, collecting outputs for comparison.
+
+**Requirements:** R8
+
+**Dependencies:** Unit 2 (baseline data must exist), Unit 6 (state validation should be in place)
+
+**Files:**
+- Create: `backend/src/kestrel_backend/assessment/runner.py`
+- Modify: `backend/src/kestrel_backend/assessment/__init__.py`
+- Create: `backend/tests/test_assessment_runner.py`
+
+**Approach:**
+- `run_assessment(queries_path, mode="replay", cassettes_dir=None)` -- main entry point
+- **Live mode**: runs pipeline normally against live APIs. Used for fresh baseline capture or production testing
+- **Replay mode**: uses the shared `cassette.py` module (from Unit 0) to serve cached HTTP responses. LLM calls (`query()`) still execute live -- replay eliminates external API dependency, not non-determinism. Each run still requires Claude SDK authentication and incurs API costs
+- For each query: run pipeline, collect `DiscoveryState` output, pass to structural checks (Unit 8)
+- CLI entry point: `python -m kestrel_backend.assessment.runner --mode replay --queries assessment_data/queries.json`
+- Output: per-query results dict + aggregate summary
+
+**Patterns to follow:**
+- `runner.py:run_discovery()` for pipeline execution
+- `assessment/cassette.py` for respx setup (shared with capture)
+
+**Test scenarios:**
+- Happy path: assessment runner in replay mode executes pipeline against 1 query using cached cassette
+- Happy path: assessment runner produces output dict with expected structure (query, state, timing)
+- Error path: missing cassette file for a query -> clear error message, skip query, continue
+- Error path: pipeline fails during execution -> error captured in results, not raised
+- Edge case: replay mode with live LLM calls (Claude SDK) -> non-deterministic output accepted
+
+**Verification:**
+- `python -m kestrel_backend.assessment.runner --mode replay --queries assessment_data/queries.json` runs to completion
+- Results contain entries for all queries in the dataset
+
+---
+
+- [ ] **Unit 8: Structural checks and JSON report**
+
+**Goal:** Implement structural checks using tolerance bands from baseline variance data, producing a JSON pass/fail report.
+
+**Requirements:** R9, R10
+
+**Dependencies:** Unit 7
+
+**Files:**
+- Create: `backend/src/kestrel_backend/assessment/checks.py`
+- Create: `backend/src/kestrel_backend/assessment/report.py`
+- Modify: `backend/src/kestrel_backend/assessment/runner.py`
+- Create: `backend/tests/test_assessment_checks.py`
+
+**Approach:**
+- `checks.py` implements individual check functions, each returning `CheckResult(passed, metric, expected, actual, tolerance, status)` where status is `pass`, `fail`, or `warning`:
+  - `check_pipeline_completion(state)` -- all expected nodes executed (check for presence of node output fields)
+  - `check_schema_conformance(state)` -- output matches `DiscoveryState` field types
+  - `check_entity_resolution_recall(state, expected_curies)` -- resolved CURIEs contain expected set
+  - `check_finding_count_stability(state, baseline_stats)` -- finding counts within tolerance band. Queries with CV > 0.5 from Unit 2 produce `warning` status, not `fail`
+  - `check_hypothesis_completeness(state)` -- each hypothesis has required fields (claim, evidence, novelty_score, etc.)
+- `report.py` aggregates results into JSON report:
+  - Per-query: pass/fail/warning per check, actual values, tolerance bands
+  - Aggregate: total pass/fail/warning, queries with regressions, summary stats
+  - Format compatible with R10 (serializable, diffable) and R13 (`human_judgment` field per hypothesis -- null initially)
+- Tolerance bands loaded from `assessment_data/tolerance_bands.json` (produced by Unit 2)
+
+**Patterns to follow:**
+- Pydantic models for report structure (consistent with state.py patterns)
+
+**Test scenarios:**
+- Happy path: all checks pass on a state dict matching baseline expectations
+- Happy path: report JSON contains per-query and aggregate sections
+- Error path: finding count outside tolerance band -> check fails with actual vs. expected
+- Error path: missing hypothesis fields -> completeness check fails listing missing fields
+- Edge case: entity resolution found extra CURIEs beyond expected -> passes (recall, not exact match)
+- Edge case: zero findings for a query that normally produces findings -> finding count check fails
+- Edge case: high-variance query (CV > 0.5) -> finding count check returns `warning`, not `fail`
+- Integration: assessment runner produces complete report for baseline query set
+
+**Verification:**
+- Running full assessment on baseline data produces all-passing report
+- Intentionally corrupted state (removed findings) produces failing report with clear diagnostics
+
+---
+
+### Phase 5: Assessment Infrastructure -- Quality + Refinement (PR5: `feat/pipeline-assessment-quality-refinement`)
+
+- [ ] **Unit 9: LLM-as-judge scorer**
+
+**Goal:** Implement quality scoring that assesses hypothesis biological plausibility, finding relevance, and novelty using an LLM judge on frozen pipeline outputs.
+
+**Requirements:** R11
+
+**Dependencies:** Unit 8 (structural checks should exist first)
+
+**Files:**
+- Create: `backend/src/kestrel_backend/assessment/scorer.py`
+- Create: `backend/tests/test_assessment_scorer.py`
+
+**Approach:**
+- **Step 0: Verify temperature parameter support.** Before designing the scorer, verify that `ClaudeAgentOptions` accepts a `temperature` parameter and that it is honored by the SDK. If temperature is not supported, adjust the judge prompt for determinism via explicit instructions ("Always assign the same score for the same evidence") and document the limitation
+- Scorer receives frozen pipeline outputs (one canonical run per query from Unit 2)
+- For each hypothesis: construct judge prompt with hypothesis text, supporting evidence, query context
+- Call `query()` with `ClaudeAgentOptions(system_prompt=JUDGE_PROMPT, allowed_tools=[], max_turns=1)` (plus `temperature=0` if supported)
+- Parse structured JSON response: `{plausibility: 1-10, relevance: 1-10, novelty: 1-10, rationale: str}` (1-10 scale for better discrimination vs. 1-5 which produces excessive ties)
+- **Stability computation**: Run scorer 5 times on frozen outputs from the full baseline query set. Compute per-dimension (plausibility, relevance, novelty) pairwise Spearman correlation across all hypotheses in the canonical set. Report mean of all 10 pairwise comparisons per dimension (C(5,2)=10). Target: mean pairwise correlation >= 0.80 on each dimension
+- **Fallback metric**: If Spearman is degenerate due to ties or small sample, compute Krippendorff's alpha (or ICC) as a secondary stability measure and report alongside
+
+**Execution note:** Start with the judge prompt design -- iterate on prompt wording using a small subset (2-3 hypotheses) before running full calibration.
+
+**Patterns to follow:**
+- `synthesis.py:1067-1083` for `query()` with `allowed_tools=[]` pattern
+- `state.py:Hypothesis` model for hypothesis field structure
+
+**Test scenarios:**
+- Happy path: scorer produces plausibility/relevance/novelty scores in 1-10 range for a hypothesis
+- Happy path: scorer parses JSON response correctly from LLM output
+- Error path: LLM returns non-JSON response -> scorer logs error, assigns default scores with flag
+- Error path: LLM returns scores outside 1-10 range -> clamped with warning
+- Edge case: hypothesis with no supporting evidence -> scorer still produces scores (may be low)
+- Edge case: empty hypothesis list -> scorer returns empty results, no errors
+- Edge case: temperature parameter not supported by SDK -> scorer still functions with prompt-based determinism
+
+**Verification:**
+- Scorer runs on frozen baseline outputs and produces valid score vectors
+- 5-run Spearman correlation computed per dimension and reported (target: mean >= 0.80 per dimension)
+- If Spearman degenerate, Krippendorff's alpha reported as fallback
+
+---
+
+- [ ] **Unit 10: Assessment dataset format and JSON schema**
+
+**Goal:** Define the assessment dataset format with Pydantic-generated JSON schema, including `human_judgment` placeholder, and produce at least one complete example.
+
+**Requirements:** R12, R13
+
+**Dependencies:** Unit 8, Unit 9
+
+**Files:**
+- Create: `backend/assessment_data/schema/example.json`
+- Modify: `backend/src/kestrel_backend/assessment/report.py`
+- Create: `backend/tests/test_assessment_schema.py`
+
+**Approach:**
+- Define the assessment dataset as a Pydantic model in `report.py`:
+  - `query`: original query text + metadata (path type, expected entities)
+  - `pipeline_output`: serialized DiscoveryState (findings, hypotheses, etc.)
+  - `structural_checks`: Tier 1 results from Unit 8
+  - `quality_scores`: per-hypothesis `{plausibility, relevance, novelty}` from Unit 9
+  - `human_judgment`: per-hypothesis `{override_plausibility, override_relevance, override_novelty, notes}` -- all null initially
+  - `metadata`: run timestamp, pipeline version (git SHA), scorer model, schema version
+- Schema generated from Pydantic model via `model_json_schema()`, not hand-authored. Versioned (start at `v1`) with a version field
+- One complete example with real baseline data
+
+**Patterns to follow:**
+- Pydantic `model_json_schema()` for auto-generating schema (no separate hand-authored schema file)
+- JSON Schema draft-07 (Pydantic default output)
+
+**Test scenarios:**
+- Happy path: assessment report validates against generated JSON schema
+- Happy path: example.json validates against schema
+- Edge case: `human_judgment` fields all null -> valid
+- Edge case: schema version mismatch -> validation warns but does not fail (forward compatibility)
+
+**Verification:**
+- Generated schema is valid JSON Schema
+- At least one complete example validates against it
+- Assessment runner output validates against schema
+
+---
+
+- [ ] **Unit 11: Literature relationship classification improvement (config-flagged)**
+
+**Goal:** Add LLM-based relationship classification behind a config flag (`use_llm_classifier`), defaulting to current "supporting" behavior. The flag flip to enable LLM classification will be a separate follow-up PR after quality measurement confirms improvement.
+
+**Requirements:** R14, R16
+
+**Dependencies:** Unit 9 (scorer must exist to measure before/after), Unit 4 (config module with `use_llm_classifier` flag)
+
+**Execution note:** Run Tier 2 scorer on baseline outputs BEFORE making changes to establish the "before" quality scores. Then implement the classification code and re-score with `use_llm_classifier=True` to measure impact. Per R16, treat this first comparison as informational, not gating. The flag ships defaulting to False (no behavior change in this PR).
+
+**Files:**
+- Modify: `backend/src/kestrel_backend/semantic_scholar.py`
+- Modify: `backend/src/kestrel_backend/graph/state.py` (update `LiteratureSupport.relationship` Literal type)
+- Modify: `backend/src/kestrel_backend/graph/nodes/literature_grounding.py`
+- Modify: `backend/tests/test_literature_grounding.py`
+
+**Approach:**
+- Update `LiteratureSupport.relationship` in `state.py` from `Literal['supporting', 'contradicting', 'nuancing']` to `Literal['supporting', 'contradicting', 'tangential', 'methodological']`. Check for any persisted artifacts (cached results, demo data) containing `'nuancing'` and update
+- Add LLM-based `classify_relationship_llm()` in `semantic_scholar.py` alongside the existing function
+- `literature_grounding.py` checks `config.literature_grounding.use_llm_classifier`:
+  - `False` (default): calls existing `classify_relationship()` (returns "supporting")
+  - `True`: calls `classify_relationship_llm()` via `query()` with `allowed_tools=[]`
+- Classification categories: "supporting", "contradicting", "tangential", "methodological"
+- If SDK unavailable (`HAS_SDK=False`), fall back to current behavior regardless of flag
+- Scope guard: changes stay within `semantic_scholar.py` and `literature_grounding.py` only
+- **Cost note**: With `use_llm_classifier=True`, up to 45 LLM calls per pipeline run (max_hypotheses=15 x papers_per_hypothesis=3). This cost increase is why the flag defaults to False and the flip is a separate decision
+
+**Patterns to follow:**
+- `synthesis.py` pure-reasoning LLM call pattern
+- Existing `classify_relationship()` and `score_relevance()` interface
+
+**Test scenarios:**
+- Happy path: `use_llm_classifier=False` -> calls existing function, returns "supporting" (no behavior change)
+- Happy path: `use_llm_classifier=True` + paper clearly supporting -> classified as "supporting"
+- Happy path: `use_llm_classifier=True` + paper contradicting -> classified as "contradicting"
+- Error path: LLM returns unexpected classification -> defaults to "supporting" with warning
+- Error path: SDK unavailable -> returns "supporting" (current behavior preserved regardless of flag)
+- Edge case: existing artifacts with `'nuancing'` classification -> handled gracefully
+- Integration: quality scores compared with flag on vs. off -- results documented as informational
+
+**Verification:**
+- With `use_llm_classifier=False`: Tier 1 structural checks pass, identical behavior to before
+- With `use_llm_classifier=True`: Tier 2 quality scores compared against baseline -- documented as informational
+- `classify_relationship_llm()` produces varied classifications across a diverse hypothesis set
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** State validation decorator wraps all 10 node `run()` functions (intake and literature_grounding included, unlike Unit 3 which only touches the 8 SDK nodes). Assessment runner calls `run_discovery()` -- same path as production WebSocket handler in `main.py`. No changes to the WebSocket protocol or frontend
+- **Error propagation:** `StateValidationError` propagates up through LangGraph execution. Assessment runner catches and reports these. Production callers (`main.py` WebSocket handler) will see these as pipeline errors -- existing error handling covers this
+- **State lifecycle risks:** Removing legacy state fields could break external consumers that access state directly. The only external consumer is `node_detail_extractors.py` (verified and addressed in Unit 5). WebSocket protocol sends extracted details, not raw state. Frontend build verification in Unit 5 confirms no silent breakage
+- **API surface parity:** No public API changes. Assessment runner is a new internal tool, not a user-facing endpoint
+- **Integration coverage:** Assessment runner provides the first cross-node integration test coverage via full pipeline execution with structural checks. Unit tests test individual nodes in isolation -- the assessment runner tests the assembled graph
+- **Unchanged invariants:** WebSocket protocol, frontend components, Kestrel API client interface, deployment workflow, and database schema are all unchanged
+
+## Risks & Dependencies
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Kestrel API unavailable during baseline capture | Low | High (blocks all work) | Capture window is one-time; schedule when API is stable. Can re-run individual queries if some fail |
+| respx incompatible with Kestrel SSE response format | Medium | Medium | **Gated by Unit 0 spike.** If spike fails, fall back to function-level mocking of the 5 external API choke points. Decision made before committing PR1 |
+| LLM-as-judge scores too noisy (Spearman < 0.80) | Medium | Medium | Iterate on judge prompt. Use 1-10 scale for better discrimination. Fallback to Krippendorff's alpha. Verify temperature parameter support in Unit 9 Step 0 |
+| Legacy field removal breaks untested code path | Low | Medium | Expanded grep across backend/, client/, docs/. Frontend build check. Baseline comparison before/after. All existing tests must pass |
+| Refactoring introduces subtle behavior change | Low | High | Deterministic refactor diff check in Unit 3: compare structural fields (CURIE sets, pre-LLM finding counts) via cassette replay pre/post-refactor |
+| Literature classification LLM calls add latency/cost | Medium | Medium | Config-flagged (defaults to off). Up to 45 LLM calls per run when enabled. Flag flip is a separate PR after quality measurement |
+| Baseline variance too high for structural checks to detect real regressions | Medium | Medium | High-variance queries (CV > 0.5) produce `warning` not `fail`. Deterministic structural fields (CURIE sets) compared separately from LLM-influenced counts |
+| Claude SDK interface changes during implementation | Low | Medium | Pin claude-agent-sdk version in pyproject.toml. Test against specific version during baseline capture |
+
+## Documentation / Operational Notes
+
+- **No CI test step exists** -- assessment runner is invocable locally via CLI command. Adding assessment runs to CI is a separate task
+- **Production impact**: Cleanup PRs (2, 3) are pure refactors with zero behavior change. Assessment infrastructure (PRs 4, 5) adds new files only. Literature classification (PR5 Unit 11) ships behind config flag defaulting to off -- no behavior change until flag flip in follow-up PR
+- **Monitoring**: Fallback observability (Unit 5b, shipped in PR2) adds structured logging visible in production logs for all subsequent PR deploys. No new monitoring infrastructure needed
+- **Dev dependencies**: `respx` and `scipy` added as dev-only dependencies in `pyproject.toml` (not needed in production). `respx` for HTTP recording/replay, `scipy` for Spearman correlation in scorer calibration
+- **Rollback plan**: PR2 and PR3 are pure refactors revertable via `git revert <merge-commit>`. PR5 behavior change is behind config flag -- revert by setting `use_llm_classifier=False` without code revert. After any revert, verify via `journalctl -u kraken-backend` and re-run assessment checks
+- **assessment_data/ directory**: Add to `.gitignore` for cassettes (large binary-adjacent files) but track `queries.json`, `tolerance_bands.json`, and `schema/` (small, reproducibility-critical)
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/pipeline-cleanup-evals-requirements.md](docs/brainstorms/pipeline-cleanup-evals-requirements.md)
+- Related code: `backend/src/kestrel_backend/graph/` (pipeline), `backend/tests/` (test suite)
+- Related PR: #6 (duplicate CURIE handling fix -- load-bearing pattern to preserve)
+- Architecture docs: `docs/discovery-pipeline.md`


### PR DESCRIPTION
## Summary

- Add shared HTTP cassette module (respx-based) for recording and replaying external API responses (Kestrel KG, OpenAlex, Semantic Scholar, Exa, PubMed)
- Build pipeline capture infrastructure that runs queries via `run_discovery()`, records all HTTP interactions, and serializes `DiscoveryState` outputs to JSON
- Define 10 representative queries (2 per pipeline path: well-characterized, sparse, cold-start, longitudinal, multi-entity)
- Add variance computation module for tolerance band generation (mean +/- 2 std dev per metric, CV > 0.5 warning threshold, canonical run selection)

## Context

This is PR1 of a 5-PR effort to bring the discovery pipeline to production-grade engineering standards (see `docs/plans/2026-04-28-001-refactor-pipeline-cleanup-evals-plan.md`). This PR establishes the baseline capture infrastructure that all subsequent PRs depend on for regression detection.

### Key spike result
**respx SSE compatibility: PASS.** Kestrel SSE-formatted HTTP responses round-trip correctly through respx record/replay with byte-identical parsed JSON. This confirms the transport-level recording architecture for the entire assessment framework.

## New files
- `backend/src/kestrel_backend/assessment/` -- new assessment package (cassette, capture, variance modules)
- `backend/assessment_data/queries.json` -- 10 representative queries
- `backend/tests/test_cassette_spike.py` -- 7 tests validating respx SSE compatibility
- `backend/tests/test_assessment_capture.py` -- 15 tests for capture infrastructure
- `backend/tests/test_assessment_variance.py` -- 13 tests for tolerance band computation

## Test plan

- [x] All 35 new assessment tests pass
- [x] 250 existing tests pass (pre-existing failures in test_multi_hop_integration and test_websocket_routing are unrelated)
- [x] respx SSE spike validates transport-level recording works for Kestrel
- [ ] Run full baseline capture against live Kestrel API (manual step after merge)

Generated with [Claude Code](https://claude.com/claude-code)