### PR TITLE
feat: add model_usages cost tracking to DiscoveryState

### DIFF
--- a/backend/src/kestrel_backend/graph/nodes/cold_start.py
+++ b/backend/src/kestrel_backend/graph/nodes/cold_start.py
@@ -30,7 +30,7 @@ from ...kestrel_client import call_kestrel_tool
 from ..state import (
     DiscoveryState, Finding, InferredAssociation, AnalogueEntity, NoveltyScore
 )
-from ..sdk_utils import HAS_SDK, query, ClaudeAgentOptions, chunk, query_with_usage, DEFAULT_MODEL_NAME
+from ..sdk_utils import HAS_SDK, ClaudeAgentOptions, chunk, query_with_usage
 from ..pipeline_config import get_pipeline_config
 from ..state_contracts import validate_state, ColdStartInput, ColdStartOutput
 

--- a/backend/src/kestrel_backend/graph/nodes/cold_start.py
+++ b/backend/src/kestrel_backend/graph/nodes/cold_start.py
@@ -30,7 +30,7 @@ from ...kestrel_client import call_kestrel_tool
 from ..state import (
     DiscoveryState, Finding, InferredAssociation, AnalogueEntity, NoveltyScore
 )
-from ..sdk_utils import HAS_SDK, query, ClaudeAgentOptions, chunk
+from ..sdk_utils import HAS_SDK, query, ClaudeAgentOptions, chunk, query_with_usage, DEFAULT_MODEL_NAME
 from ..pipeline_config import get_pipeline_config
 from ..state_contracts import validate_state, ColdStartInput, ColdStartOutput
 
@@ -369,7 +369,7 @@ async def analyze_cold_start_entity(
     curie: str,
     raw_name: str,
     edge_count: int
-) -> tuple[list[AnalogueEntity], list[InferredAssociation], list[Finding], list[str]]:
+) -> tuple[list[AnalogueEntity], list[InferredAssociation], list[Finding], list[str], Any | None]:
     """
     Analyze a single sparse/cold-start entity using direct HTTP API + SDK inference.
 
@@ -401,6 +401,7 @@ async def analyze_cold_start_entity(
                 logic_chain="Vector similarity search returned no results",
             )],
             [],
+            None,
         )
 
     # Convert to AnalogueEntity objects
@@ -435,6 +436,7 @@ async def analyze_cold_start_entity(
                 logic_chain=f"Found {len(analogues)} analogues but none with similarity >= 0.7 (skipped inference)",
             )],
             [],
+            None,
         )
 
     # Step 2: Get connections for each analogue via direct HTTP API
@@ -472,6 +474,7 @@ async def analyze_cold_start_entity(
                 logic_chain=f"Found {len(analogues)} analogues via vector similarity search (SDK unavailable for inference)",
             )],
             [],
+            None,
         )
 
     try:
@@ -489,26 +492,17 @@ async def analyze_cold_start_entity(
                 permission_mode="bypassPermissions",
             )
 
-            result_text_parts: list[str] = []
-            event_count = 0
-
-            async def collect_events() -> None:
-                """Collect SDK query events into result_text_parts."""
-                nonlocal event_count
-                async for event in query(
-                    prompt=inference_prompt,
-                    options=options
-                ):
-                    event_count += 1
-                    if hasattr(event, 'content'):
-                        for block in event.content:
-                            if hasattr(block, 'text'):
-                                result_text_parts.append(block.text)
-
             logger.info("Cold-start Step 3: Invoking SDK inference for '%s' (%s)...", raw_name, curie)
             try:
-                await asyncio.wait_for(collect_events(), timeout=_config.inference_timeout)
-                logger.info("Cold-start SDK inference for '%s' completed with %d events", raw_name, event_count)
+                result_text, usage_record = await asyncio.wait_for(
+                    query_with_usage(
+                        prompt=inference_prompt,
+                        options=options,
+                        node_name="cold_start",
+                    ),
+                    timeout=_config.inference_timeout,
+                )
+                logger.info("Cold-start SDK inference for '%s' completed", raw_name)
             except asyncio.TimeoutError:
                 logger.error(
                     "Cold-start SDK inference TIMED OUT for '%s' (%s) after %ds",
@@ -528,6 +522,7 @@ async def analyze_cold_start_entity(
                         logic_chain=f"Found {len(analogues)} analogues (inference timed out)",
                     )],
                     [f"SDK inference timed out for {curie} after {_config.inference_timeout}s"],
+                    None,
                 )
             except Exception as sdk_error:
                 logger.error(
@@ -549,9 +544,8 @@ async def analyze_cold_start_entity(
                         logic_chain=f"Found {len(analogues)} analogues (inference failed: {str(sdk_error)[:50]})",
                     )],
                     [f"SDK inference failed for {curie}: {str(sdk_error)}"],
+                    None,
                 )
-
-            result_text = "".join(result_text_parts)
 
             # Log successful response for diagnosis
             logger.info(
@@ -576,7 +570,7 @@ async def analyze_cold_start_entity(
                 logic_chain=f"Found {len(analogues)} analogues via vector similarity search",
             ))
 
-        return analogues, inferences, findings, errors
+        return analogues, inferences, findings, errors, usage_record
 
     except Exception as e:
         error_msg = f"Cold-start analysis failed for {curie}: {str(e)}"
@@ -594,6 +588,7 @@ async def analyze_cold_start_entity(
                 confidence="low",
             )],
             [error_msg],
+            None,
         )
 
 
@@ -726,6 +721,7 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
     all_inferences: list[InferredAssociation] = []
     all_findings: list[Finding] = []
     errors: list[str] = []
+    all_usage_records: list = []
 
     # Process in batches for controlled parallelism
     batches = chunk(entities, _config.batch_size)
@@ -756,11 +752,13 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
                     confidence="low",
                 ))
             else:
-                analogues, inferences, findings, errs = result
+                analogues, inferences, findings, errs, usage_rec = result
                 all_analogues.extend(analogues)
                 all_inferences.extend(inferences)
                 all_findings.extend(findings)
                 errors.extend(errs)
+                if usage_rec is not None:
+                    all_usage_records.append(usage_rec)
 
         # Progress logging
         processed_count = min((batch_idx + 1) * _config.batch_size, len(entities))
@@ -775,10 +773,13 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
         duration, len(all_analogues), len(all_inferences), skipped_count
     )
 
-    return {
+    result: dict[str, Any] = {
         "cold_start_findings": all_findings,
         "inferred_associations": all_inferences,
         "analogues_found": all_analogues,
         "errors": errors,
         "cold_start_skipped_count": skipped_count,
     }
+    if all_usage_records:
+        result["model_usages"] = all_usage_records
+    return result

--- a/backend/src/kestrel_backend/graph/nodes/direct_kg.py
+++ b/backend/src/kestrel_backend/graph/nodes/direct_kg.py
@@ -31,7 +31,7 @@ from ...kestrel_client import call_kestrel_tool
 from ..state import (
     DiscoveryState, Finding, DiseaseAssociation, PathwayMembership, NoveltyScore
 )
-from ..sdk_utils import HAS_SDK, query, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS
+from ..sdk_utils import HAS_SDK, query, query_with_usage, DEFAULT_MODEL_NAME, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS
 from ..pipeline_config import get_pipeline_config
 from ..state_contracts import validate_state, DirectKGInput, DirectKGOutput
 
@@ -530,14 +530,14 @@ def parse_direct_kg_result(
 async def analyze_single_entity(
     curie: str,
     raw_name: str
-) -> tuple[list[DiseaseAssociation], list[PathwayMembership], list[Finding], list[str], list[str]]:
+) -> tuple[list[DiseaseAssociation], list[PathwayMembership], list[Finding], list[str], list[str], Any]:
     """
     Tier 2: Analyze a single entity using Claude Agent SDK with LLM reasoning.
 
     This is the fallback path when Tier 1 API calls fail.
 
     Returns:
