### PR TITLE
refactor: add per-node state validation with path-conditional contracts

### DIFF
--- a/backend/src/kestrel_backend/graph/nodes/cold_start.py
+++ b/backend/src/kestrel_backend/graph/nodes/cold_start.py
@@ -32,6 +32,7 @@ from ..state import (
 )
 from ..sdk_utils import HAS_SDK, query, ClaudeAgentOptions, chunk
 from ..pipeline_config import get_pipeline_config
+from ..state_contracts import validate_state, ColdStartInput, ColdStartOutput
 
 logger = logging.getLogger(__name__)
 
@@ -644,6 +645,7 @@ def get_entity_info(
     return curie_or_name, curie_or_name, 0
 
 
+@validate_state(ColdStartInput, ColdStartOutput)
 async def run(state: DiscoveryState) -> dict[str, Any]:
     """
     Analyze entities with sparse or no KG representation.

--- a/backend/src/kestrel_backend/graph/nodes/direct_kg.py
+++ b/backend/src/kestrel_backend/graph/nodes/direct_kg.py
@@ -33,6 +33,7 @@ from ..state import (
 )
 from ..sdk_utils import HAS_SDK, query, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS
 from ..pipeline_config import get_pipeline_config
+from ..state_contracts import validate_state, DirectKGInput, DirectKGOutput
 
 logger = logging.getLogger(__name__)
 
@@ -627,6 +628,7 @@ def get_raw_name_for_curie(curie: str, novelty_scores: list[NoveltyScore], resol
 # Main Run Function
 # =============================================================================
 
+@validate_state(DirectKGInput, DirectKGOutput)
 async def run(state: DiscoveryState) -> dict[str, Any]:
     """
     Analyze entities using Kestrel ranking presets for established vs novel connections.

--- a/backend/src/kestrel_backend/graph/nodes/entity_resolution.py
+++ b/backend/src/kestrel_backend/graph/nodes/entity_resolution.py
@@ -30,6 +30,7 @@ from ...kestrel_client import call_kestrel_tool
 from ..state import DiscoveryState, EntityResolution
 from ..sdk_utils import HAS_SDK, query, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS
 from ..pipeline_config import get_pipeline_config
+from ..state_contracts import validate_state, EntityResolutionInput, EntityResolutionOutput
 
 logger = logging.getLogger(__name__)
 
@@ -322,6 +323,7 @@ async def resolve_single_entity(entity: str, is_retry: bool = False) -> EntityRe
 
 
 
+@validate_state(EntityResolutionInput, EntityResolutionOutput)
 async def run(state: DiscoveryState) -> dict[str, Any]:
     """
     Resolve all raw entities to knowledge graph identifiers.

--- a/backend/src/kestrel_backend/graph/nodes/intake.py
+++ b/backend/src/kestrel_backend/graph/nodes/intake.py
@@ -15,6 +15,7 @@ import re
 import time
 from typing import Any
 from ..state import DiscoveryState
+from ..state_contracts import validate_state, IntakeInput, IntakeOutput
 
 logger = logging.getLogger(__name__)
 
@@ -600,6 +601,7 @@ def detect_longitudinal_context(query: str) -> tuple[bool, int | None]:
     return is_longitudinal, duration
 
 
+@validate_state(IntakeInput, IntakeOutput)
 async def run(state: DiscoveryState) -> dict[str, Any]:
     """
     Process input query and extract structured information.

--- a/backend/src/kestrel_backend/graph/nodes/integration.py
+++ b/backend/src/kestrel_backend/graph/nodes/integration.py
@@ -28,6 +28,7 @@ from ..state import (
 )
 from ...kestrel_client import multi_hop_query
 from ..sdk_utils import HAS_SDK, query, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS
+from ..state_contracts import validate_state, IntegrationInput, IntegrationOutput
 
 logger = logging.getLogger(__name__)
 
@@ -438,6 +439,7 @@ def parse_integration_result(
     return bridges, gaps, errors
 
 
+@validate_state(IntegrationInput, IntegrationOutput)
 async def run(state: DiscoveryState) -> dict[str, Any]:
     """
     Perform integration analysis: bridge detection and gap analysis.

--- a/backend/src/kestrel_backend/graph/nodes/literature_grounding.py
+++ b/backend/src/kestrel_backend/graph/nodes/literature_grounding.py
@@ -36,6 +36,7 @@ from ...pubmed_client import (
 )
 
 from ..pipeline_config import get_pipeline_config
+from ..state_contracts import validate_state, LiteratureGroundingInput, LiteratureGroundingOutput
 
 logger = logging.getLogger(__name__)
 
@@ -1030,6 +1031,7 @@ def ground_hypothesis_kg(
     return hypothesis, False
 
 
+@validate_state(LiteratureGroundingInput, LiteratureGroundingOutput)
 async def run(state: DiscoveryState) -> dict[str, Any]:
     """
     Ground synthesis hypotheses with literature citations.

--- a/backend/src/kestrel_backend/graph/nodes/pathway_enrichment.py
+++ b/backend/src/kestrel_backend/graph/nodes/pathway_enrichment.py
@@ -26,6 +26,7 @@ from ..state import (
 from ...kestrel_client import multi_hop_query
 from ..sdk_utils import HAS_SDK, query, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS
 from ..pipeline_config import get_pipeline_config
+from ..state_contracts import validate_state, PathwayEnrichmentInput, PathwayEnrichmentOutput
 
 logger = logging.getLogger(__name__)
 
@@ -255,6 +256,7 @@ async def find_two_hop_shared_neighbors(
     return shared_neighbors, errors
 
 
+@validate_state(PathwayEnrichmentInput, PathwayEnrichmentOutput)
 async def run(state: DiscoveryState) -> dict[str, Any]:
     """
     Analyze pathway enrichment across all resolved entities.

--- a/backend/src/kestrel_backend/graph/nodes/synthesis.py
+++ b/backend/src/kestrel_backend/graph/nodes/synthesis.py
@@ -27,6 +27,7 @@ from ..state import (
 from ...literature_utils import format_pmid_link
 from ...kestrel_client import multi_hop_query
 from ..sdk_utils import HAS_SDK, query, ClaudeAgentOptions
+from ..state_contracts import validate_state, SynthesisInput, SynthesisOutput
 
 logger = logging.getLogger(__name__)
 
@@ -1026,6 +1027,7 @@ def extract_hypotheses(state: DiscoveryState) -> list[Hypothesis]:
     return hypotheses
 
 
+@validate_state(SynthesisInput, SynthesisOutput)
 async def run(state: DiscoveryState) -> dict[str, Any]:
     """
     Generate a synthesis report and extract hypotheses from all analysis phases.

--- a/backend/src/kestrel_backend/graph/nodes/temporal.py
+++ b/backend/src/kestrel_backend/graph/nodes/temporal.py
@@ -30,6 +30,7 @@ from ..state import (
     DiseaseAssociation, PathwayMembership, InferredAssociation, Bridge
 )
 from ..sdk_utils import HAS_SDK, query, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS
+from ..state_contracts import validate_state, TemporalInput, TemporalOutput
 
 logger = logging.getLogger(__name__)
 
@@ -224,6 +225,7 @@ def parse_temporal_result(
     return classifications, errors
 
 
+@validate_state(TemporalInput, TemporalOutput)
 async def run(state: DiscoveryState) -> dict[str, Any]:
     """
     Classify findings by temporal relationship to disease progression.

--- a/backend/src/kestrel_backend/graph/nodes/triage.py
+++ b/backend/src/kestrel_backend/graph/nodes/triage.py
@@ -32,6 +32,7 @@ from ...kestrel_client import call_kestrel_tool
 from ..state import DiscoveryState, NoveltyScore, EntityResolution
 from ..sdk_utils import HAS_SDK, query, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS
 from ..pipeline_config import get_pipeline_config
+from ..state_contracts import validate_state, TriageInput, TriageOutput
 
 logger = logging.getLogger(__name__)
 
@@ -234,6 +235,7 @@ async def count_edges_single(entity: EntityResolution) -> NoveltyScore:
 
 
 
+@validate_state(TriageInput, TriageOutput)
 async def run(state: DiscoveryState) -> dict[str, Any]:
     """
     Triage resolved entities by KG connectivity using two-tier approach.

--- a/backend/src/kestrel_backend/graph/state_contracts.py
+++ b/backend/src/kestrel_backend/graph/state_contracts.py
@@ -1,0 +1,290 @@
+"""Per-node state validation contracts for the discovery pipeline.
+
+Defines input/output Pydantic models for each pipeline node and a @validate_state
+decorator that validates state at node entry and exit. Models serve dual purpose:
+runtime validation (R6) and machine-checkable documentation (R7).
+
+Field categories:
+- Always-required: populated by all upstream paths (validated as non-None)
+- Path-conditional: populated only on certain routes (Optional, with model_validator
+  for OR-semantics where at least one branch must provide data)
+- Output: what the node must return
+
+The @validate_state decorator wraps async run() functions. On entry, it constructs
+the InputModel from the state dict. On exit, it validates the returned dict against
+the OutputModel. Validation errors include node name, missing/invalid fields, and
+actual vs. expected types.
+"""
+
+import functools
+import logging
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, model_validator
+
+logger = logging.getLogger(__name__)
+
+
+class StateValidationError(Exception):
+    """Raised when node state fails validation."""
+
+    def __init__(self, node_name: str, direction: str, errors: list[str]):
+        self.node_name = node_name
+        self.direction = direction  # "input" or "output"
+        self.validation_errors = errors
+        msg = (
+            f"State validation failed for node '{node_name}' ({direction}):\n"
+            + "\n".join(f"  - {e}" for e in errors)
+        )
+        super().__init__(msg)
+
+
+# =============================================================================
+# Base configuration for all contract models
+# =============================================================================
+
+class _ContractBase(BaseModel):
+    """Base for all contract models. Uses extra='ignore' to accept the full state dict."""
+    model_config = ConfigDict(extra="ignore", arbitrary_types_allowed=True)
+
+
+# =============================================================================
+# Input Models
+# =============================================================================
+
+class IntakeInput(_ContractBase):
+    """Intake node reads the raw query from the user."""
+    raw_query: str
+
+
+class EntityResolutionInput(_ContractBase):
+    """Entity resolution reads extracted entity names from intake."""
+    raw_entities: list[str]
+
+
+class TriageInput(_ContractBase):
+    """Triage reads resolved entities from entity resolution."""
+    resolved_entities: list[Any]  # list[EntityResolution] but using Any to avoid circular import
+
+
+class DirectKGInput(_ContractBase):
+    """Direct KG reads well-characterized and moderate CURIEs from triage."""
+    well_characterized_curies: list[str] | None = None
+    moderate_curies: list[str] | None = None
+    novelty_scores: list[Any] | None = None
+    resolved_entities: list[Any] | None = None
+
+
+class ColdStartInput(_ContractBase):
+    """Cold start reads sparse and cold-start CURIEs from triage."""
+    sparse_curies: list[str] | None = None
+    cold_start_curies: list[str] | None = None
+    novelty_scores: list[Any] | None = None
+    resolved_entities: list[Any] | None = None
+
+
+class PathwayEnrichmentInput(_ContractBase):
+    """Pathway enrichment reads all resolved entities after both branches converge."""
+    resolved_entities: list[Any]
+    novelty_scores: list[Any] | None = None
+
+
+class IntegrationInput(_ContractBase):
+    """Integration reads findings from both branches — at least one must be non-empty.
+
+    Uses @model_validator(mode='after') for OR-semantics: Pydantic doesn't express
+    'at least one of X or Y must be non-empty' natively, so Optional alone would
+    silently accept both-None/both-empty states.
+    """
+    resolved_entities: list[Any] | None = None
+    direct_findings: list[Any] | None = None
+    cold_start_findings: list[Any] | None = None
+    disease_associations: list[Any] | None = None
+    pathway_memberships: list[Any] | None = None
+    inferred_associations: list[Any] | None = None
+    biological_themes: list[Any] | None = None
+    raw_query: str | None = None
+
+    @model_validator(mode="after")
+    def at_least_one_findings_branch(self) -> "IntegrationInput":
+        direct = self.direct_findings or []
+        cold = self.cold_start_findings or []
+        if not direct and not cold:
+            raise ValueError(
+                "IntegrationInput requires at least one of direct_findings or "
+                "cold_start_findings to be non-empty. Both are empty/None — "
+                "this suggests neither direct_kg nor cold_start produced results."
+            )
+        return self
+
+
+class TemporalInput(_ContractBase):
+    """Temporal reads findings and longitudinal context — only runs if is_longitudinal."""
+    is_longitudinal: bool | None = None
+    direct_findings: list[Any] | None = None
+    cold_start_findings: list[Any] | None = None
+
+
+class SynthesisInput(_ContractBase):
+    """Synthesis reads all accumulated state. Path-conditional fields are Optional."""
+    resolved_entities: list[Any] | None = None
+    novelty_scores: list[Any] | None = None
+    direct_findings: list[Any] | None = None
+    cold_start_findings: list[Any] | None = None
+    disease_associations: list[Any] | None = None
+    pathway_memberships: list[Any] | None = None
+    inferred_associations: list[Any] | None = None
+    analogues_found: list[Any] | None = None
+    shared_neighbors: list[Any] | None = None
+    biological_themes: list[Any] | None = None
+    bridges: list[Any] | None = None
+    gap_entities: list[Any] | None = None
+    temporal_classifications: list[Any] | None = None
+
+    @model_validator(mode="after")
+    def at_least_one_findings_branch(self) -> "SynthesisInput":
+        """Same OR-semantics as IntegrationInput."""
+        direct = self.direct_findings or []
+        cold = self.cold_start_findings or []
+        if not direct and not cold:
+            raise ValueError(
+                "SynthesisInput requires at least one of direct_findings or "
+                "cold_start_findings to be non-empty."
+            )
+        return self
+
+
+class LiteratureGroundingInput(_ContractBase):
+    """Literature grounding reads hypotheses from synthesis."""
+    hypotheses: list[Any]
+
+
+# =============================================================================
+# Output Models
+# =============================================================================
+
+class IntakeOutput(_ContractBase):
+    """Intake must produce raw_entities and query_type."""
+    raw_entities: list[str]
+    query_type: str
+
+
+class EntityResolutionOutput(_ContractBase):
+    """Entity resolution must produce resolved_entities."""
+    resolved_entities: list[Any]
+
+
+class TriageOutput(_ContractBase):
+    """Triage must produce novelty_scores and classification buckets."""
+    novelty_scores: list[Any]
+
+
+class DirectKGOutput(_ContractBase):
+    """Direct KG must produce direct_findings."""
+    direct_findings: list[Any]
+
+
+class ColdStartOutput(_ContractBase):
+    """Cold start must produce cold_start_findings."""
+    cold_start_findings: list[Any]
+
+
+class PathwayEnrichmentOutput(_ContractBase):
+    """Pathway enrichment must produce shared_neighbors."""
+    shared_neighbors: list[Any]
+
+
+class IntegrationOutput(_ContractBase):
+    """Integration must produce bridges and gap_entities."""
+    bridges: list[Any]
+    gap_entities: list[Any]
+
+
+class TemporalOutput(_ContractBase):
+    """Temporal must produce temporal_classifications (may be empty if not longitudinal)."""
+    temporal_classifications: list[Any] | None = None
+
+
+class SynthesisOutput(_ContractBase):
+    """Synthesis must produce synthesis_report and hypotheses."""
+    synthesis_report: str
+    hypotheses: list[Any]
+
+
+class LiteratureGroundingOutput(_ContractBase):
+    """Literature grounding must produce updated hypotheses."""
+    hypotheses: list[Any]
+
+
+# =============================================================================
+# Node Contract Registry
+# =============================================================================
+
+NODE_CONTRACTS: dict[str, tuple[type[_ContractBase], type[_ContractBase]]] = {
+    "intake": (IntakeInput, IntakeOutput),
+    "entity_resolution": (EntityResolutionInput, EntityResolutionOutput),
+    "triage": (TriageInput, TriageOutput),
+    "direct_kg": (DirectKGInput, DirectKGOutput),
+    "cold_start": (ColdStartInput, ColdStartOutput),
+    "pathway_enrichment": (PathwayEnrichmentInput, PathwayEnrichmentOutput),
+    "integration": (IntegrationInput, IntegrationOutput),
+    "temporal": (TemporalInput, TemporalOutput),
+    "synthesis": (SynthesisInput, SynthesisOutput),
+    "literature_grounding": (LiteratureGroundingInput, LiteratureGroundingOutput),
+}
+
+
+# =============================================================================
+# Decorator
+# =============================================================================
+
+def validate_state(input_model: type[_ContractBase], output_model: type[_ContractBase]):
+    """Decorator that validates node state at entry and exit.
+
+    Usage:
+        @validate_state(IntakeInput, IntakeOutput)
+        async def run(state: DiscoveryState) -> dict[str, Any]:
+            ...
+
+    On entry: constructs input_model from state dict, raises StateValidationError on failure.
+    On exit: constructs output_model from returned dict, raises StateValidationError on failure.
+    """
+    def decorator(func):
+        # Extract node name from the function's module path
+        node_name = func.__module__.rsplit(".", 1)[-1] if func.__module__ else func.__qualname__
+
+        @functools.wraps(func)
+        async def wrapper(state, *args, **kwargs):
+            # Validate input
+            try:
+                input_model.model_validate(dict(state))
+            except Exception as e:
+                errors = _extract_validation_errors(e)
+                raise StateValidationError(node_name, "input", errors) from e
+
+            # Execute the node
+            result = await func(state, *args, **kwargs)
+
+            # Validate output
+            if result is not None:
+                try:
+                    output_model.model_validate(result)
+                except Exception as e:
+                    errors = _extract_validation_errors(e)
+                    raise StateValidationError(node_name, "output", errors) from e
+
+            return result
+
+        return wrapper
+    return decorator
+
+
+def _extract_validation_errors(exc: Exception) -> list[str]:
+    """Extract human-readable error messages from a Pydantic validation exception."""
+    from pydantic import ValidationError
+    if isinstance(exc, ValidationError):
+        return [
+            f"{'.'.join(str(loc) for loc in err['loc'])}: {err['msg']}"
+            for err in exc.errors()
+        ]
+    return [str(exc)]

--- a/backend/src/kestrel_backend/graph/state_contracts.py
+++ b/backend/src/kestrel_backend/graph/state_contracts.py
@@ -20,7 +20,7 @@ import functools
 import logging
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, ValidationError, model_validator
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +74,18 @@ class DirectKGInput(_ContractBase):
     novelty_scores: list[Any] | None = None
     resolved_entities: list[Any] | None = None
 
+    @model_validator(mode="after")
+    def at_least_one_curie_list(self) -> "DirectKGInput":
+        wc = self.well_characterized_curies or []
+        mod = self.moderate_curies or []
+        if not wc and not mod:
+            raise ValueError(
+                "DirectKGInput requires at least one of well_characterized_curies or "
+                "moderate_curies to be non-empty. Both are empty/None — "
+                "this suggests triage found no well-characterized or moderate entities."
+            )
+        return self
+
 
 class ColdStartInput(_ContractBase):
     """Cold start reads sparse and cold-start CURIEs from triage."""
@@ -81,6 +93,18 @@ class ColdStartInput(_ContractBase):
     cold_start_curies: list[str] | None = None
     novelty_scores: list[Any] | None = None
     resolved_entities: list[Any] | None = None
+
+    @model_validator(mode="after")
+    def at_least_one_curie_list(self) -> "ColdStartInput":
+        sparse = self.sparse_curies or []
+        cold = self.cold_start_curies or []
+        if not sparse and not cold:
+            raise ValueError(
+                "ColdStartInput requires at least one of sparse_curies or "
+                "cold_start_curies to be non-empty. Both are empty/None — "
+                "this suggests triage found no sparse or cold-start entities."
+            )
+        return self
 
 
 class PathwayEnrichmentInput(_ContractBase):
@@ -255,10 +279,10 @@ def validate_state(input_model: type[_ContractBase], output_model: type[_Contrac
 
         @functools.wraps(func)
         async def wrapper(state, *args, **kwargs):
-            # Validate input
+            # Validate input — catch only ValidationError, let other exceptions propagate
             try:
                 input_model.model_validate(dict(state))
-            except Exception as e:
+            except ValidationError as e:
                 errors = _extract_validation_errors(e)
                 raise StateValidationError(node_name, "input", errors) from e
 
@@ -269,9 +293,20 @@ def validate_state(input_model: type[_ContractBase], output_model: type[_Contrac
             if result is not None:
                 try:
                     output_model.model_validate(result)
-                except Exception as e:
+                except ValidationError as e:
                     errors = _extract_validation_errors(e)
                     raise StateValidationError(node_name, "output", errors) from e
+            else:
+                # Log warning when None is returned from nodes with required output fields
+                required_fields = [
+                    name for name, field in output_model.model_fields.items()
+                    if field.is_required()
+                ]
+                if required_fields:
+                    logger.warning(
+                        "Node '%s' returned None but output contract requires: %s",
+                        node_name, ", ".join(required_fields),
+                    )
 
             return result
 
@@ -281,7 +316,6 @@ def validate_state(input_model: type[_ContractBase], output_model: type[_Contrac
 
 def _extract_validation_errors(exc: Exception) -> list[str]:
     """Extract human-readable error messages from a Pydantic validation exception."""
-    from pydantic import ValidationError
     if isinstance(exc, ValidationError):
         return [
             f"{'.'.join(str(loc) for loc in err['loc'])}: {err['msg']}"

--- a/backend/src/kestrel_backend/graph/state_contracts.py
+++ b/backend/src/kestrel_backend/graph/state_contracts.py
@@ -201,6 +201,10 @@ class EntityResolutionOutput(_ContractBase):
 class TriageOutput(_ContractBase):
     """Triage must produce novelty_scores and classification buckets."""
     novelty_scores: list[Any]
+    well_characterized_curies: list[str]
+    moderate_curies: list[str]
+    sparse_curies: list[str]
+    cold_start_curies: list[str]
 
 
 class DirectKGOutput(_ContractBase):

--- a/backend/tests/test_state_contracts.py
+++ b/backend/tests/test_state_contracts.py
@@ -96,10 +96,17 @@ class TestDirectKGContract:
         })
         assert model.well_characterized_curies == ["CHEBI:15422"]
 
-    def test_all_optional_fields(self):
-        """Direct KG input fields are all optional (may not run on cold-start-only path)."""
-        model = DirectKGInput.model_validate({})
-        assert model.well_characterized_curies is None
+    def test_both_curie_lists_empty_raises(self):
+        """Direct KG requires at least one of well_characterized or moderate CURIEs."""
+        with pytest.raises(ValueError, match="at least one of well_characterized_curies or moderate_curies"):
+            DirectKGInput.model_validate({})
+
+    def test_moderate_only_valid(self):
+        model = DirectKGInput.model_validate({
+            "well_characterized_curies": [],
+            "moderate_curies": ["CHEBI:12345"],
+        })
+        assert model.moderate_curies == ["CHEBI:12345"]
 
     def test_valid_output(self):
         model = DirectKGOutput.model_validate({
@@ -116,9 +123,17 @@ class TestColdStartContract:
         })
         assert model.sparse_curies == ["CHEBI:99999"]
 
-    def test_all_optional_fields(self):
-        model = ColdStartInput.model_validate({})
-        assert model.sparse_curies is None
+    def test_both_curie_lists_empty_raises(self):
+        """Cold start requires at least one of sparse or cold_start CURIEs."""
+        with pytest.raises(ValueError, match="at least one of sparse_curies or cold_start_curies"):
+            ColdStartInput.model_validate({})
+
+    def test_cold_start_only_valid(self):
+        model = ColdStartInput.model_validate({
+            "sparse_curies": [],
+            "cold_start_curies": ["UNKNOWN:1"],
+        })
+        assert model.cold_start_curies == ["UNKNOWN:1"]
 
     def test_valid_output(self):
         model = ColdStartOutput.model_validate({

--- a/backend/tests/test_state_contracts.py
+++ b/backend/tests/test_state_contracts.py
@@ -84,8 +84,21 @@ class TestTriageContract:
         assert len(model.resolved_entities) == 1
 
     def test_valid_output(self):
-        model = TriageOutput.model_validate({"novelty_scores": [{"score": 0.8}]})
+        model = TriageOutput.model_validate({
+            "novelty_scores": [{"score": 0.8}],
+            "well_characterized_curies": ["CHEBI:15422"],
+            "moderate_curies": [],
+            "sparse_curies": ["CHEBI:99999"],
+            "cold_start_curies": [],
+        })
         assert len(model.novelty_scores) == 1
+        assert model.well_characterized_curies == ["CHEBI:15422"]
+        assert model.sparse_curies == ["CHEBI:99999"]
+
+    def test_missing_classification_buckets_raises(self):
+        """Triage output must include all 4 classification bucket lists."""
+        with pytest.raises(Exception):
+            TriageOutput.model_validate({"novelty_scores": [{"score": 0.8}]})
 
 
 class TestDirectKGContract:

--- a/backend/tests/test_state_contracts.py
+++ b/backend/tests/test_state_contracts.py
@@ -1,0 +1,316 @@
+"""Tests for state validation contracts.
+
+Tests the @validate_state decorator and per-node input/output Pydantic models,
+including path-conditional field handling and OR-semantics validation.
+"""
+
+import pytest
+
+from kestrel_backend.graph.state_contracts import (
+    ColdStartInput,
+    ColdStartOutput,
+    DirectKGInput,
+    DirectKGOutput,
+    EntityResolutionInput,
+    EntityResolutionOutput,
+    IntakeInput,
+    IntakeOutput,
+    IntegrationInput,
+    IntegrationOutput,
+    LiteratureGroundingInput,
+    LiteratureGroundingOutput,
+    PathwayEnrichmentInput,
+    PathwayEnrichmentOutput,
+    StateValidationError,
+    SynthesisInput,
+    SynthesisOutput,
+    TemporalInput,
+    TemporalOutput,
+    TriageInput,
+    TriageOutput,
+    validate_state,
+)
+
+
+class TestIntakeContract:
+    """Test intake node input/output validation."""
+
+    def test_valid_input(self):
+        model = IntakeInput.model_validate({"raw_query": "NAD+ and aging"})
+        assert model.raw_query == "NAD+ and aging"
+
+    def test_missing_raw_query_raises(self):
+        with pytest.raises(Exception):
+            IntakeInput.model_validate({})
+
+    def test_valid_output(self):
+        model = IntakeOutput.model_validate({
+            "raw_entities": ["NAD+", "aging"],
+            "query_type": "discovery",
+        })
+        assert model.raw_entities == ["NAD+", "aging"]
+
+    def test_extra_fields_ignored(self):
+        """State dict has many fields — extras should be silently ignored."""
+        model = IntakeInput.model_validate({
+            "raw_query": "test",
+            "conversation_history": [],
+            "unrelated_field": "value",
+        })
+        assert model.raw_query == "test"
+
+
+class TestEntityResolutionContract:
+    def test_valid_input(self):
+        model = EntityResolutionInput.model_validate({"raw_entities": ["NAD+"]})
+        assert model.raw_entities == ["NAD+"]
+
+    def test_missing_raw_entities_raises(self):
+        with pytest.raises(Exception):
+            EntityResolutionInput.model_validate({})
+
+    def test_valid_output(self):
+        model = EntityResolutionOutput.model_validate({
+            "resolved_entities": [{"raw_name": "NAD+", "curie": "CHEBI:15422"}],
+        })
+        assert len(model.resolved_entities) == 1
+
+
+class TestTriageContract:
+    def test_valid_input(self):
+        model = TriageInput.model_validate({
+            "resolved_entities": [{"raw_name": "NAD+", "curie": "CHEBI:15422"}],
+        })
+        assert len(model.resolved_entities) == 1
+
+    def test_valid_output(self):
+        model = TriageOutput.model_validate({"novelty_scores": [{"score": 0.8}]})
+        assert len(model.novelty_scores) == 1
+
+
+class TestDirectKGContract:
+    def test_valid_input(self):
+        model = DirectKGInput.model_validate({
+            "well_characterized_curies": ["CHEBI:15422"],
+            "moderate_curies": [],
+        })
+        assert model.well_characterized_curies == ["CHEBI:15422"]
+
+    def test_all_optional_fields(self):
+        """Direct KG input fields are all optional (may not run on cold-start-only path)."""
+        model = DirectKGInput.model_validate({})
+        assert model.well_characterized_curies is None
+
+    def test_valid_output(self):
+        model = DirectKGOutput.model_validate({
+            "direct_findings": [{"text": "finding"}],
+        })
+        assert len(model.direct_findings) == 1
+
+
+class TestColdStartContract:
+    def test_valid_input(self):
+        model = ColdStartInput.model_validate({
+            "sparse_curies": ["CHEBI:99999"],
+            "cold_start_curies": [],
+        })
+        assert model.sparse_curies == ["CHEBI:99999"]
+
+    def test_all_optional_fields(self):
+        model = ColdStartInput.model_validate({})
+        assert model.sparse_curies is None
+
+    def test_valid_output(self):
+        model = ColdStartOutput.model_validate({
+            "cold_start_findings": [{"text": "inferred finding"}],
+        })
+        assert len(model.cold_start_findings) == 1
+
+
+class TestIntegrationContract:
+    """Test integration node's OR-semantics validation."""
+
+    def test_valid_with_direct_findings_only(self):
+        """Direct-KG-only path: cold_start_findings is None/empty."""
+        model = IntegrationInput.model_validate({
+            "direct_findings": [{"text": "finding"}],
+            "cold_start_findings": None,
+        })
+        assert len(model.direct_findings) == 1
+
+    def test_valid_with_cold_start_findings_only(self):
+        """Cold-start-only path: direct_findings is None/empty."""
+        model = IntegrationInput.model_validate({
+            "direct_findings": None,
+            "cold_start_findings": [{"text": "inferred"}],
+        })
+        assert len(model.cold_start_findings) == 1
+
+    def test_valid_with_both_branches(self):
+        """Both branches produced findings."""
+        model = IntegrationInput.model_validate({
+            "direct_findings": [{"text": "direct"}],
+            "cold_start_findings": [{"text": "cold"}],
+        })
+        assert len(model.direct_findings) == 1
+        assert len(model.cold_start_findings) == 1
+
+    def test_both_empty_raises(self):
+        """Neither branch produced findings — should raise."""
+        with pytest.raises(ValueError, match="at least one of direct_findings or cold_start_findings"):
+            IntegrationInput.model_validate({
+                "direct_findings": [],
+                "cold_start_findings": [],
+            })
+
+    def test_both_none_raises(self):
+        """Neither branch ran — should raise."""
+        with pytest.raises(ValueError, match="at least one of direct_findings or cold_start_findings"):
+            IntegrationInput.model_validate({
+                "direct_findings": None,
+                "cold_start_findings": None,
+            })
+
+    def test_valid_output(self):
+        model = IntegrationOutput.model_validate({
+            "bridges": [{"source": "A", "target": "B"}],
+            "gap_entities": [],
+        })
+        assert len(model.bridges) == 1
+
+
+class TestSynthesisContract:
+    """Test synthesis node's OR-semantics (same as integration)."""
+
+    def test_valid_with_direct_findings(self):
+        model = SynthesisInput.model_validate({
+            "direct_findings": [{"text": "finding"}],
+        })
+        assert len(model.direct_findings) == 1
+
+    def test_both_empty_raises(self):
+        with pytest.raises(ValueError, match="at least one of direct_findings or cold_start_findings"):
+            SynthesisInput.model_validate({
+                "direct_findings": [],
+                "cold_start_findings": [],
+            })
+
+    def test_valid_output(self):
+        model = SynthesisOutput.model_validate({
+            "synthesis_report": "# Report\n\nFindings...",
+            "hypotheses": [{"claim": "test"}],
+        })
+        assert model.synthesis_report.startswith("# Report")
+
+
+class TestTemporalContract:
+    def test_valid_input_longitudinal(self):
+        model = TemporalInput.model_validate({
+            "is_longitudinal": True,
+            "direct_findings": [{"text": "finding"}],
+        })
+        assert model.is_longitudinal is True
+
+    def test_valid_input_non_longitudinal(self):
+        model = TemporalInput.model_validate({"is_longitudinal": False})
+        assert model.is_longitudinal is False
+
+    def test_valid_output(self):
+        model = TemporalOutput.model_validate({
+            "temporal_classifications": [{"entity": "NAD+", "category": "upstream_cause"}],
+        })
+        assert len(model.temporal_classifications) == 1
+
+
+class TestLiteratureGroundingContract:
+    def test_valid_input(self):
+        model = LiteratureGroundingInput.model_validate({
+            "hypotheses": [{"claim": "test hypothesis"}],
+        })
+        assert len(model.hypotheses) == 1
+
+    def test_missing_hypotheses_raises(self):
+        with pytest.raises(Exception):
+            LiteratureGroundingInput.model_validate({})
+
+
+class TestValidateStateDecorator:
+    """Test the @validate_state decorator."""
+
+    async def test_valid_input_and_output(self):
+        @validate_state(IntakeInput, IntakeOutput)
+        async def run(state):
+            return {
+                "raw_entities": ["NAD+"],
+                "query_type": "discovery",
+            }
+
+        result = await run({"raw_query": "NAD+ and aging"})
+        assert result["raw_entities"] == ["NAD+"]
+
+    async def test_invalid_input_raises_state_validation_error(self):
+        @validate_state(IntakeInput, IntakeOutput)
+        async def run(state):
+            return {"raw_entities": [], "query_type": "discovery"}
+
+        with pytest.raises(StateValidationError, match="input"):
+            await run({})  # Missing raw_query
+
+    async def test_invalid_output_raises_state_validation_error(self):
+        @validate_state(IntakeInput, IntakeOutput)
+        async def run(state):
+            return {"missing_field": True}  # Missing raw_entities and query_type
+
+        with pytest.raises(StateValidationError, match="output"):
+            await run({"raw_query": "test"})
+
+    async def test_error_message_includes_node_name(self):
+        @validate_state(IntakeInput, IntakeOutput)
+        async def run(state):
+            return {"raw_entities": [], "query_type": "discovery"}
+
+        try:
+            await run({})
+        except StateValidationError as e:
+            assert "run" in e.node_name or "test" in e.node_name
+            assert e.direction == "input"
+            assert len(e.validation_errors) > 0
+
+    async def test_extra_state_fields_accepted(self):
+        """Decorator should not reject state dicts with extra fields."""
+        @validate_state(IntakeInput, IntakeOutput)
+        async def run(state):
+            return {"raw_entities": ["x"], "query_type": "discovery"}
+
+        result = await run({
+            "raw_query": "test",
+            "conversation_history": [],
+            "some_extra_field": "value",
+        })
+        assert result["raw_entities"] == ["x"]
+
+    async def test_integration_or_semantics(self):
+        """Integration decorator should enforce at least one findings branch."""
+        @validate_state(IntegrationInput, IntegrationOutput)
+        async def run(state):
+            return {"bridges": [], "gap_entities": []}
+
+        # Should fail: both branches empty
+        with pytest.raises(StateValidationError, match="input"):
+            await run({"direct_findings": [], "cold_start_findings": []})
+
+        # Should pass: one branch has data
+        result = await run({
+            "direct_findings": [{"text": "finding"}],
+            "cold_start_findings": [],
+        })
+        assert result["bridges"] == []
+
+    async def test_none_return_accepted(self):
+        """Some nodes may return None in edge cases — decorator should handle gracefully."""
+        @validate_state(IntakeInput, IntakeOutput)
+        async def run(state):
+            return None
+
+        result = await run({"raw_query": "test"})
+        assert result is None


### PR DESCRIPTION
## Summary

- Add `graph/state_contracts.py` with input/output Pydantic models for all 10 pipeline nodes
- Create `@validate_state` decorator that validates state at node entry and exit
- Apply decorator to all 10 node `run()` functions (intake through literature_grounding)
- Handle path-conditional fields via `@model_validator(mode='after')` OR-semantics

## Context

PR3 of 5 in the pipeline cleanup effort (see `docs/plans/2026-04-28-001-refactor-pipeline-cleanup-evals-plan.md`). This formalizes the state contracts that were previously implicit in each node's `.get()` calls.

### Key design decisions
- **Three field categories**: always-required (validated non-None), path-conditional (Optional + model_validator), output (what node must return)
- **OR-semantics for branch convergence**: `IntegrationInput` and `SynthesisInput` use `@model_validator(mode='after')` to enforce at least one of `direct_findings`/`cold_start_findings` is non-empty -- Pydantic doesn't express this natively with Optional alone
- **Extra fields ignored**: All models use `extra='ignore'` so the full state dict is accepted without failing on unrelated fields
- **Clear error messages**: `StateValidationError` includes node name, direction (input/output), and specific field-level messages

### Path-conditional test coverage
- Cold-start-only path: `IntegrationInput` validates with `direct_findings=None` and `cold_start_findings` populated
- Direct-KG-only path: `IntegrationInput` validates with `cold_start_findings=None` and `direct_findings` populated
- Both empty: raises `ValueError` with descriptive message

## New files
- `backend/src/kestrel_backend/graph/state_contracts.py` -- models + decorator
- `backend/tests/test_state_contracts.py` -- 36 tests

## Test plan

- [x] All 36 new state contract tests pass
- [x] Integration OR-semantics validated for both cold-start-only and direct-kg-only paths
- [x] Decorator correctly raises StateValidationError on invalid input and output
- [x] Extra state fields silently accepted (no false positives)

Generated with [Claude Code](https://claude.com/claude-code)