### PR TITLE
feat: add assessment runner with structural checks and JSON reports

### DIFF
--- a/backend/src/kestrel_backend/assessment/checks.py
+++ b/backend/src/kestrel_backend/assessment/checks.py
@@ -18,6 +18,8 @@ from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
 
+_CV_WARNING_THRESHOLD = 0.5
+
 
 class CheckResult(BaseModel):
     """Result of a single structural check."""
@@ -174,7 +176,7 @@ def check_finding_count_stability(
     lower = metric_band.get("lower_bound", 0)
     upper = metric_band.get("upper_bound", float("inf"))
     cv = metric_band.get("cv", 0)
-    is_high_variance = metric_band.get("status") == "warning"
+    is_high_variance = cv > _CV_WARNING_THRESHOLD
 
     in_band = lower <= direct <= upper
 
@@ -186,8 +188,8 @@ def check_finding_count_stability(
         status = "warning"
         passed = True
         logger.warning(
-            "Finding count %d outside band [%.1f, %.1f] but CV=%.3f exceeds threshold — warning only",
-            direct, lower, upper, cv,
+            "Finding count %d outside band [%.1f, %.1f] but CV=%.3f > %.1f threshold — warning only",
+            direct, lower, upper, cv, _CV_WARNING_THRESHOLD,
         )
     else:
         status = "fail"

--- a/backend/src/kestrel_backend/assessment/checks.py
+++ b/backend/src/kestrel_backend/assessment/checks.py
@@ -1,0 +1,259 @@
+"""Structural checks for pipeline assessment.
+
+Implements deterministic checks using tolerance bands calibrated from baseline
+variance data. Each check returns a CheckResult with pass/fail/warning status.
+
+Checks:
+- Pipeline completion: all expected nodes executed
+- Schema conformance: output matches DiscoveryState field types
+- Entity resolution recall: resolved CURIEs contain expected set
+- Finding count stability: counts within tolerance band (CV > 0.5 = warning)
+- Hypothesis completeness: required fields present on each hypothesis
+"""
+
+import logging
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+
+class CheckResult(BaseModel):
+    """Result of a single structural check."""
+    name: str = Field(..., description="Check name")
+    passed: bool = Field(..., description="Whether the check passed")
+    status: str = Field(..., description="pass, fail, or warning")
+    metric: str = Field(..., description="What was measured")
+    expected: Any = Field(None, description="Expected value or range")
+    actual: Any = Field(None, description="Actual observed value")
+    tolerance: Any = Field(None, description="Tolerance band if applicable")
+    message: str = Field("", description="Human-readable explanation")
+
+
+def check_pipeline_completion(state: dict[str, Any]) -> CheckResult:
+    """Check that all expected pipeline nodes executed.
+
+    Verifies presence of node output fields in the state dict.
+    """
+    node_indicators = {
+        "intake": "raw_entities",
+        "entity_resolution": "resolved_entities",
+        "triage": "novelty_scores",
+        "synthesis": "synthesis_report",
+    }
+
+    missing = []
+    for node, field in node_indicators.items():
+        value = state.get(field)
+        if value is None or (isinstance(value, (list, str)) and len(value) == 0):
+            missing.append(f"{node} ({field})")
+
+    passed = len(missing) == 0
+    return CheckResult(
+        name="pipeline_completion",
+        passed=passed,
+        status="pass" if passed else "fail",
+        metric="nodes_executed",
+        expected=list(node_indicators.keys()),
+        actual=[n for n in node_indicators if n not in [m.split(" ")[0] for m in missing]],
+        message=f"Missing nodes: {', '.join(missing)}" if missing else "All core nodes executed",
+    )
+
+
+def check_schema_conformance(state: dict[str, Any]) -> CheckResult:
+    """Check that key output fields have the correct types."""
+    type_checks = {
+        "resolved_entities": list,
+        "novelty_scores": list,
+        "synthesis_report": str,
+        "hypotheses": list,
+        "errors": list,
+    }
+
+    violations = []
+    for field, expected_type in type_checks.items():
+        value = state.get(field)
+        if value is not None and not isinstance(value, expected_type):
+            violations.append(f"{field}: expected {expected_type.__name__}, got {type(value).__name__}")
+
+    passed = len(violations) == 0
+    return CheckResult(
+        name="schema_conformance",
+        passed=passed,
+        status="pass" if passed else "fail",
+        metric="type_violations",
+        expected=0,
+        actual=len(violations),
+        message="; ".join(violations) if violations else "All fields conform to expected types",
+    )
+
+
+def check_entity_resolution_recall(
+    state: dict[str, Any],
+    expected_curies: list[str] | None = None,
+) -> CheckResult:
+    """Check that resolved CURIEs contain the expected set (recall, not exact match).
+
+    Extra resolved CURIEs beyond expected are acceptable.
+    """
+    if not expected_curies:
+        return CheckResult(
+            name="entity_resolution_recall",
+            passed=True,
+            status="pass",
+            metric="recall",
+            expected="no expected CURIEs specified",
+            actual="skipped",
+            message="No expected CURIEs to check — skipping",
+        )
+
+    resolved = state.get("resolved_entities", [])
+    resolved_curies = set()
+    for entity in resolved:
+        curie = entity.get("curie") if isinstance(entity, dict) else getattr(entity, "curie", None)
+        if curie:
+            resolved_curies.add(curie)
+
+    expected_set = set(expected_curies)
+    found = expected_set & resolved_curies
+    missing = expected_set - resolved_curies
+
+    recall = len(found) / len(expected_set) if expected_set else 1.0
+    passed = len(missing) == 0
+
+    return CheckResult(
+        name="entity_resolution_recall",
+        passed=passed,
+        status="pass" if passed else "fail",
+        metric="recall",
+        expected=sorted(expected_set),
+        actual=sorted(resolved_curies),
+        tolerance=None,
+        message=f"Recall: {recall:.2f}. Missing: {sorted(missing)}" if missing
+        else f"All {len(expected_set)} expected CURIEs found",
+    )
+
+
+def check_finding_count_stability(
+    state: dict[str, Any],
+    baseline_stats: dict[str, Any] | None = None,
+) -> CheckResult:
+    """Check finding counts are within tolerance bands from baseline variance.
+
+    Queries with CV > 0.5 produce 'warning' status instead of 'fail'.
+    """
+    if baseline_stats is None:
+        return CheckResult(
+            name="finding_count_stability",
+            passed=True,
+            status="pass",
+            metric="finding_counts",
+            expected="no baseline stats",
+            actual="skipped",
+            message="No baseline stats provided — skipping",
+        )
+
+    direct = len(state.get("direct_findings", []))
+    cold = len(state.get("cold_start_findings", []))
+    total = direct + cold
+
+    # Check against tolerance band
+    metric_band = baseline_stats.get("metric_bands", {}).get("direct_finding_count", {})
+    if not metric_band or metric_band.get("status") == "insufficient_data":
+        return CheckResult(
+            name="finding_count_stability",
+            passed=True,
+            status="warning",
+            metric="finding_counts",
+            expected="insufficient baseline data",
+            actual={"direct": direct, "cold_start": cold, "total": total},
+            message="Insufficient baseline data for comparison",
+        )
+
+    lower = metric_band.get("lower_bound", 0)
+    upper = metric_band.get("upper_bound", float("inf"))
+    cv = metric_band.get("cv", 0)
+    is_high_variance = metric_band.get("status") == "warning"
+
+    in_band = lower <= direct <= upper
+
+    if in_band:
+        status = "pass"
+        passed = True
+    elif is_high_variance:
+        # High-variance query — produce warning, not fail
+        status = "warning"
+        passed = True
+        logger.warning(
+            "Finding count %d outside band [%.1f, %.1f] but CV=%.3f exceeds threshold — warning only",
+            direct, lower, upper, cv,
+        )
+    else:
+        status = "fail"
+        passed = False
+
+    return CheckResult(
+        name="finding_count_stability",
+        passed=passed,
+        status=status,
+        metric="direct_finding_count",
+        expected={"lower": lower, "upper": upper},
+        actual=direct,
+        tolerance={"cv": cv, "high_variance": is_high_variance},
+        message=f"Direct findings: {direct} (band: [{lower:.1f}, {upper:.1f}], CV={cv:.3f})",
+    )
+
+
+def check_hypothesis_completeness(state: dict[str, Any]) -> CheckResult:
+    """Check that each hypothesis has the required fields."""
+    hypotheses = state.get("hypotheses", [])
+
+    if not hypotheses:
+        return CheckResult(
+            name="hypothesis_completeness",
+            passed=True,
+            status="pass",
+            metric="hypothesis_fields",
+            expected="hypotheses present",
+            actual=0,
+            message="No hypotheses to check",
+        )
+
+    required_fields = ["claim", "evidence", "novelty_score"]
+    incomplete = []
+
+    for i, h in enumerate(hypotheses):
+        if isinstance(h, dict):
+            missing = [f for f in required_fields if f not in h or h[f] is None]
+        else:
+            missing = [f for f in required_fields if not hasattr(h, f) or getattr(h, f) is None]
+
+        if missing:
+            incomplete.append(f"hypothesis[{i}] missing: {', '.join(missing)}")
+
+    passed = len(incomplete) == 0
+    return CheckResult(
+        name="hypothesis_completeness",
+        passed=passed,
+        status="pass" if passed else "fail",
+        metric="incomplete_hypotheses",
+        expected=0,
+        actual=len(incomplete),
+        message="; ".join(incomplete[:5]) if incomplete else f"All {len(hypotheses)} hypotheses complete",
+    )
+
+
+def run_all_checks(
+    state: dict[str, Any],
+    baseline_stats: dict[str, Any] | None = None,
+    expected_curies: list[str] | None = None,
+) -> list[CheckResult]:
+    """Run all structural checks and return results."""
+    return [
+        check_pipeline_completion(state),
+        check_schema_conformance(state),
+        check_entity_resolution_recall(state, expected_curies),
+        check_finding_count_stability(state, baseline_stats),
+        check_hypothesis_completeness(state),
+    ]

--- a/backend/src/kestrel_backend/assessment/report.py
+++ b/backend/src/kestrel_backend/assessment/report.py
@@ -1,0 +1,135 @@
+"""Assessment report generation.
+
+Aggregates structural check results into a JSON report with per-query
+and aggregate sections. Format is compatible with R10 (serializable, diffable)
+and includes human_judgment placeholder fields for R13.
+"""
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from .checks import CheckResult, run_all_checks
+
+logger = logging.getLogger(__name__)
+
+
+class HypothesisJudgment(BaseModel):
+    """Placeholder for expert-in-the-loop human judgment (R13)."""
+    override_plausibility: int | None = None
+    override_relevance: int | None = None
+    override_novelty: int | None = None
+    notes: str | None = None
+
+
+class QueryReport(BaseModel):
+    """Assessment report for a single query."""
+    query: str
+    query_hash: str
+    path_type: str | None = None
+    checks: list[CheckResult]
+    passed: bool = Field(..., description="True if all checks passed (warnings count as pass)")
+    warnings: int = Field(0, description="Number of checks with warning status")
+    human_judgment: list[HypothesisJudgment] = Field(
+        default_factory=list,
+        description="Per-hypothesis human judgment placeholders (initially empty)",
+    )
+
+
+class AssessmentReport(BaseModel):
+    """Full assessment report across all queries."""
+    timestamp: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    schema_version: str = "v1"
+    mode: str = "replay"
+    query_reports: list[QueryReport] = Field(default_factory=list)
+    aggregate: dict[str, Any] = Field(default_factory=dict)
+
+
+def generate_report(
+    assessment_results: dict[str, Any],
+    tolerance_bands: dict[str, Any] | None = None,
+) -> AssessmentReport:
+    """Generate an assessment report from runner results and tolerance bands.
+
+    Args:
+        assessment_results: Output from run_assessment()
+        tolerance_bands: Tolerance band data keyed by query_hash
+
+    Returns:
+        AssessmentReport with per-query checks and aggregate summary.
+    """
+    tolerance_bands = tolerance_bands or {}
+    query_reports = []
+
+    total_passed = 0
+    total_failed = 0
+    total_warnings = 0
+    total_checks = 0
+
+    for result in assessment_results.get("results", []):
+        state = result.get("state")
+        if state is None:
+            # Skipped or failed query
+            continue
+
+        qhash = result["query_hash"]
+        metadata = result.get("metadata", {})
+        baseline = tolerance_bands.get(qhash)
+
+        # Run structural checks
+        checks = run_all_checks(
+            state=state,
+            baseline_stats=baseline,
+            expected_curies=metadata.get("expected_curies"),
+        )
+
+        # Compute pass/fail/warning counts
+        check_passed = all(c.passed for c in checks)
+        warnings = sum(1 for c in checks if c.status == "warning")
+
+        # Create hypothesis judgment placeholders
+        hypotheses = state.get("hypotheses", [])
+        judgments = [HypothesisJudgment() for _ in hypotheses]
+
+        query_reports.append(QueryReport(
+            query=result["query"],
+            query_hash=qhash,
+            path_type=metadata.get("path_type"),
+            checks=checks,
+            passed=check_passed,
+            warnings=warnings,
+            human_judgment=judgments,
+        ))
+
+        total_checks += len(checks)
+        if check_passed:
+            total_passed += 1
+        else:
+            total_failed += 1
+        total_warnings += warnings
+
+    report = AssessmentReport(
+        mode=assessment_results.get("summary", {}).get("mode", "unknown"),
+        query_reports=query_reports,
+        aggregate={
+            "total_queries": len(query_reports),
+            "passed": total_passed,
+            "failed": total_failed,
+            "total_warnings": total_warnings,
+            "total_checks": total_checks,
+            "pass_rate": round(total_passed / len(query_reports), 2) if query_reports else 0,
+        },
+    )
+
+    return report
+
+
+def save_report(report: AssessmentReport, path: Path) -> None:
+    """Save assessment report to JSON file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(report.model_dump_json(indent=2))
+    logger.info("Assessment report saved to %s", path)

--- a/backend/src/kestrel_backend/assessment/runner.py
+++ b/backend/src/kestrel_backend/assessment/runner.py
@@ -1,0 +1,195 @@
+"""Assessment runner for the discovery pipeline.
+
+Executes the pipeline against a query dataset in either live or replay mode,
+collecting outputs for structural checks and quality scoring.
+
+Live mode runs against real APIs. Replay mode uses the shared cassette module
+to serve cached HTTP responses — LLM calls (Claude SDK query()) still execute
+live, so each run requires SDK auth and incurs API costs.
+
+Usage:
+    python -m kestrel_backend.assessment.runner --mode replay --queries assessment_data/queries.json
+    python -m kestrel_backend.assessment.runner --mode live --queries assessment_data/queries.json
+"""
+
+import argparse
+import asyncio
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+from .capture import PipelineCapture, _serialize_state, query_hash
+from .cassette import setup_replay
+
+logger = logging.getLogger(__name__)
+
+
+async def run_single_assessment(
+    query: str,
+    mode: str = "replay",
+    cassettes_dir: Path | None = None,
+    query_metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Run the pipeline for a single query and collect output for assessment.
+
+    Args:
+        query: The query text to run
+        mode: "live" or "replay"
+        cassettes_dir: Directory containing cassette files (required for replay mode)
+        query_metadata: Optional metadata about the query (path_type, expected_entities, etc.)
+
+    Returns:
+        Result dict with query, state output, timing, mode, and any errors.
+    """
+    from ..graph.runner import run_discovery
+
+    qhash = query_hash(query)
+    start_time = time.time()
+    state = None
+    error = None
+
+    try:
+        if mode == "replay":
+            if cassettes_dir is None:
+                raise ValueError("cassettes_dir required for replay mode")
+
+            # Find the cassette file for this query (use run 1 as default replay source)
+            cassette_path = cassettes_dir / f"{qhash}_run1.json"
+            if not cassette_path.exists():
+                # Try to find any cassette for this query
+                candidates = sorted(cassettes_dir.glob(f"{qhash}_run*.json"))
+                if not candidates:
+                    return {
+                        "query": query,
+                        "query_hash": qhash,
+                        "mode": mode,
+                        "duration_seconds": 0,
+                        "state": None,
+                        "error": f"No cassette found for query hash {qhash}",
+                        "metadata": query_metadata,
+                    }
+                cassette_path = candidates[0]
+
+            router, replayer = setup_replay(cassette_path)
+            with router:
+                state = await run_discovery(query)
+
+        else:  # live mode
+            state = await run_discovery(query)
+
+    except Exception as e:
+        error = str(e)
+        logger.error("Assessment run failed for query '%s': %s", query[:50], e)
+
+    duration = time.time() - start_time
+
+    result = {
+        "query": query,
+        "query_hash": qhash,
+        "mode": mode,
+        "duration_seconds": round(duration, 2),
+        "state": _serialize_state(state) if state is not None else None,
+        "error": error,
+        "metadata": query_metadata,
+    }
+
+    logger.info(
+        "Assessment run complete: query='%s' mode=%s duration=%.1fs error=%s",
+        query[:50], mode, duration, error,
+    )
+
+    return result
+
+
+async def run_assessment(
+    queries_path: str | Path,
+    mode: str = "replay",
+    cassettes_dir: str | Path | None = None,
+) -> dict[str, Any]:
+    """Run assessment across a full query dataset.
+
+    Args:
+        queries_path: Path to queries.json
+        mode: "live" or "replay"
+        cassettes_dir: Directory containing cassette files (defaults to assessment_data/cassettes)
+
+    Returns:
+        Assessment results dict with per-query results and aggregate summary.
+    """
+    queries_path = Path(queries_path)
+    queries = json.loads(queries_path.read_text())
+
+    if cassettes_dir is None:
+        cassettes_dir = queries_path.parent / "cassettes"
+    else:
+        cassettes_dir = Path(cassettes_dir)
+
+    results = []
+    errors = 0
+    total_duration = 0
+
+    for i, q in enumerate(queries):
+        query_text = q["query"]
+        metadata = {k: v for k, v in q.items() if k != "query"}
+
+        logger.info("Running assessment %d/%d: '%s'", i + 1, len(queries), query_text[:50])
+
+        result = await run_single_assessment(
+            query=query_text,
+            mode=mode,
+            cassettes_dir=cassettes_dir,
+            query_metadata=metadata,
+        )
+        results.append(result)
+
+        if result["error"]:
+            errors += 1
+        total_duration += result["duration_seconds"]
+
+    summary = {
+        "total_queries": len(queries),
+        "successful": len(queries) - errors,
+        "failed": errors,
+        "total_duration_seconds": round(total_duration, 2),
+        "mode": mode,
+    }
+
+    return {
+        "summary": summary,
+        "results": results,
+    }
+
+
+async def main():
+    """CLI entry point for assessment runner."""
+    parser = argparse.ArgumentParser(description="Run pipeline assessment")
+    parser.add_argument("--queries", type=str, required=True, help="Path to queries.json")
+    parser.add_argument("--mode", type=str, default="replay", choices=["live", "replay"],
+                        help="Execution mode (default: replay)")
+    parser.add_argument("--cassettes-dir", type=str, default=None,
+                        help="Cassettes directory (default: assessment_data/cassettes)")
+    parser.add_argument("--output", type=str, default=None,
+                        help="Output file for results JSON (default: stdout)")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
+
+    results = await run_assessment(
+        queries_path=args.queries,
+        mode=args.mode,
+        cassettes_dir=args.cassettes_dir,
+    )
+
+    output_json = json.dumps(results, indent=2, default=str)
+
+    if args.output:
+        Path(args.output).write_text(output_json)
+        print(f"Results written to {args.output}")
+    else:
+        print(output_json)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/tests/test_assessment_checks.py
+++ b/backend/tests/test_assessment_checks.py
@@ -1,0 +1,290 @@
+"""Tests for structural checks and assessment report."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kestrel_backend.assessment.checks import (
+    CheckResult,
+    check_entity_resolution_recall,
+    check_finding_count_stability,
+    check_hypothesis_completeness,
+    check_pipeline_completion,
+    check_schema_conformance,
+    run_all_checks,
+)
+from kestrel_backend.assessment.report import (
+    AssessmentReport,
+    generate_report,
+    save_report,
+)
+
+
+# === Shared test state ===
+
+COMPLETE_STATE = {
+    "raw_query": "NAD+ and aging",
+    "raw_entities": ["NAD+", "aging"],
+    "resolved_entities": [
+        {"raw_name": "NAD+", "curie": "CHEBI:15422", "confidence": 0.95},
+        {"raw_name": "aging", "curie": "HP:0011462", "confidence": 0.8},
+    ],
+    "novelty_scores": [{"curie": "CHEBI:15422", "edge_count": 500}],
+    "direct_findings": [
+        {"text": "NAD+ is involved in energy metabolism", "tier": "tier1"},
+        {"text": "NAD+ declines with age", "tier": "tier1"},
+    ],
+    "cold_start_findings": [],
+    "synthesis_report": "# Analysis\n\nNAD+ metabolism and aging...",
+    "hypotheses": [
+        {"claim": "NAD+ decline drives aging", "evidence": ["finding1"], "novelty_score": 0.7},
+        {"claim": "NMN restores NAD+", "evidence": ["finding2"], "novelty_score": 0.5},
+    ],
+    "errors": [],
+}
+
+
+class TestCheckPipelineCompletion:
+    def test_all_nodes_present(self):
+        result = check_pipeline_completion(COMPLETE_STATE)
+        assert result.passed
+        assert result.status == "pass"
+
+    def test_missing_synthesis(self):
+        state = {**COMPLETE_STATE, "synthesis_report": ""}
+        result = check_pipeline_completion(state)
+        assert not result.passed
+        assert "synthesis" in result.message
+
+    def test_missing_entities(self):
+        state = {**COMPLETE_STATE, "raw_entities": []}
+        result = check_pipeline_completion(state)
+        assert not result.passed
+        assert "intake" in result.message
+
+    def test_empty_state(self):
+        result = check_pipeline_completion({})
+        assert not result.passed
+
+
+class TestCheckSchemaConformance:
+    def test_valid_types(self):
+        result = check_schema_conformance(COMPLETE_STATE)
+        assert result.passed
+
+    def test_wrong_type_synthesis_report(self):
+        state = {**COMPLETE_STATE, "synthesis_report": 42}
+        result = check_schema_conformance(state)
+        assert not result.passed
+        assert "synthesis_report" in result.message
+
+    def test_none_fields_accepted(self):
+        """None values should not trigger type violations."""
+        state = {**COMPLETE_STATE, "hypotheses": None}
+        result = check_schema_conformance(state)
+        assert result.passed
+
+
+class TestCheckEntityResolutionRecall:
+    def test_all_expected_found(self):
+        result = check_entity_resolution_recall(
+            COMPLETE_STATE, expected_curies=["CHEBI:15422", "HP:0011462"]
+        )
+        assert result.passed
+        assert result.status == "pass"
+
+    def test_missing_expected_curie(self):
+        result = check_entity_resolution_recall(
+            COMPLETE_STATE, expected_curies=["CHEBI:15422", "MISSING:999"]
+        )
+        assert not result.passed
+        assert "MISSING:999" in result.message
+
+    def test_extra_curies_accepted(self):
+        """Extra resolved CURIEs beyond expected should pass (recall, not exact match)."""
+        result = check_entity_resolution_recall(
+            COMPLETE_STATE, expected_curies=["CHEBI:15422"]
+        )
+        assert result.passed
+
+    def test_no_expected_curies_skipped(self):
+        result = check_entity_resolution_recall(COMPLETE_STATE, expected_curies=None)
+        assert result.passed
+        assert "skipping" in result.message.lower()
+
+
+class TestCheckFindingCountStability:
+    def test_within_tolerance_band(self):
+        baseline = {
+            "metric_bands": {
+                "direct_finding_count": {
+                    "mean": 2.0, "stddev": 0.5,
+                    "lower_bound": 1.0, "upper_bound": 3.0,
+                    "cv": 0.25, "status": "ok",
+                }
+            }
+        }
+        result = check_finding_count_stability(COMPLETE_STATE, baseline)
+        assert result.passed
+        assert result.status == "pass"
+
+    def test_outside_tolerance_band_fails(self):
+        baseline = {
+            "metric_bands": {
+                "direct_finding_count": {
+                    "mean": 10.0, "stddev": 0.5,
+                    "lower_bound": 9.0, "upper_bound": 11.0,
+                    "cv": 0.05, "status": "ok",
+                }
+            }
+        }
+        result = check_finding_count_stability(COMPLETE_STATE, baseline)
+        assert not result.passed
+        assert result.status == "fail"
+
+    def test_high_variance_produces_warning(self):
+        """CV > 0.5 should produce warning, not fail."""
+        baseline = {
+            "metric_bands": {
+                "direct_finding_count": {
+                    "mean": 10.0, "stddev": 6.0,
+                    "lower_bound": 0.0, "upper_bound": 22.0,
+                    "cv": 0.6, "status": "warning",
+                }
+            }
+        }
+        # State has 2 direct findings, which is outside [0, 22] — wait no, 2 is in [0, 22]
+        # Let me make it actually outside
+        state = {**COMPLETE_STATE, "direct_findings": [{"text": f"f{i}"} for i in range(25)]}
+        result = check_finding_count_stability(state, baseline)
+        assert result.passed  # warnings count as pass
+        assert result.status == "warning"
+
+    def test_no_baseline_skipped(self):
+        result = check_finding_count_stability(COMPLETE_STATE, None)
+        assert result.passed
+
+    def test_zero_findings_detected(self):
+        state = {**COMPLETE_STATE, "direct_findings": []}
+        baseline = {
+            "metric_bands": {
+                "direct_finding_count": {
+                    "mean": 5.0, "stddev": 1.0,
+                    "lower_bound": 3.0, "upper_bound": 7.0,
+                    "cv": 0.2, "status": "ok",
+                }
+            }
+        }
+        result = check_finding_count_stability(state, baseline)
+        assert not result.passed
+
+
+class TestCheckHypothesisCompleteness:
+    def test_complete_hypotheses(self):
+        result = check_hypothesis_completeness(COMPLETE_STATE)
+        assert result.passed
+
+    def test_missing_claim_field(self):
+        state = {
+            **COMPLETE_STATE,
+            "hypotheses": [{"evidence": ["e1"], "novelty_score": 0.5}],
+        }
+        result = check_hypothesis_completeness(state)
+        assert not result.passed
+        assert "claim" in result.message
+
+    def test_no_hypotheses(self):
+        state = {**COMPLETE_STATE, "hypotheses": []}
+        result = check_hypothesis_completeness(state)
+        assert result.passed
+
+
+class TestRunAllChecks:
+    def test_returns_five_results(self):
+        results = run_all_checks(COMPLETE_STATE)
+        assert len(results) == 5
+        assert all(isinstance(r, CheckResult) for r in results)
+
+    def test_all_pass_on_complete_state(self):
+        results = run_all_checks(COMPLETE_STATE)
+        assert all(r.passed for r in results)
+
+
+class TestAssessmentReport:
+    def test_generate_report(self):
+        assessment_results = {
+            "summary": {"mode": "replay"},
+            "results": [
+                {
+                    "query": "NAD+ and aging",
+                    "query_hash": "abc123",
+                    "state": COMPLETE_STATE,
+                    "metadata": {"path_type": "well-characterized"},
+                    "error": None,
+                },
+            ],
+        }
+        report = generate_report(assessment_results)
+        assert report.schema_version == "v1"
+        assert len(report.query_reports) == 1
+        assert report.query_reports[0].passed
+        assert report.aggregate["passed"] == 1
+        assert report.aggregate["failed"] == 0
+
+    def test_report_includes_human_judgment_placeholders(self):
+        assessment_results = {
+            "summary": {"mode": "replay"},
+            "results": [
+                {
+                    "query": "test",
+                    "query_hash": "def456",
+                    "state": COMPLETE_STATE,
+                    "metadata": {},
+                    "error": None,
+                },
+            ],
+        }
+        report = generate_report(assessment_results)
+        qr = report.query_reports[0]
+        # Should have one judgment placeholder per hypothesis
+        assert len(qr.human_judgment) == len(COMPLETE_STATE["hypotheses"])
+        assert all(j.override_plausibility is None for j in qr.human_judgment)
+
+    def test_skipped_queries_excluded(self):
+        assessment_results = {
+            "summary": {"mode": "replay"},
+            "results": [
+                {"query": "failed", "query_hash": "x", "state": None, "metadata": {}, "error": "API down"},
+            ],
+        }
+        report = generate_report(assessment_results)
+        assert len(report.query_reports) == 0
+
+    def test_save_report(self, tmp_path: Path):
+        report = AssessmentReport(mode="test", aggregate={"total": 0})
+        output_path = tmp_path / "report.json"
+        save_report(report, output_path)
+        assert output_path.exists()
+        loaded = json.loads(output_path.read_text())
+        assert loaded["schema_version"] == "v1"
+
+    def test_report_json_serializable(self):
+        assessment_results = {
+            "summary": {"mode": "replay"},
+            "results": [
+                {
+                    "query": "test",
+                    "query_hash": "abc",
+                    "state": COMPLETE_STATE,
+                    "metadata": {},
+                    "error": None,
+                },
+            ],
+        }
+        report = generate_report(assessment_results)
+        # Should serialize without errors
+        json_str = report.model_dump_json()
+        parsed = json.loads(json_str)
+        assert parsed["schema_version"] == "v1"
+        assert len(parsed["query_reports"]) == 1

--- a/backend/tests/test_assessment_runner.py
+++ b/backend/tests/test_assessment_runner.py
@@ -1,0 +1,215 @@
+"""Tests for assessment runner."""
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from kestrel_backend.assessment.cassette import CassetteRecorder
+from kestrel_backend.assessment.runner import (
+    run_assessment,
+    run_single_assessment,
+)
+
+
+MOCK_STATE = {
+    "raw_query": "NAD+ and aging",
+    "resolved_entities": [],
+    "direct_findings": [],
+    "hypotheses": [],
+    "errors": [],
+}
+
+SSE_RESPONSE = 'event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"test"}]}}\n'
+
+
+def _create_cassette(tmp_path: Path, query: str, query_hash: str) -> Path:
+    """Create a minimal cassette file for replay testing."""
+    recorder = CassetteRecorder()
+
+    import httpx
+    request = httpx.Request(
+        "POST", "https://kestrel.nathanpricelab.com/mcp",
+        json={"jsonrpc": "2.0", "method": "tools/call", "id": 1},
+    )
+    response = httpx.Response(status_code=200, text=SSE_RESPONSE)
+    recorder.record_interaction(request, response)
+
+    cassettes_dir = tmp_path / "cassettes"
+    cassettes_dir.mkdir(parents=True, exist_ok=True)
+    cassette_path = cassettes_dir / f"{query_hash}_run1.json"
+    recorder.save(cassette_path, metadata={"query": query})
+
+    return cassettes_dir
+
+
+class TestRunSingleAssessment:
+    """Test single query assessment runs."""
+
+    async def test_live_mode_produces_result(self, tmp_path: Path):
+        """Live mode should execute pipeline and return result dict."""
+        with patch(
+            "kestrel_backend.graph.runner.run_discovery",
+            new_callable=AsyncMock,
+            return_value=MOCK_STATE,
+        ):
+            result = await run_single_assessment(
+                query="NAD+ and aging",
+                mode="live",
+            )
+
+        assert result["query"] == "NAD+ and aging"
+        assert result["mode"] == "live"
+        assert result["error"] is None
+        assert result["state"] is not None
+        assert result["duration_seconds"] >= 0
+
+    async def test_replay_mode_with_cassette(self, tmp_path: Path):
+        """Replay mode should serve cached responses from cassette."""
+        from kestrel_backend.assessment.capture import query_hash
+        qhash = query_hash("NAD+ and aging")
+        cassettes_dir = _create_cassette(tmp_path, "NAD+ and aging", qhash)
+
+        with patch(
+            "kestrel_backend.graph.runner.run_discovery",
+            new_callable=AsyncMock,
+            return_value=MOCK_STATE,
+        ):
+            result = await run_single_assessment(
+                query="NAD+ and aging",
+                mode="replay",
+                cassettes_dir=cassettes_dir,
+            )
+
+        assert result["mode"] == "replay"
+        assert result["error"] is None
+        assert result["state"] is not None
+
+    async def test_replay_mode_missing_cassette(self, tmp_path: Path):
+        """Missing cassette should return error, not raise."""
+        cassettes_dir = tmp_path / "cassettes"
+        cassettes_dir.mkdir(parents=True, exist_ok=True)
+
+        result = await run_single_assessment(
+            query="unknown query",
+            mode="replay",
+            cassettes_dir=cassettes_dir,
+        )
+
+        assert result["error"] is not None
+        assert "No cassette found" in result["error"]
+        assert result["state"] is None
+
+    async def test_replay_mode_requires_cassettes_dir(self):
+        """Replay mode without cassettes_dir should raise ValueError."""
+        with patch(
+            "kestrel_backend.graph.runner.run_discovery",
+            new_callable=AsyncMock,
+        ):
+            result = await run_single_assessment(
+                query="test",
+                mode="replay",
+                cassettes_dir=None,
+            )
+
+        assert result["error"] is not None
+        assert "cassettes_dir required" in result["error"]
+
+    async def test_pipeline_failure_captured(self, tmp_path: Path):
+        """Pipeline execution failure should be captured, not raised."""
+        with patch(
+            "kestrel_backend.graph.runner.run_discovery",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("SDK auth expired"),
+        ):
+            result = await run_single_assessment(
+                query="failing query",
+                mode="live",
+            )
+
+        assert result["error"] is not None
+        assert "SDK auth expired" in result["error"]
+        assert result["state"] is None
+
+    async def test_metadata_passed_through(self, tmp_path: Path):
+        """Query metadata should be included in result."""
+        with patch(
+            "kestrel_backend.graph.runner.run_discovery",
+            new_callable=AsyncMock,
+            return_value=MOCK_STATE,
+        ):
+            result = await run_single_assessment(
+                query="test",
+                mode="live",
+                query_metadata={"path_type": "well-characterized"},
+            )
+
+        assert result["metadata"]["path_type"] == "well-characterized"
+
+
+class TestRunAssessment:
+    """Test full assessment runs across query dataset."""
+
+    async def test_batch_assessment(self, tmp_path: Path):
+        """Batch assessment should run all queries and produce summary."""
+        queries = [
+            {"query": "query A", "path_type": "well-characterized"},
+            {"query": "query B", "path_type": "sparse"},
+        ]
+        queries_path = tmp_path / "queries.json"
+        queries_path.write_text(json.dumps(queries))
+
+        # Create cassettes for both queries
+        from kestrel_backend.assessment.capture import query_hash
+        for q in queries:
+            _create_cassette(tmp_path, q["query"], query_hash(q["query"]))
+
+        with patch(
+            "kestrel_backend.graph.runner.run_discovery",
+            new_callable=AsyncMock,
+            return_value=MOCK_STATE,
+        ):
+            results = await run_assessment(
+                queries_path=queries_path,
+                mode="replay",
+                cassettes_dir=tmp_path / "cassettes",
+            )
+
+        assert results["summary"]["total_queries"] == 2
+        assert results["summary"]["successful"] == 2
+        assert results["summary"]["failed"] == 0
+        assert len(results["results"]) == 2
+
+    async def test_batch_with_failure(self, tmp_path: Path):
+        """Batch should continue after individual query failures."""
+        queries = [
+            {"query": "good query"},
+            {"query": "bad query"},
+        ]
+        queries_path = tmp_path / "queries.json"
+        queries_path.write_text(json.dumps(queries))
+
+        call_count = 0
+
+        async def mock_run(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                raise RuntimeError("API error")
+            return MOCK_STATE
+
+        with patch(
+            "kestrel_backend.graph.runner.run_discovery",
+            new_callable=AsyncMock,
+            side_effect=mock_run,
+        ):
+            results = await run_assessment(
+                queries_path=queries_path,
+                mode="live",
+            )
+
+        assert results["summary"]["successful"] == 1
+        assert results["summary"]["failed"] == 1
+        assert results["results"][0]["error"] is None
+        assert results["results"][1]["error"] is not None


### PR DESCRIPTION
## Summary

- Add assessment runner (`assessment/runner.py`) with live and replay execution modes
- Add 5 structural check functions (`assessment/checks.py`) with tolerance band support
- Add JSON report generation (`assessment/report.py`) with per-query results, aggregate summary, and human_judgment placeholders

## Context

PR4 of 5 in the pipeline cleanup effort. This is the first regression detection layer — structural checks catch pipeline completion failures, schema violations, entity resolution recall drops, finding count instability, and hypothesis incompleteness.

### Key design decisions
- **Replay mode** uses the shared cassette module from PR1 to serve cached HTTP responses. LLM calls (Claude SDK `query()`) still execute live — replay eliminates external API dependency, not non-determinism
- **Tolerance bands** from baseline variance data drive finding count stability checks. Queries with CV > 0.5 produce `warning` status, not `fail`
- **human_judgment placeholders** (R13) included per hypothesis in every report — null initially, ready for expert-in-the-loop consumption
- **Schema version v1** on all reports for forward compatibility

### Structural checks
1. **Pipeline completion** — all core nodes (intake, entity_resolution, triage, synthesis) produced output
2. **Schema conformance** — key fields have correct types
3. **Entity resolution recall** — expected CURIEs found (extra CURIEs acceptable)
4. **Finding count stability** — within tolerance bands from baseline variance
5. **Hypothesis completeness** — required fields (claim, evidence, novelty_score) present

## New files
- `backend/src/kestrel_backend/assessment/runner.py` — assessment runner with CLI
- `backend/src/kestrel_backend/assessment/checks.py` — 5 structural check functions
- `backend/src/kestrel_backend/assessment/report.py` — Pydantic report models + generation
- `backend/tests/test_assessment_runner.py` — 8 tests
- `backend/tests/test_assessment_checks.py` — 26 tests

## Test plan

- [x] All 34 new tests pass (runner + checks/report)
- [x] Runner handles missing cassettes gracefully (returns error, doesn't raise)
- [x] Runner captures pipeline failures without crashing batch
- [x] CV > 0.5 tolerance band produces warning, not fail
- [x] Report JSON is fully serializable and parseable
- [x] human_judgment placeholders present per hypothesis

Generated with [Claude Code](https://claude.com/claude-code)