-        tuple of (diseases, pathways, findings, hub_flags, errors)
+        tuple of (diseases, pathways, findings, hub_flags, errors, ModelUsageRecord | None)
     """
     if not HAS_SDK:
         return (
@@ -552,6 +552,7 @@ async def analyze_single_entity(
             )],
             [],
             [],
+            None,
         )
 
     try:
@@ -571,14 +572,11 @@ async def analyze_single_entity(
                 max_buffer_size=10 * 1024 * 1024,
             )
 
-            result_text_parts = []
-            async for event in query(prompt=f"Analyze entity: {raw_name} ({curie})", options=options):
-                if hasattr(event, 'content'):
-                    for block in event.content:
-                        if hasattr(block, 'text'):
-                            result_text_parts.append(block.text)
-
-            result_text = "".join(result_text_parts)
+            result_text, usage_record = await query_with_usage(
+                prompt=f"Analyze entity: {raw_name} ({curie})",
+                options=options,
+                node_name="direct_kg",
+            )
         diseases, pathways, findings, hub_flags = parse_direct_kg_result(curie, raw_name, result_text)
 
         logger.info(
@@ -586,7 +584,7 @@ async def analyze_single_entity(
             curie, len(diseases), len(pathways), len(findings)
         )
 
-        return diseases, pathways, findings, hub_flags, []
+        return diseases, pathways, findings, hub_flags, [], usage_record
 
     except Exception as e:
         error_msg = f"Tier 2 direct_kg failed for {curie}: {str(e)}"
@@ -603,6 +601,7 @@ async def analyze_single_entity(
             )],
             [],
             [error_msg],
+            None,
         )
 
 
@@ -709,6 +708,7 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
                 tier1_success, len(unique_curies), tier1_duration)
 
     # ========== TIER 2: LLM Fallback ==========
+    model_usages = []
     if tier2_needed_curies and HAS_SDK:
         tier2_start = time.time()
         logger.info("Tier 2 (LLM): Processing %d unique entities that failed Tier 1",
@@ -732,8 +732,14 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
                 if isinstance(result, Exception):
                     errors.append(f"Tier 2 failed for {curie}: {str(result)}")
                 elif result is not None:
+                    # Extract usage record from the 6th element of the tuple
+                    usage_record = result[5] if len(result) > 5 else None
+                    # Pass the 5-element tuple (without usage) to all_results
+                    result_without_usage = result[:5]
                     for idx in indices:
-                        all_results[idx] = result
+                        all_results[idx] = result_without_usage
+                    if usage_record is not None:
+                        model_usages.append(usage_record)
 
         tier2_duration = time.time() - tier2_start
         logger.info("Tier 2 (LLM) completed in %.1fs", tier2_duration)
@@ -771,10 +777,13 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
         len(all_diseases), len(all_pathways)
     )
 
-    return {
+    result = {
         "direct_findings": all_findings,
         "disease_associations": all_diseases,
         "pathway_memberships": all_pathways,
         "hub_flags": all_hub_flags,
         "errors": errors,
     }
+    if model_usages:
+        result["model_usages"] = model_usages
+    return result

--- a/backend/src/kestrel_backend/graph/nodes/direct_kg.py
+++ b/backend/src/kestrel_backend/graph/nodes/direct_kg.py
@@ -31,7 +31,7 @@ from ...kestrel_client import call_kestrel_tool
 from ..state import (
     DiscoveryState, Finding, DiseaseAssociation, PathwayMembership, NoveltyScore
 )
-from ..sdk_utils import HAS_SDK, query, query_with_usage, DEFAULT_MODEL_NAME, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS
+from ..sdk_utils import HAS_SDK, query_with_usage, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS
 from ..pipeline_config import get_pipeline_config
 from ..state_contracts import validate_state, DirectKGInput, DirectKGOutput
 

--- a/backend/src/kestrel_backend/graph/nodes/entity_resolution.py
+++ b/backend/src/kestrel_backend/graph/nodes/entity_resolution.py
@@ -28,7 +28,7 @@ from typing import Any
 
 from ...kestrel_client import call_kestrel_tool
 from ..state import DiscoveryState, EntityResolution
-from ..sdk_utils import HAS_SDK, query, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS
+from ..sdk_utils import HAS_SDK, query, query_with_usage, DEFAULT_MODEL_NAME, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS
 from ..pipeline_config import get_pipeline_config
 from ..state_contracts import validate_state, EntityResolutionInput, EntityResolutionOutput
 
@@ -256,7 +256,7 @@ def parse_resolution_result(entity: str, result_text: str) -> EntityResolution:
     )
 
 
-async def resolve_single_entity(entity: str, is_retry: bool = False) -> EntityResolution:
+async def resolve_single_entity(entity: str, is_retry: bool = False) -> tuple[EntityResolution, Any]:
     """
     Resolve a single entity name to a CURIE using Claude Agent SDK.
 
@@ -264,18 +264,19 @@ async def resolve_single_entity(entity: str, is_retry: bool = False) -> EntityRe
         entity: The entity name to resolve
         is_retry: If True, use more aggressive retry prompt
 
