### PR TITLE
fix(deploy): source VITE_* vars from .env during production build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,8 +32,10 @@ jobs:
           git fetch origin main
           git reset --hard origin/main
 
-          # Rebuild frontend with production WebSocket URL
+          # Rebuild frontend — export VITE_* vars from backend .env for the build
+          # (Clerk publishable key, allowed domains, etc. are set in the server's .env)
           npm ci
+          set -a; source <(grep '^VITE_' ~/kraken-chatbot/backend/.env 2>/dev/null); set +a
           VITE_WS_URL=wss://kraken.expertintheloop.io/ws/chat npm run build
 
           # Update backend dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,15 @@ jobs:
           # Rebuild frontend — export VITE_* vars from backend .env for the build
           # (Clerk publishable key, allowed domains, etc. are set in the server's .env)
           npm ci
-          set -a; source <(grep '^VITE_' ~/kraken-chatbot/backend/.env 2>/dev/null); set +a
+          ENV_FILE=~/kraken-chatbot/backend/.env
+          if [ ! -f "$ENV_FILE" ]; then
+            echo "ERROR: $ENV_FILE not found — frontend build will lack VITE_* vars"
+            exit 1
+          fi
+          set -a; source <(grep '^VITE_' "$ENV_FILE"); set +a
+          if [ -z "$VITE_CLERK_PUBLISHABLE_KEY" ]; then
+            echo "WARNING: VITE_CLERK_PUBLISHABLE_KEY not set — app will run without Clerk auth"
+          fi
           VITE_WS_URL=wss://kraken.expertintheloop.io/ws/chat npm run build
 
           # Update backend dependencies


### PR DESCRIPTION
## Summary

- Fix production deploy workflow to source `VITE_*` vars from server's `backend/.env` before `npm run build`, matching the dev deploy workflow pattern
- Without this, `VITE_CLERK_PUBLISHABLE_KEY` was missing at build time, causing the app to render without ClerkProvider

## Test plan

- [x] Manually verified on production — Clerk sign-in flow working at kraken.expertintheloop.io
- [x] Dev workflow already uses this pattern successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)