-    Returns EntityResolution with method="failed" on any error.
+    Returns tuple of (EntityResolution, ModelUsageRecord | None).
+    EntityResolution has method="failed" on any error.
     """
     if not HAS_SDK:
         # SDK not available - return mock for testing
-        return EntityResolution(
+        return (EntityResolution(
             raw_name=entity,
             curie=None,
             resolved_name=None,
             category=None,
             confidence=0.0,
             method="failed",
-        )
+        ), None)
 
     try:
         async with SDK_SEMAPHORE:
@@ -301,25 +302,22 @@ async def resolve_single_entity(entity: str, is_retry: bool = False) -> EntityRe
                 max_buffer_size=10 * 1024 * 1024,  # 10MB buffer for large KG responses
             )
 
-            result_text_parts = []
-            async for event in query(prompt=f"Resolve: {entity}", options=options):
-                if hasattr(event, "content"):
-                    for block in event.content:
-                        if hasattr(block, "text"):
-                            result_text_parts.append(block.text)
-
-            result_text = "".join(result_text_parts)
-            return parse_resolution_result(entity, result_text)
+            result_text, usage_record = await query_with_usage(
+                prompt=f"Resolve: {entity}",
+                options=options,
+                node_name="entity_resolution",
+            )
+            return parse_resolution_result(entity, result_text), usage_record
 
     except Exception as e:
-        return EntityResolution(
+        return (EntityResolution(
             raw_name=entity,
             curie=None,
             resolved_name=None,
             category=None,
             confidence=0.0,
             method="failed",
-        )
+        ), None)
 
 
 
@@ -438,6 +436,7 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
         )
 
     # ========== TIER 2: LLM Resolution ==========
+    model_usages: list = []
     if tier2_needed_indices and HAS_SDK:
         tier2_start = time.time()
         failed_entities = [entities[i] for i in tier2_needed_indices]
@@ -473,7 +472,10 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
                     method="failed",
                 )
             else:
-                all_results[idx] = result
+                resolution, usage_record = result
+                all_results[idx] = resolution
+                if usage_record is not None:
+                    model_usages.append(usage_record)
 
         # Second pass: Aggressive retry for still-failed entities
         still_failed_indices = [i for i in tier2_needed_indices if all_results[i] and not all_results[i].curie]
@@ -497,8 +499,13 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
 
             # Merge successful retries back
             for idx, retry_result in zip(still_failed_indices, retry_results):
-                if isinstance(retry_result, EntityResolution) and retry_result.curie:
-                    all_results[idx] = retry_result
+                if isinstance(retry_result, Exception):
+                    continue
+                resolution, usage_record = retry_result
+                if isinstance(resolution, EntityResolution) and resolution.curie:
+                    all_results[idx] = resolution
+                if usage_record is not None:
+                    model_usages.append(usage_record)
 
         tier2_duration = time.time() - tier2_start
         tier2_resolved = sum(1 for i in tier2_needed_indices if all_results[i] and all_results[i].curie)
@@ -555,7 +562,10 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
         duration, len(resolved), tier1_resolved, alias_resolved, llm_resolved, len(failed), rate
     )
 
-    return {
+    result = {
         "resolved_entities": final_results,
         "errors": errors,
     }
+    if model_usages:
+        result["model_usages"] = model_usages
+    return result

--- a/backend/src/kestrel_backend/graph/nodes/entity_resolution.py
+++ b/backend/src/kestrel_backend/graph/nodes/entity_resolution.py
@@ -28,7 +28,7 @@ from typing import Any
 
 from ...kestrel_client import call_kestrel_tool
 from ..state import DiscoveryState, EntityResolution
-from ..sdk_utils import HAS_SDK, query, query_with_usage, DEFAULT_MODEL_NAME, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS
+from ..sdk_utils import HAS_SDK, query_with_usage, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS
 from ..pipeline_config import get_pipeline_config
 from ..state_contracts import validate_state, EntityResolutionInput, EntityResolutionOutput
 

--- a/backend/src/kestrel_backend/graph/nodes/integration.py
+++ b/backend/src/kestrel_backend/graph/nodes/integration.py
@@ -27,7 +27,7 @@ from ..state import (
     EntityResolution
 )
 from ...kestrel_client import multi_hop_query
-from ..sdk_utils import HAS_SDK, query, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS
+from ..sdk_utils import HAS_SDK, query, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS, query_with_usage, DEFAULT_MODEL_NAME
 from ..state_contracts import validate_state, IntegrationInput, IntegrationOutput
 
 logger = logging.getLogger(__name__)
@@ -590,15 +590,12 @@ If no gaps found, return: {{"gaps": []}}
             permission_mode="bypassPermissions",
         )
 
-        # Execute the query using async generator pattern
-        result_text_parts = []
-        async for event in query(prompt=gap_analysis_prompt, options=options):
-            if hasattr(event, 'content'):
-                for block in event.content:
-                    if hasattr(block, 'text'):
-                        result_text_parts.append(block.text)
-
-        result_text = "".join(result_text_parts)
+        # Execute the query using query_with_usage
+        result_text, usage_record = await query_with_usage(
+            prompt=gap_analysis_prompt,
+            options=options,
+            node_name="integration",
+        )
 
         # Parse only gap analysis from LLM result
         _, gaps, parse_errors = parse_integration_result(result_text)
@@ -636,12 +633,15 @@ If no gaps found, return: {{"gaps": []}}
             duration, len(bridges), len(gaps)
         )
 
-        return {
+        result_dict: dict[str, Any] = {
             "bridges": bridges,
             "gap_entities": gaps,
             "direct_findings": findings,  # Uses operator.add reducer
             "errors": parse_errors,
         }
+        if usage_record is not None:
+            result_dict["model_usages"] = [usage_record]
+        return result_dict
 
     except Exception as e:
         duration = time.time() - start

--- a/backend/src/kestrel_backend/graph/nodes/integration.py
+++ b/backend/src/kestrel_backend/graph/nodes/integration.py
@@ -27,7 +27,7 @@ from ..state import (
     EntityResolution
 )
 from ...kestrel_client import multi_hop_query
-from ..sdk_utils import HAS_SDK, query, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS, query_with_usage, DEFAULT_MODEL_NAME
+from ..sdk_utils import HAS_SDK, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS, query_with_usage
 from ..state_contracts import validate_state, IntegrationInput, IntegrationOutput
 
 logger = logging.getLogger(__name__)

--- a/backend/src/kestrel_backend/graph/nodes/pathway_enrichment.py
+++ b/backend/src/kestrel_backend/graph/nodes/pathway_enrichment.py
@@ -24,7 +24,7 @@ from ..state import (
     DiscoveryState, SharedNeighbor, BiologicalTheme, Finding
 )
 from ...kestrel_client import multi_hop_query
-from ..sdk_utils import HAS_SDK, query, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS
+from ..sdk_utils import HAS_SDK, query, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS, query_with_usage, DEFAULT_MODEL_NAME
 from ..pipeline_config import get_pipeline_config
 from ..state_contracts import validate_state, PathwayEnrichmentInput, PathwayEnrichmentOutput
 
@@ -380,19 +380,16 @@ NOTE: Two-hop analysis already completed separately. Focus on ONE-HOP neighbors 
             max_buffer_size=10 * 1024 * 1024,  # 10MB buffer for large KG responses
         )
 
-        # Execute the query using async generator pattern with timeout
-        result_text_parts: list[str] = []
-
-        async def collect_events() -> None:
-            """Collect SDK query events into result_text_parts."""
-            async for event in query(prompt=user_prompt, options=options):
-                if hasattr(event, 'content'):
-                    for block in event.content:
-                        if hasattr(block, 'text'):
-                            result_text_parts.append(block.text)
-
+        # Execute the query using query_with_usage with timeout
         try:
-            await asyncio.wait_for(collect_events(), timeout=SDK_QUERY_TIMEOUT)
+            result_text, usage_record = await asyncio.wait_for(
+                query_with_usage(
+                    prompt=user_prompt,
+                    options=options,
+                    node_name="pathway_enrichment",
+                ),
+                timeout=SDK_QUERY_TIMEOUT,
+            )
         except asyncio.TimeoutError:
             duration = time.time() - start
             logger.error(
@@ -404,8 +401,6 @@ NOTE: Two-hop analysis already completed separately. Focus on ONE-HOP neighbors 
                 "biological_themes": [],
                 "errors": [f"SDK query timed out after {SDK_QUERY_TIMEOUT}s"],
             }
-
-        result_text = "".join(result_text_parts)
 
         # Log raw response for diagnosis
         logger.info(
@@ -459,12 +454,15 @@ NOTE: Two-hop analysis already completed separately. Focus on ONE-HOP neighbors 
         # Combine errors
         all_errors = parse_errors + two_hop_errors
 
-        return {
+        result_dict: dict[str, Any] = {
             "shared_neighbors": shared_neighbors,
             "biological_themes": themes,
             "direct_findings": findings,  # Add to direct_findings via reducer
             "errors": all_errors,
         }
+        if usage_record is not None:
+            result_dict["model_usages"] = [usage_record]
+        return result_dict
 
     except Exception as e:
         duration = time.time() - start

--- a/backend/src/kestrel_backend/graph/nodes/pathway_enrichment.py
+++ b/backend/src/kestrel_backend/graph/nodes/pathway_enrichment.py
@@ -24,7 +24,7 @@ from ..state import (
     DiscoveryState, SharedNeighbor, BiologicalTheme, Finding
 )
 from ...kestrel_client import multi_hop_query
-from ..sdk_utils import HAS_SDK, query, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS, query_with_usage, DEFAULT_MODEL_NAME
+from ..sdk_utils import HAS_SDK, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS, query_with_usage
 from ..pipeline_config import get_pipeline_config
 from ..state_contracts import validate_state, PathwayEnrichmentInput, PathwayEnrichmentOutput
 

--- a/backend/src/kestrel_backend/graph/nodes/synthesis.py
+++ b/backend/src/kestrel_backend/graph/nodes/synthesis.py
@@ -26,7 +26,7 @@ from ..state import (
 )
 from ...literature_utils import format_pmid_link
 from ...kestrel_client import multi_hop_query
-from ..sdk_utils import HAS_SDK, query, ClaudeAgentOptions, query_with_usage, DEFAULT_MODEL_NAME
+from ..sdk_utils import HAS_SDK, ClaudeAgentOptions, query_with_usage
 from ..state_contracts import validate_state, SynthesisInput, SynthesisOutput
 
 logger = logging.getLogger(__name__)
@@ -1075,6 +1075,8 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
                 options=options,
                 node_name="synthesis",
             )
+            # NOTE: query_with_usage joins text blocks with "", not "\n" (previous behavior).
+            # All other nodes use "".join(); synthesis now matches them.
 
             report = text if text.strip() else fallback_report(state)
         except Exception as e:

--- a/backend/src/kestrel_backend/graph/nodes/synthesis.py
+++ b/backend/src/kestrel_backend/graph/nodes/synthesis.py
@@ -26,7 +26,7 @@ from ..state import (
 )
 from ...literature_utils import format_pmid_link
 from ...kestrel_client import multi_hop_query
-from ..sdk_utils import HAS_SDK, query, ClaudeAgentOptions
+from ..sdk_utils import HAS_SDK, query, ClaudeAgentOptions, query_with_usage, DEFAULT_MODEL_NAME
 from ..state_contracts import validate_state, SynthesisInput, SynthesisOutput
 
 logger = logging.getLogger(__name__)
@@ -1060,6 +1060,7 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
     context = assemble_synthesis_context(state_with_validated)
 
     # Phase C: LLM synthesis or fallback
+    usage_record = None
     if HAS_SDK:
         try:
             options = ClaudeAgentOptions(
@@ -1068,15 +1069,14 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
                 max_turns=1,
                 permission_mode="bypassPermissions",
             )
-            
-            result_text = []
-            async for event in query(prompt=context, options=options):
-                if hasattr(event, 'content'):
-                    for block in event.content:
-                        if hasattr(block, 'text'):
-                            result_text.append(block.text)
-            
-            report = "\n".join(result_text) if result_text else fallback_report(state)
+
+            text, usage_record = await query_with_usage(
+                prompt=context,
+                options=options,
+                node_name="synthesis",
+            )
+
+            report = text if text.strip() else fallback_report(state)
         except Exception as e:
             # Fallback on any SDK error
             report = fallback_report(state)
@@ -1098,4 +1098,5 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
         "synthesis_report": report,
         "hypotheses": hypotheses,
         "bridges": validated_bridges,  # Return validated bridges
+        "model_usages": [usage_record] if usage_record else [],
     }

--- a/backend/src/kestrel_backend/graph/nodes/temporal.py
+++ b/backend/src/kestrel_backend/graph/nodes/temporal.py
@@ -29,7 +29,7 @@ from ..state import (
     DiscoveryState, TemporalClassification, Finding,
     DiseaseAssociation, PathwayMembership, InferredAssociation, Bridge
 )
-from ..sdk_utils import HAS_SDK, query, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS, query_with_usage, DEFAULT_MODEL_NAME
+from ..sdk_utils import HAS_SDK, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS, query_with_usage
 from ..state_contracts import validate_state, TemporalInput, TemporalOutput
 
 logger = logging.getLogger(__name__)

--- a/backend/src/kestrel_backend/graph/nodes/temporal.py
+++ b/backend/src/kestrel_backend/graph/nodes/temporal.py
@@ -29,7 +29,7 @@ from ..state import (
     DiscoveryState, TemporalClassification, Finding,
     DiseaseAssociation, PathwayMembership, InferredAssociation, Bridge
 )
-from ..sdk_utils import HAS_SDK, query, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS
+from ..sdk_utils import HAS_SDK, query, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS, query_with_usage, DEFAULT_MODEL_NAME
 from ..state_contracts import validate_state, TemporalInput, TemporalOutput
 
 logger = logging.getLogger(__name__)
@@ -298,15 +298,12 @@ Classify each finding by its temporal relationship to disease progression.
             permission_mode="bypassPermissions",
         )
 
-        # Execute the query using async generator pattern
-        result_text_parts = []
-        async for event in query(prompt=full_prompt, options=options):
-            if hasattr(event, 'content'):
-                for block in event.content:
-                    if hasattr(block, 'text'):
-                        result_text_parts.append(block.text)
-
-        result_text = "".join(result_text_parts)
+        # Execute the query and capture usage metrics
+        result_text, usage_record = await query_with_usage(
+            prompt=full_prompt,
+            options=options,
+            node_name="temporal",
+        )
 
         # Parse the result
         classifications, parse_errors = parse_temporal_result(result_text)
@@ -325,6 +322,7 @@ Classify each finding by its temporal relationship to disease progression.
         return {
             "temporal_classifications": classifications,
             "errors": parse_errors,
+            "model_usages": [usage_record] if usage_record else [],
         }
 
     except Exception as e:

--- a/backend/src/kestrel_backend/graph/nodes/triage.py
+++ b/backend/src/kestrel_backend/graph/nodes/triage.py
@@ -30,7 +30,7 @@ from typing import Any
 
 from ...kestrel_client import call_kestrel_tool
 from ..state import DiscoveryState, NoveltyScore, EntityResolution
-from ..sdk_utils import HAS_SDK, query, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS
+from ..sdk_utils import HAS_SDK, query, query_with_usage, DEFAULT_MODEL_NAME, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS
 from ..pipeline_config import get_pipeline_config
 from ..state_contracts import validate_state, TriageInput, TriageOutput
 
@@ -164,32 +164,33 @@ def parse_edge_count_result(curie: str, raw_name: str, result_text: str) -> Nove
     )
 
 
-async def count_edges_single(entity: EntityResolution) -> NoveltyScore:
+async def count_edges_single(entity: EntityResolution) -> tuple[NoveltyScore, Any]:
     """
     Count edges for a single resolved entity using Claude Agent SDK.
 
-    Returns NoveltyScore with edge_count=0 (cold_start) on any error.
+    Returns tuple of (NoveltyScore, ModelUsageRecord | None).
+    NoveltyScore has edge_count=0 (cold_start) on any error.
     """
     curie = entity.curie
     raw_name = entity.raw_name
 
     # Skip entities that failed resolution
     if not curie or entity.method == "failed":
-        return NoveltyScore(
+        return (NoveltyScore(
             curie=curie or raw_name,
             raw_name=raw_name,
             edge_count=0,
             classification="cold_start",
-        )
+        ), None)
 
     if not HAS_SDK:
         # SDK not available - return mock for testing
-        return NoveltyScore(
+        return (NoveltyScore(
             curie=curie,
             raw_name=raw_name,
             edge_count=0,
             classification="cold_start",
-        )
+        ), None)
 
     try:
         async with SDK_SEMAPHORE:
@@ -207,14 +208,11 @@ async def count_edges_single(entity: EntityResolution) -> NoveltyScore:
                 max_buffer_size=10 * 1024 * 1024,  # 10MB buffer for large KG responses
             )
 
-            result_text_parts = []
-            async for event in query(prompt=f"Count edges for: {curie}", options=options):
-                if hasattr(event, 'content'):
-                    for block in event.content:
-                        if hasattr(block, 'text'):
-                            result_text_parts.append(block.text)
-
-            result_text = "".join(result_text_parts)
+            result_text, usage_record = await query_with_usage(
+                prompt=f"Count edges for: {curie}",
+                options=options,
+                node_name="triage",
+            )
 
         # Debug logging for triage edge counting
         if not result_text:
@@ -222,16 +220,16 @@ async def count_edges_single(entity: EntityResolution) -> NoveltyScore:
         else:
             logger.debug("Triage result for %s: %s", curie, result_text[:200] if len(result_text) > 200 else result_text)
 
-        return parse_edge_count_result(curie, raw_name, result_text)
+        return parse_edge_count_result(curie, raw_name, result_text), usage_record
 
     except Exception as e:
         logger.warning("Edge counting failed for %s: %s", curie, str(e))
-        return NoveltyScore(
+        return (NoveltyScore(
             curie=curie,
             raw_name=raw_name,
             edge_count=0,
             classification="cold_start",
-        )
+        ), None)
 
 
 
@@ -303,6 +301,7 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
     )
 
     # ========== TIER 2: LLM Edge Counting ==========
+    model_usages: list = []
     if tier1_failed_indices and HAS_SDK:
         tier2_start = time.time()
         failed_entities = [valid_entities[i] for i in tier1_failed_indices]
@@ -337,7 +336,10 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
                     classification="cold_start",
                 )
             else:
-                all_scores[idx] = result
+                score, usage_record = result
+                all_scores[idx] = score
+                if usage_record is not None:
+                    model_usages.append(usage_record)
 
         tier2_duration = time.time() - tier2_start
         tier2_success = sum(1 for i in tier1_failed_indices if all_scores[i] and all_scores[i].edge_count > 0)
@@ -385,7 +387,7 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
         tier1_success, len(valid_entities) - tier1_success
     )
 
-    return {
+    result = {
         "novelty_scores": final_scores,
         "well_characterized_curies": well_characterized,
         "moderate_curies": moderate,
@@ -393,3 +395,6 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
         "cold_start_curies": cold_start,
         "errors": errors,
     }
+    if model_usages:
+        result["model_usages"] = model_usages
+    return result

--- a/backend/src/kestrel_backend/graph/nodes/triage.py
+++ b/backend/src/kestrel_backend/graph/nodes/triage.py
@@ -30,7 +30,7 @@ from typing import Any
 
 from ...kestrel_client import call_kestrel_tool
 from ..state import DiscoveryState, NoveltyScore, EntityResolution
-from ..sdk_utils import HAS_SDK, query, query_with_usage, DEFAULT_MODEL_NAME, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS
+from ..sdk_utils import HAS_SDK, query_with_usage, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS
 from ..pipeline_config import get_pipeline_config
 from ..state_contracts import validate_state, TriageInput, TriageOutput
 

--- a/backend/src/kestrel_backend/graph/sdk_utils.py
+++ b/backend/src/kestrel_backend/graph/sdk_utils.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 # Centralized SDK availability check — single try/except for all nodes
 try:
-    from claude_agent_sdk import query, ClaudeAgentOptions  # noqa: F401
+    from claude_agent_sdk import query, ClaudeAgentOptions, ResultMessage  # noqa: F401
     from claude_agent_sdk.types import McpStdioServerConfig  # noqa: F401
     HAS_SDK = True
 except ImportError:
@@ -24,6 +24,12 @@ except ImportError:
     query = None  # type: ignore[assignment]
     ClaudeAgentOptions = None  # type: ignore[assignment,misc]
     McpStdioServerConfig = None  # type: ignore[assignment,misc]
+
+    # Sentinel class so isinstance(event, ResultMessage) returns False
+    # rather than raising TypeError when SDK is unavailable
+    class _ResultMessageStub:  # type: ignore[no-redef]
+        pass
+    ResultMessage = _ResultMessageStub  # type: ignore[assignment,misc]
 
 # Kestrel MCP server configuration constants
 KESTREL_COMMAND = "uvx"
@@ -94,3 +100,98 @@ def chunk(items: list, size: int) -> list[list]:
     Previously duplicated in entity_resolution, triage, direct_kg, and cold_start.
     """
     return [items[i:i + size] for i in range(0, len(items), size)]
+
+
+# Default model name constant — all pipeline nodes currently use the same model
+DEFAULT_MODEL_NAME = "anthropic/claude-sonnet-4-20250514"
+
+
+async def query_with_usage(
+    prompt: str,
+    options: Any,
+    node_name: str,
+    model_name: str = DEFAULT_MODEL_NAME,
+) -> tuple[str, Any]:
+    """Stream a query() call and extract both text and usage metrics.
+
+    Replaces the common pattern of ``async for event in query(...)`` followed
+    by text block collection.  Accumulates usage from ALL events that carry a
+    ``.usage`` attribute (not just ``ResultMessage``), following the dual-path
+    pattern in ``agent.py:510-534``.  This ensures accurate token counts for
+    multi-turn nodes like pathway_enrichment (``max_turns=25``).
+
+    Does NOT handle timeouts — nodes that need ``asyncio.wait_for()`` should
+    wrap this coroutine themselves, since timeout recovery logic is
+    domain-specific.
+
+    Args:
+        prompt: The prompt to send to the SDK.
+        options: ClaudeAgentOptions instance.
+        node_name: Name of the calling graph node (for the usage record).
+        model_name: Model identifier string.
+
+    Returns:
+        A tuple of ``(text, record)`` where *text* is the joined text content
+        and *record* is a ``ModelUsageRecord`` or ``None`` if no usage data
+        was found on any event.
+
+    Raises:
+        RuntimeError: If the SDK is not available (``HAS_SDK is False``).
+    """
+    if not HAS_SDK or query is None:
+        raise RuntimeError("Claude Agent SDK is not available")
+
+    from .state import ModelUsageRecord
+
+    result_text_parts: list[str] = []
+    input_tokens = 0
+    output_tokens = 0
+    cache_creation_tokens = 0
+    cache_read_tokens = 0
+    has_usage = False
+
+    async for event in query(prompt=prompt, options=options):
+        # Collect text content
+        if hasattr(event, "content"):
+            for block in event.content:
+                if hasattr(block, "text"):
+                    result_text_parts.append(block.text)
+
+        # Accumulate usage from ResultMessage (final totals — replaces)
+        if isinstance(event, ResultMessage):
+            if event.usage:
+                usage = event.usage
+                if isinstance(usage, dict):
+                    input_tokens = usage.get("input_tokens", 0)
+                    output_tokens = usage.get("output_tokens", 0)
+                    cache_creation_tokens = usage.get("cache_creation_input_tokens", 0)
+                    cache_read_tokens = usage.get("cache_read_input_tokens", 0)
+                    has_usage = True
+        # Accumulate usage from other event types (e.g., AssistantMessage)
+        elif hasattr(event, "usage") and event.usage:
+            usage = event.usage
+            if isinstance(usage, dict):
+                input_tokens += usage.get("input_tokens", 0)
+                output_tokens += usage.get("output_tokens", 0)
+                cache_creation_tokens += usage.get("cache_creation_input_tokens", 0)
+                cache_read_tokens += usage.get("cache_read_input_tokens", 0)
+            else:
+                input_tokens += getattr(usage, "input_tokens", 0)
+                output_tokens += getattr(usage, "output_tokens", 0)
+                cache_creation_tokens += getattr(usage, "cache_creation_input_tokens", 0)
+                cache_read_tokens += getattr(usage, "cache_read_input_tokens", 0)
+            has_usage = True
+
+    text = "".join(result_text_parts)
+    record = None
+    if has_usage:
+        record = ModelUsageRecord(
+            model_name=model_name,
+            node_name=node_name,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_tokens=cache_read_tokens,
+            cache_creation_tokens=cache_creation_tokens,
+        )
+
+    return text, record

--- a/backend/src/kestrel_backend/graph/state.py
+++ b/backend/src/kestrel_backend/graph/state.py
@@ -258,6 +258,23 @@ class Hypothesis(BaseModel):
     )
 
 
+class ModelUsageRecord(BaseModel):
+    """Record of a single model API call for cost tracking.
+
+    Enables AstaBench per-node cost tracking. The solver repo converts
+    these records to Inspect AI's ModelUsage format.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    model_name: str = Field(..., description="Model identifier (e.g., 'anthropic/claude-sonnet-4-20250514')")
+    node_name: str = Field(..., description="Which graph node made this call")
+    input_tokens: int = Field(0, ge=0)
+    output_tokens: int = Field(0, ge=0)
+    cache_read_tokens: int = Field(0, ge=0, description="Prompt cache read tokens")
+    cache_creation_tokens: int = Field(0, ge=0, description="Prompt cache creation tokens")
+
+
 class DiscoveryState(TypedDict, total=False):
     """
     State schema for the KRAKEN discovery workflow.
@@ -333,6 +350,10 @@ class DiscoveryState(TypedDict, total=False):
 
     # === Phase 5b: Literature Grounding ===
     literature_errors: Annotated[list[str], operator.add]
+
+    # === Cost Tracking ===
+    # Uses operator.add reducer for parallel writes from concurrent branches
+    model_usages: Annotated[list[ModelUsageRecord], operator.add]
 
     # === Metadata ===
     # Uses operator.add reducer to accumulate errors from all nodes

--- a/backend/tests/test_cold_start_performance.py
+++ b/backend/tests/test_cold_start_performance.py
@@ -140,14 +140,14 @@ class TestEarlyTermination:
         with patch("kestrel_backend.graph.nodes.cold_start.get_similar_entities") as mock_similar:
             mock_similar.return_value = low_quality_analogues
 
-            # Mock query to ensure it's NOT called
-            with patch("kestrel_backend.graph.nodes.cold_start.query") as mock_query:
+            # Mock query_with_usage to ensure it's NOT called
+            with patch("kestrel_backend.graph.nodes.cold_start.query_with_usage") as mock_qwu:
                 analogues, inferences, findings, errors, _usage = await analyze_cold_start_entity(
                     "TEST:001", "Test Entity", 5
                 )
 
                 # SDK inference should NOT have been called
-                mock_query.assert_not_called()
+                mock_qwu.assert_not_called()
 
                 # Should have returned analogues but no inferences
                 assert len(analogues) == 2

--- a/backend/tests/test_cold_start_performance.py
+++ b/backend/tests/test_cold_start_performance.py
@@ -65,7 +65,7 @@ class TestEntityLimiting:
 
         # Mock analyze_cold_start_entity to avoid actual API calls
         with patch("kestrel_backend.graph.nodes.cold_start.analyze_cold_start_entity") as mock_analyze:
-            mock_analyze.return_value = ([], [], [], [])
+            mock_analyze.return_value = ([], [], [], [], None)
 
             result = await run(state)
 
@@ -90,7 +90,7 @@ class TestEntityLimiting:
         }
 
         with patch("kestrel_backend.graph.nodes.cold_start.analyze_cold_start_entity") as mock_analyze:
-            mock_analyze.return_value = ([], [], [], [])
+            mock_analyze.return_value = ([], [], [], [], None)
 
             result = await run(state)
 
@@ -116,7 +116,7 @@ class TestEntityLimiting:
         }
 
         with patch("kestrel_backend.graph.nodes.cold_start.analyze_cold_start_entity") as mock_analyze:
-            mock_analyze.return_value = ([], [], [], [])
+            mock_analyze.return_value = ([], [], [], [], None)
 
             await run(state)
 
@@ -142,7 +142,7 @@ class TestEarlyTermination:
 
             # Mock query to ensure it's NOT called
             with patch("kestrel_backend.graph.nodes.cold_start.query") as mock_query:
-                analogues, inferences, findings, errors = await analyze_cold_start_entity(
+                analogues, inferences, findings, errors, _usage = await analyze_cold_start_entity(
                     "TEST:001", "Test Entity", 5
                 )
 
@@ -167,22 +167,19 @@ class TestEarlyTermination:
 
         with patch("kestrel_backend.graph.nodes.cold_start.get_similar_entities") as mock_similar:
             with patch("kestrel_backend.graph.nodes.cold_start.get_entity_connections") as mock_connections:
-                with patch("kestrel_backend.graph.nodes.cold_start.query") as mock_query:
+                with patch("kestrel_backend.graph.nodes.cold_start.query_with_usage") as mock_qwu:
                     mock_similar.return_value = quality_analogues
                     mock_connections.return_value = {"edges": [], "summary": "No edges"}
 
-                    # Mock SDK query to return immediately - use side_effect to create fresh generator per call
-                    async def mock_query_gen(*args, **kwargs):
-                        yield MagicMock(content=[MagicMock(text='{"inferences": []}')])
+                    # Mock query_with_usage to return text + None usage record
+                    mock_qwu.return_value = ('{"inferences": []}', None)
 
-                    mock_query.side_effect = lambda *a, **kw: mock_query_gen()
-
-                    analogues, inferences, findings, errors = await analyze_cold_start_entity(
+                    analogues, inferences, findings, errors, _usage = await analyze_cold_start_entity(
                         "TEST:001", "Test Entity", 5
                     )
 
                     # SDK inference should have been called
-                    mock_query.assert_called_once()
+                    mock_qwu.assert_called_once()
 
 
 @pytest.mark.integration

--- a/backend/tests/test_langgraph_prototype.py
+++ b/backend/tests/test_langgraph_prototype.py
@@ -279,7 +279,7 @@ class TestTriageNode:
             classification="well_characterized",
         )
 
-        with patch.object(triage, 'count_edges_single', return_value=mock_score):
+        with patch.object(triage, 'count_edges_single', return_value=(mock_score, None)):
             state: DiscoveryState = {
                 "resolved_entities": [
                     EntityResolution(
@@ -788,8 +788,8 @@ class TestEndToEnd:
             classification="well_characterized",
         )
 
-        with patch.object(entity_resolution, 'resolve_single_entity', return_value=mock_resolution):
-            with patch.object(triage, 'count_edges_single', return_value=mock_score):
+        with patch.object(entity_resolution, 'resolve_single_entity', return_value=(mock_resolution, None)):
+            with patch.object(triage, 'count_edges_single', return_value=(mock_score, None)):
                 with patch.object(direct_kg, 'HAS_SDK', False):
                     with patch.object(cold_start, 'HAS_SDK', False):
                         graph = build_discovery_graph()
@@ -836,8 +836,8 @@ class TestEndToEnd:
             classification="well_characterized",
         )
 
-        with patch.object(entity_resolution, 'resolve_single_entity', return_value=mock_resolution):
-            with patch.object(triage, 'count_edges_single', return_value=mock_score):
+        with patch.object(entity_resolution, 'resolve_single_entity', return_value=(mock_resolution, None)):
+            with patch.object(triage, 'count_edges_single', return_value=(mock_score, None)):
                 with patch.object(direct_kg, 'HAS_SDK', False):
                     with patch.object(cold_start, 'HAS_SDK', False):
                         graph = build_discovery_graph()
@@ -1508,8 +1508,8 @@ class TestEndToEndPhase4b:
             classification="well_characterized",
         )
 
-        with patch.object(entity_resolution, 'resolve_single_entity', return_value=mock_resolution):
-            with patch.object(triage, 'count_edges_single', return_value=mock_score):
+        with patch.object(entity_resolution, 'resolve_single_entity', return_value=(mock_resolution, None)):
+            with patch.object(triage, 'count_edges_single', return_value=(mock_score, None)):
                 with patch.object(direct_kg, 'HAS_SDK', False):
                     with patch.object(cold_start, 'HAS_SDK', False):
                         with patch.object(pathway_enrichment, 'HAS_SDK', False):
@@ -1548,8 +1548,8 @@ class TestEndToEndPhase4b:
             classification="well_characterized",
         )
 
-        with patch.object(entity_resolution, 'resolve_single_entity', return_value=mock_resolution):
-            with patch.object(triage, 'count_edges_single', return_value=mock_score):
+        with patch.object(entity_resolution, 'resolve_single_entity', return_value=(mock_resolution, None)):
+            with patch.object(triage, 'count_edges_single', return_value=(mock_score, None)):
                 with patch.object(direct_kg, 'HAS_SDK', False):
                     with patch.object(cold_start, 'HAS_SDK', False):
                         with patch.object(pathway_enrichment, 'HAS_SDK', False):
@@ -2071,8 +2071,8 @@ class TestEndToEndPhase5:
             significance="Glucose dysregulation is a hallmark of diabetes",
         )
 
-        with patch.object(entity_resolution, 'resolve_single_entity', return_value=mock_resolution):
-            with patch.object(triage, 'count_edges_single', return_value=mock_score):
+        with patch.object(entity_resolution, 'resolve_single_entity', return_value=(mock_resolution, None)):
+            with patch.object(triage, 'count_edges_single', return_value=(mock_score, None)):
                 with patch.object(direct_kg, 'HAS_SDK', False):
                     with patch.object(cold_start, 'HAS_SDK', False):
                         with patch.object(pathway_enrichment, 'HAS_SDK', False):

--- a/backend/tests/test_sdk_utils.py
+++ b/backend/tests/test_sdk_utils.py
@@ -1,13 +1,20 @@
 """Tests for shared SDK utilities module."""
 
+from unittest.mock import AsyncMock, MagicMock
+import pytest
+
 from kestrel_backend.graph.sdk_utils import (
+    DEFAULT_MODEL_NAME,
     HAS_SDK,
     KESTREL_ARGS,
     KESTREL_COMMAND,
+    ResultMessage,
     chunk,
     create_agent_options,
     get_kestrel_mcp_config,
+    query_with_usage,
 )
+from kestrel_backend.graph.state import ModelUsageRecord
 
 
 class TestHasSDK:
@@ -102,3 +109,139 @@ class TestChunk:
 
     def test_exact_size(self):
         assert chunk([1, 2, 3], 3) == [[1, 2, 3]]
+
+
+# --- Helper factories for mock SDK events ---
+
+def _make_text_event(text: str):
+    """Create a mock event with a text content block."""
+    block = MagicMock()
+    block.text = text
+    event = MagicMock(spec=[])  # no .usage attribute
+    event.content = [block]
+    return event
+
+
+def _make_result_message(usage_dict: dict | None = None):
+    """Create a mock ResultMessage with optional usage dict."""
+    event = MagicMock(spec=ResultMessage)
+    event.__class__ = ResultMessage  # so isinstance() works
+    event.content = []
+    event.usage = usage_dict
+    return event
+
+
+def _make_assistant_event(usage_dict: dict | None = None):
+    """Create a mock AssistantMessage-like event with usage."""
+    event = MagicMock()
+    event.content = []
+    event.usage = usage_dict
+    return event
+
+
+async def _mock_query_gen(events):
+    """Async generator yielding a list of mock events."""
+    for event in events:
+        yield event
+
+
+class TestQueryWithUsage:
+    """Test query_with_usage() wrapper for text + usage extraction."""
+
+    async def test_text_and_usage_extraction(self, monkeypatch):
+        """Happy path: text events + ResultMessage with usage dict."""
+        events = [
+            _make_text_event("Hello "),
+            _make_text_event("world"),
+            _make_result_message({
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_creation_input_tokens": 5,
+                "cache_read_input_tokens": 10,
+            }),
+        ]
+        monkeypatch.setattr("kestrel_backend.graph.sdk_utils.query", lambda **kw: _mock_query_gen(events))
+        monkeypatch.setattr("kestrel_backend.graph.sdk_utils.HAS_SDK", True)
+
+        text, record = await query_with_usage("test prompt", MagicMock(), "synthesis")
+
+        assert text == "Hello world"
+        assert isinstance(record, ModelUsageRecord)
+        assert record.node_name == "synthesis"
+        assert record.input_tokens == 100
+        assert record.output_tokens == 50
+        assert record.cache_creation_tokens == 5
+        assert record.cache_read_tokens == 10
+        assert record.model_name == DEFAULT_MODEL_NAME
+
+    async def test_cache_tokens_mapped_correctly(self, monkeypatch):
+        """Cache token field names are mapped from SDK naming to model naming."""
+        events = [
+            _make_result_message({
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_creation_input_tokens": 42,
+                "cache_read_input_tokens": 99,
+            }),
+        ]
+        monkeypatch.setattr("kestrel_backend.graph.sdk_utils.query", lambda **kw: _mock_query_gen(events))
+        monkeypatch.setattr("kestrel_backend.graph.sdk_utils.HAS_SDK", True)
+
+        _, record = await query_with_usage("p", MagicMock(), "triage")
+
+        assert record.cache_creation_tokens == 42
+        assert record.cache_read_tokens == 99
+
+    async def test_multi_turn_usage_accumulation(self, monkeypatch):
+        """Usage from multiple events is accumulated (dual-path extraction)."""
+        events = [
+            _make_assistant_event({
+                "input_tokens": 50,
+                "output_tokens": 20,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+            }),
+            _make_text_event("response"),
+            _make_assistant_event({
+                "input_tokens": 30,
+                "output_tokens": 10,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+            }),
+        ]
+        monkeypatch.setattr("kestrel_backend.graph.sdk_utils.query", lambda **kw: _mock_query_gen(events))
+        monkeypatch.setattr("kestrel_backend.graph.sdk_utils.HAS_SDK", True)
+
+        text, record = await query_with_usage("p", MagicMock(), "pathway_enrichment")
+
+        assert text == "response"
+        assert record.input_tokens == 80  # 50 + 30
+        assert record.output_tokens == 30  # 20 + 10
+
+    async def test_no_usage_returns_none(self, monkeypatch):
+        """Events with no .usage attribute → None record."""
+        events = [_make_text_event("just text")]
+        monkeypatch.setattr("kestrel_backend.graph.sdk_utils.query", lambda **kw: _mock_query_gen(events))
+        monkeypatch.setattr("kestrel_backend.graph.sdk_utils.HAS_SDK", True)
+
+        text, record = await query_with_usage("p", MagicMock(), "test")
+
+        assert text == "just text"
+        assert record is None
+
+    async def test_result_message_no_usage_attr(self, monkeypatch):
+        """ResultMessage with usage=None → None record."""
+        events = [_make_result_message(None)]
+        monkeypatch.setattr("kestrel_backend.graph.sdk_utils.query", lambda **kw: _mock_query_gen(events))
+        monkeypatch.setattr("kestrel_backend.graph.sdk_utils.HAS_SDK", True)
+
+        _, record = await query_with_usage("p", MagicMock(), "test")
+
+        assert record is None
+
+    async def test_has_sdk_false_raises(self, monkeypatch):
+        """When HAS_SDK is False, raise RuntimeError."""
+        monkeypatch.setattr("kestrel_backend.graph.sdk_utils.HAS_SDK", False)
+
+        with pytest.raises(RuntimeError, match="SDK is not available"):
+            await query_with_usage("p", MagicMock(), "test")

--- a/backend/tests/test_state_contracts.py
+++ b/backend/tests/test_state_contracts.py
@@ -1,11 +1,14 @@
-"""Tests for state validation contracts.
+"""Tests for state validation contracts and state models.
 
 Tests the @validate_state decorator and per-node input/output Pydantic models,
 including path-conditional field handling and OR-semantics validation.
+Also tests ModelUsageRecord and the model_usages reducer field.
 """
 
+import operator
 import pytest
 
+from kestrel_backend.graph.state import ModelUsageRecord
 from kestrel_backend.graph.state_contracts import (
     ColdStartInput,
     ColdStartOutput,
@@ -342,3 +345,78 @@ class TestValidateStateDecorator:
 
         result = await run({"raw_query": "test"})
         assert result is None
+
+
+class TestModelUsageRecord:
+    """Test ModelUsageRecord Pydantic model for cost tracking."""
+
+    def test_instantiate_with_all_fields(self):
+        record = ModelUsageRecord(
+            model_name="anthropic/claude-sonnet-4-20250514",
+            node_name="synthesis",
+            input_tokens=100,
+            output_tokens=50,
+            cache_read_tokens=10,
+            cache_creation_tokens=5,
+        )
+        assert record.model_name == "anthropic/claude-sonnet-4-20250514"
+        assert record.node_name == "synthesis"
+        assert record.input_tokens == 100
+        assert record.output_tokens == 50
+        assert record.cache_read_tokens == 10
+        assert record.cache_creation_tokens == 5
+
+    def test_serializes_to_dict(self):
+        record = ModelUsageRecord(
+            model_name="anthropic/claude-sonnet-4-20250514",
+            node_name="triage",
+            input_tokens=200,
+            output_tokens=100,
+        )
+        d = record.model_dump()
+        assert d["model_name"] == "anthropic/claude-sonnet-4-20250514"
+        assert d["node_name"] == "triage"
+        assert d["input_tokens"] == 200
+        assert d["output_tokens"] == 100
+        assert d["cache_read_tokens"] == 0
+        assert d["cache_creation_tokens"] == 0
+
+    def test_default_token_values_are_zero(self):
+        record = ModelUsageRecord(
+            model_name="test-model",
+            node_name="test-node",
+        )
+        assert record.input_tokens == 0
+        assert record.output_tokens == 0
+        assert record.cache_read_tokens == 0
+        assert record.cache_creation_tokens == 0
+
+    def test_negative_tokens_rejected(self):
+        with pytest.raises(Exception):
+            ModelUsageRecord(
+                model_name="test-model",
+                node_name="test-node",
+                input_tokens=-1,
+            )
+
+    def test_frozen_rejects_mutation(self):
+        record = ModelUsageRecord(
+            model_name="test-model",
+            node_name="test-node",
+            input_tokens=100,
+        )
+        with pytest.raises(Exception):
+            record.input_tokens = 200
+
+    def test_operator_add_reducer_merges_lists(self):
+        """Verify that operator.add correctly merges model_usages lists."""
+        list_a = [
+            ModelUsageRecord(model_name="m", node_name="direct_kg", input_tokens=100),
+        ]
+        list_b = [
+            ModelUsageRecord(model_name="m", node_name="cold_start", input_tokens=200),
+        ]
+        merged = operator.add(list_a, list_b)
+        assert len(merged) == 2
+        assert merged[0].node_name == "direct_kg"
+        assert merged[1].node_name == "cold_start"

--- a/docs/plans/2026-05-07-001-feat-model-usages-cost-tracking-plan.md
+++ b/docs/plans/2026-05-07-001-feat-model-usages-cost-tracking-plan.md
@@ -1,0 +1,282 @@
+---
+title: "feat: Add model_usages cost tracking to DiscoveryState"
+type: feat
+status: active
+date: 2026-05-07
+deepened: 2026-05-07
+---
+
+# feat: Add model_usages cost tracking to DiscoveryState
+
+## Overview
+
+Add a `model_usages` reducer field to `DiscoveryState` and instrument each SDK-calling graph node to emit `ModelUsageRecord` entries. This enables AstaBench cost tracking for the KRAKEN evaluation pipeline. A separate repo (`kraken-chatbot-solver`) will consume this field to report costs to Inspect AI.
+
+**Branch workflow:** Implement on `feat/model-usages-cost-tracking` branched from `dev`. PR targets `dev` for Greptile automated review. Address any Greptile findings before merge.
+
+## Problem Frame
+
+AstaBench requires accurate per-model cost tracking for Pareto frontier analysis (cost vs. performance). The discovery pipeline currently has no node-level usage tracking — `agent.py` tracks turn-level costs for the chat agent, but the 8 graph nodes that call Claude Agent SDK `query()` silently discard `ResultMessage.usage` data. Without per-node usage records on the state, the solver repo cannot compute pipeline execution costs.
+
+## Requirements Trace
+
+- R1. Define `ModelUsageRecord` Pydantic model in `state.py` with fields: `model_name`, `node_name`, `input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_creation_tokens`
+- R2. Add `model_usages: Annotated[list[ModelUsageRecord], operator.add]` to `DiscoveryState`
+- R3. Instrument all nodes that call SDK `query()` to emit usage records (8 nodes)
+- R4. Nodes that don't call LLM (intake, literature_grounding) should not emit usage records
+- R5. Existing tests must continue to pass
+
+## Scope Boundaries
+
+- Do not change graph structure or node logic — only add usage tracking instrumentation
+- Do not change existing node return signatures beyond adding `model_usages`
+- Do not add `inspect-ai` as a dependency — the solver repo handles Inspect AI conversion
+- Do not build cost aggregation, reporting, or database storage — that belongs in the solver repo
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `backend/src/kestrel_backend/graph/state.py` — 12+ fields already use `Annotated[list[X], operator.add]` reducer pattern for parallel writes
+- `backend/src/kestrel_backend/graph/sdk_utils.py` — centralized SDK imports, `query`, `ClaudeAgentOptions`, `get_kestrel_mcp_config()`, `chunk()`
+- `backend/src/kestrel_backend/agent.py:510-534` — proven pattern for extracting usage from `ResultMessage.usage` (dict with `input_tokens`, `output_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`)
+- All 8 SDK-calling nodes use identical streaming pattern: `async for event in query(prompt=..., options=...)` → collect text blocks
+
+### Nodes by SDK Usage
+
+| Node | Uses SDK `query()` | Notes |
+|------|-------------------|-------|
+| intake | No | Heuristic parsing only |
+| entity_resolution | Yes | Tier 2 fallback |
+| triage | Yes | Fallback for edge counting |
+| direct_kg | Yes | Tier 2 fallback |
+| cold_start | Yes | Primary reasoning path |
+| pathway_enrichment | Yes | Shared neighbor analysis |
+| integration | Yes | Gap analysis reasoning |
+| temporal | Yes | Classification via SDK |
+| synthesis | Yes | Report + hypothesis generation |
+| literature_grounding | No | HTTP APIs only (Semantic Scholar, OpenAlex, Exa, PubMed) |
+
+### SDK Response Shape
+
+`ResultMessage` is the final event in the `query()` stream. Its `.usage` is a dict:
+```
+{"input_tokens": int, "output_tokens": int, "cache_creation_input_tokens": int, "cache_read_input_tokens": int}
+```
+
+Some nodes call `query()` multiple times (e.g., entity_resolution per-entity, cold_start per-entity). Each call produces its own `ResultMessage` with independent usage.
+
+## Key Technical Decisions
+
+- **Shared wrapper in `sdk_utils.py`**: Add a `query_with_usage()` function that wraps the common `async for event in query(...)` streaming pattern and returns `(text, ModelUsageRecord | None)`. This centralizes usage extraction and reduces per-node changes to swapping the call site. The existing `agent.py:510-534` pattern is the reference implementation.
+- **Wrapper does NOT handle timeouts**: Nodes that need timeouts (cold_start, pathway_enrichment) keep their own `asyncio.wait_for()` wrapping the `query_with_usage()` call. This is necessary because those nodes have domain-specific timeout recovery logic (cold_start constructs `Finding` objects from already-gathered analogues; pathway_enrichment returns node-specific error dicts). A generic wrapper cannot replicate this.
+- **Dual-path usage extraction**: Following `agent.py:510-534`, the wrapper accumulates usage from ALL events with a `.usage` attribute, not just `ResultMessage`. This ensures accurate token counts for multi-turn nodes like pathway_enrichment (`max_turns=25`) where `ResultMessage.usage` may not contain cumulative totals.
+- **Reducer for parallel safety**: `model_usages` uses `operator.add` reducer so parallel branches (direct_kg + cold_start) can safely append records in the same superstep.
+- **No `to_inspect_usage()` method**: The solver repo owns the conversion from `ModelUsageRecord` → Inspect AI's `ModelUsage`. This avoids coupling this repo to `inspect_ai`'s API surface.
+- **Cache token field rename is intentional**: The SDK response uses `cache_creation_input_tokens` and `cache_read_input_tokens`. `ModelUsageRecord` stores these as `cache_creation_tokens` and `cache_read_tokens` (dropping the `input_` prefix) for a cleaner domain model. The wrapper handles the mapping.
+- **No model name inference**: Nodes should pass the model name explicitly. The SDK doesn't expose which model was used in `ResultMessage`. For now, a constant like `"anthropic/claude-sonnet-4-20250514"` is acceptable since all nodes use the same model.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Decorator vs per-node?** Resolved: shared `query_with_usage()` wrapper. All 8 nodes use the identical streaming pattern (`async for event in query(...)`), making a wrapper natural. Per-node inline extraction would duplicate the `ResultMessage` handling 8 times.
+- **Which nodes need instrumentation?** 8 of 10 — all except `intake` (heuristic) and `literature_grounding` (HTTP APIs only, no LLM).
+- **How to handle nodes with multiple `query()` calls?** Each call returns its own `ModelUsageRecord`. Nodes accumulate them in a local list and return the full list in `model_usages`.
+
+### Deferred to Implementation
+
+- **Exact model name string**: Nodes may use different models in the future. For now, a module-level constant or parameter on `query_with_usage()` is sufficient. The implementer should check if the SDK exposes the model name anywhere in the response.
+
+## Implementation Units
+
+- [x] **Unit 1: ModelUsageRecord and state field**
+
+  **Goal:** Define the Pydantic model and add the reducer field to `DiscoveryState`.
+
+  **Requirements:** R1, R2
+
+  **Dependencies:** None
+
+  **Files:**
+  - Modify: `backend/src/kestrel_backend/graph/state.py`
+  - Test: `backend/tests/test_state_contracts.py`
+
+  **Approach:**
+  - Add `ModelUsageRecord(BaseModel)` with `model_config = ConfigDict(frozen=True)` following existing patterns (e.g., `Finding`, `NoveltyScore`)
+  - Fields: `model_name: str`, `node_name: str`, `input_tokens: int = 0`, `output_tokens: int = 0`, `cache_read_tokens: int = 0`, `cache_creation_tokens: int = 0` — all token fields with `ge=0` constraint. Note: field names intentionally drop the `input_` prefix from the SDK's `cache_creation_input_tokens` / `cache_read_input_tokens` for a cleaner domain model
+  - Add `model_usages: Annotated[list[ModelUsageRecord], operator.add]` to `DiscoveryState` under a `# === Cost Tracking ===` section
+
+  **Patterns to follow:**
+  - Existing Pydantic models in `state.py` (e.g., `Finding`, `NoveltyScore`, `EntityResolution`)
+  - Existing reducer pattern: `Annotated[list[X], operator.add]`
+
+  **Test scenarios:**
+  - Happy path: `ModelUsageRecord` instantiates with all fields, serializes to dict correctly
+  - Happy path: `ModelUsageRecord` with default token values (all 0) is valid
+  - Edge case: Negative token values rejected by `ge=0` constraint
+  - Happy path: Frozen model rejects mutation (assign to field raises)
+  - Integration: `DiscoveryState` accepts `model_usages` field with operator.add reducer (two dicts with `model_usages` lists merge correctly)
+
+  **Verification:**
+  - `ModelUsageRecord` can be instantiated and serialized
+  - State contract tests pass with new field
+
+- [x] **Unit 2: `query_with_usage()` wrapper in sdk_utils.py**
+
+  **Goal:** Add a shared utility that wraps the SDK streaming loop and extracts usage from `ResultMessage`.
+
+  **Requirements:** R3 (enabling infrastructure)
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Modify: `backend/src/kestrel_backend/graph/sdk_utils.py`
+  - Test: `backend/tests/test_sdk_utils.py`
+
+  **Approach:**
+  - Add `async def query_with_usage(prompt: str, options: Any, node_name: str, model_name: str = "anthropic/claude-sonnet-4-20250514") -> tuple[str, ModelUsageRecord | None]`
+  - Import `ResultMessage` from `claude_agent_sdk` (top-level package, matching `agent.py:20`). Add it to the existing try/except import block alongside `query`, `ClaudeAgentOptions`. For `HAS_SDK = False`, add a stub sentinel class (e.g., `class _ResultMessageStub: pass`) so `isinstance(event, ResultMessage)` returns `False` rather than raising `TypeError`
+  - Internally: stream `query(prompt, options)`, collect text blocks (existing pattern). Accumulate usage from ALL events that have a `.usage` attribute (following `agent.py:510-534` dual-path pattern) — not just `ResultMessage`. This ensures accurate counts for multi-turn nodes like pathway_enrichment (`max_turns=25`)
+  - Map SDK field names to model field names: `cache_creation_input_tokens` → `cache_creation_tokens`, `cache_read_input_tokens` → `cache_read_tokens`
+  - Return `(joined_text, record)` where `record` is `None` if no event had usage data
+  - The wrapper does NOT handle timeouts — nodes with timeout requirements (cold_start, pathway_enrichment) wrap their `query_with_usage()` call in their own `asyncio.wait_for()`
+  - When `HAS_SDK = False`, raise `RuntimeError` — consistent with existing SDK-unavailable behavior where nodes check `HAS_SDK` before calling SDK functions
+
+  **Patterns to follow:**
+  - `agent.py:510-534` — `ResultMessage` usage extraction
+  - Existing `sdk_utils.py` patterns for SDK availability checks
+
+  **Test scenarios:**
+  - Happy path: Mock `query()` to yield text events + `ResultMessage` with usage dict → returns correct text and `ModelUsageRecord`
+  - Happy path: `ResultMessage` with cache tokens → cache fields populated correctly
+  - Happy path: Multi-turn stream with usage on multiple events → accumulates tokens across all events
+  - Edge case: Events with no `.usage` attribute → skipped, no error
+  - Edge case: No events have usage data → returns `None` usage record
+  - Error path: `HAS_SDK = False` → raises `RuntimeError`
+
+  **Verification:**
+  - `test_sdk_utils.py` passes with new tests
+  - Function signature is compatible with all 8 nodes' call patterns
+
+- [x] **Unit 3: Instrument nodes — entity_resolution, triage, direct_kg**
+
+  **Goal:** Replace raw `query()` streaming with `query_with_usage()` in the first batch of nodes and return `model_usages` in state updates.
+
+  **Requirements:** R3, R5
+
+  **Dependencies:** Unit 2
+
+  **Files:**
+  - Modify: `backend/src/kestrel_backend/graph/nodes/entity_resolution.py`
+  - Modify: `backend/src/kestrel_backend/graph/nodes/triage.py`
+  - Modify: `backend/src/kestrel_backend/graph/nodes/direct_kg.py`
+
+  **Approach:**
+  - For each node: replace `async for event in query(...)` + text collection with `query_with_usage()` call
+  - Each call returns `(text, record | None)`. Accumulate non-None records in a local list across loop iterations
+  - Add `"model_usages": accumulated_records` to the return dict
+  - **entity_resolution**: calls `query()` per-entity in a loop — accumulate records across all entities
+  - **triage**: calls `query()` per-curie as SDK fallback — accumulate records
+  - **direct_kg**: calls `query()` per-entity as Tier 2 fallback — accumulate records
+  - For `operator.add` reducer fields, omitting the key from the return dict is equivalent to returning `[]`. Only add `"model_usages"` at the call sites where SDK usage is actually collected — do not modify early-return paths. This minimizes lines changed and avoids touching ~15+ early-return statements across all nodes
+
+  **Patterns to follow:**
+  - Existing node return patterns: `return {"field1": [...], "field2": [...], "errors": [...]}`
+  - Keep the same error handling and fallback structure
+
+  **Test scenarios:**
+  - Happy path: Node returns `model_usages` key in output dict when SDK path is taken
+  - Happy path: Node returns `model_usages: []` when primary HTTP path succeeds (no SDK fallback)
+  - Edge case: Node processes multiple entities — each SDK call produces a separate `ModelUsageRecord` with correct `node_name`
+  - Integration: Node output merges correctly with `DiscoveryState` reducer
+
+  **Verification:**
+  - Existing tests pass unchanged
+  - Each instrumented node includes `model_usages` in its return dict
+
+- [x] **Unit 4: Instrument nodes — cold_start, pathway_enrichment, integration**
+
+  **Goal:** Instrument the second batch of nodes, including those with `collect_events()` inner functions.
+
+  **Requirements:** R3, R5
+
+  **Dependencies:** Unit 2
+
+  **Files:**
+  - Modify: `backend/src/kestrel_backend/graph/nodes/cold_start.py`
+  - Modify: `backend/src/kestrel_backend/graph/nodes/pathway_enrichment.py`
+  - Modify: `backend/src/kestrel_backend/graph/nodes/integration.py`
+
+  **Approach:**
+  - **cold_start**: Replace `collect_events()` inner function with `query_with_usage()`, but keep the node's own `asyncio.wait_for()` wrapping it — cold_start has domain-specific timeout recovery (constructs `Finding` from already-gathered analogues, returns specific error message). The `event_count` tracked via `nonlocal` in `collect_events()` is only used for a diagnostic `logger.info` line — accept its loss rather than complicating the wrapper interface. Each per-entity call to `query_with_usage()` returns `(text, record | None)`. Entities that exit early (no analogues, low similarity, HAS_SDK=False, timeout) produce no record — the outer loop accumulates non-None records across all entities
+  - **pathway_enrichment**: Same `collect_events()` replacement but simpler — pathway_enrichment does NOT use `nonlocal event_count`. Keep the node's own `asyncio.wait_for()` for timeout handling
+  - **integration**: Calls `query()` for gap analysis — straightforward replacement, no timeout needed
+  - All three add `"model_usages": accumulated_records` only at the SDK call sites — early-return paths omit the key (safe for `operator.add` reducers)
+
+  **Patterns to follow:**
+  - Same pattern as Unit 3 nodes
+  - Preserve existing semaphore and concurrency patterns (these are per-node for good reasons)
+
+  **Test scenarios:**
+  - Happy path: cold_start emits usage records for each entity inference
+  - Happy path: pathway_enrichment emits usage records for shared-neighbor queries
+  - Happy path: integration emits usage records for gap analysis
+  - Edge case: cold_start skips entities (cold_start_skipped_count) — only emits records for entities actually processed
+
+  **Verification:**
+  - Existing tests pass unchanged
+  - Each instrumented node includes `model_usages` in its return dict
+
+- [x] **Unit 5: Instrument nodes — temporal, synthesis**
+
+  **Goal:** Instrument the final two SDK-calling nodes.
+
+  **Requirements:** R3, R5
+
+  **Dependencies:** Unit 2
+
+  **Files:**
+  - Modify: `backend/src/kestrel_backend/graph/nodes/temporal.py`
+  - Modify: `backend/src/kestrel_backend/graph/nodes/synthesis.py`
+
+  **Approach:**
+  - **temporal**: Single `query()` call for classification — straightforward replacement
+  - **synthesis**: Single `query()` call for report generation — straightforward replacement. Note: synthesis has multiple `fallback_report(state)` paths for when query returns empty text. After replacing with `query_with_usage()`, check `text` for emptiness and fall back to `fallback_report()` as before
+  - Both add `"model_usages": [record]` at the SDK call site (filter None)
+  - Verify that `intake.py` and `literature_grounding.py` do NOT need changes (no SDK calls)
+
+  **Patterns to follow:**
+  - Same pattern as Unit 3/4 nodes
+
+  **Test scenarios:**
+  - Happy path: temporal emits single usage record for classification
+  - Happy path: synthesis emits single usage record for report generation
+  **Verification:**
+  - All existing tests pass: `cd backend && uv run pytest tests/ -v -m "not integration"`
+  - All 8 SDK-calling nodes include `model_usages` in their return dicts
+  - intake and literature_grounding are unchanged (no SDK calls, no `model_usages` key needed)
+
+## System-Wide Impact
+
+- **Interaction graph:** No callbacks, middleware, or observers affected. The change is additive — a new field on state and usage extraction in the streaming loop.
+- **Error propagation:** If usage extraction fails (e.g., unexpected `ResultMessage` shape), the wrapper should log a warning and return 0 tokens rather than failing the node. Node logic must not be disrupted by cost tracking.
+- **State lifecycle risks:** The `operator.add` reducer handles parallel writes safely. No partial-write risk since records are appended atomically.
+- **API surface parity:** `runner.py`'s `run_discovery()` returns the full `DiscoveryState` from `graph.ainvoke()`, so `model_usages` flows through automatically. No runner changes needed.
+- **Integration coverage:** The reducer merge behavior should be tested — two parallel branches (direct_kg + cold_start) both emitting `model_usages` should produce a combined list.
+- **Unchanged invariants:** All existing state fields, graph structure, node routing, and analysis logic remain unchanged. No existing return fields are modified — `model_usages` is purely additive.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `ResultMessage` shape changes in future SDK versions | Defensive extraction with `.get()` and fallback to 0, matching `agent.py` pattern |
+| `cold_start`'s `collect_events()` uses `nonlocal event_count` (pathway_enrichment does not) | Accept loss of diagnostic log line — it has no functional effect. Wrapper focuses on text + usage only |
+
+## Sources & References
+
+- Task spec: `AGENT-TASK-model-usages.md`
+- Usage extraction pattern: `backend/src/kestrel_backend/agent.py:510-534`
+- State schema: `backend/src/kestrel_backend/graph/state.py:261-342`
+- SDK utilities: `backend/src/kestrel_backend/graph/sdk_utils.py`
+- Related: AstaBench evaluation strategy (referenced in task spec)


### PR DESCRIPTION
## Summary

- Add `ModelUsageRecord` Pydantic model and `model_usages` reducer field to `DiscoveryState` for AstaBench per-node cost tracking
- Add shared `query_with_usage()` wrapper in `sdk_utils.py` that streams `query()`, collects text, and extracts usage from all events (dual-path extraction matching `agent.py` pattern)
- Instrument all 8 SDK-calling graph nodes to emit usage records: entity_resolution, triage, direct_kg, cold_start, pathway_enrichment, integration, temporal, synthesis
- 2 nodes unchanged: intake (heuristic only), literature_grounding (HTTP APIs only)

## Key design decisions

- **Shared wrapper, not per-node**: `query_with_usage()` centralizes text + usage extraction, reducing per-node changes to swapping the call site
- **Wrapper does NOT handle timeouts**: cold_start and pathway_enrichment keep their own `asyncio.wait_for()` for domain-specific timeout recovery
- **Dual-path usage extraction**: Accumulates usage from ALL events with `.usage` attribute (not just `ResultMessage`), ensuring accuracy for multi-turn nodes like pathway_enrichment (`max_turns=25`)
- **No `inspect-ai` dependency**: The solver repo (`kraken-chatbot-solver`) owns the conversion to Inspect AI's `ModelUsage` format
- **operator.add reducer**: Safe for parallel branches (direct_kg + cold_start). Early-return paths omit the key (safe for reducers)

## Nodes instrumented

| Node | Pattern | Notes |
|------|---------|-------|
| entity_resolution | Per-entity loop | Accumulates records across entities |
| triage | Per-curie SDK fallback | Accumulates records |
| direct_kg | Per-entity Tier 2 fallback | Accumulates records |
| cold_start | Per-entity + timeout | Keeps own `asyncio.wait_for()`, accepts `event_count` log loss |
| pathway_enrichment | Single call + timeout | Keeps own `asyncio.wait_for()` |
| integration | Single call | Straightforward |
| temporal | Single call | Straightforward |
| synthesis | Single call + fallback | Preserves `fallback_report()` pattern |

## Test plan

- [x] 6 new `ModelUsageRecord` tests (instantiation, serialization, validation, frozen, reducer merge)
- [x] 6 new `query_with_usage()` tests (text+usage extraction, cache token mapping, multi-turn accumulation, no-usage, HAS_SDK=False)
- [x] Fixed 18 pre-existing test mock return types (4-tuple → 5-tuple for cold_start, score → (score, None) for triage, resolution → (resolution, None) for entity_resolution)
- [x] All existing tests pass (zero new failures; pre-existing failures in test_migrations, test_websocket_routing unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)