### PR TITLE
fix(tests): resolve pytest collection failures (#40)

### DIFF
--- a/backend/tests/test_literature_grounding.py
+++ b/backend/tests/test_literature_grounding.py
@@ -17,10 +17,18 @@ spec.loader.exec_module(state_module)
 LiteratureSupport = state_module.LiteratureSupport
 Hypothesis = state_module.Hypothesis
 
-# Set up package hierarchy for literature_grounding relative imports
+# Set up package hierarchy for literature_grounding relative imports.
+# NOTE (issue #40): give each stub a real __path__ so submodules this file does NOT
+# explicitly fake (e.g. kestrel_backend.logging_config, imported by test_logging.py)
+# still resolve to the real source instead of failing with "'kestrel_backend' is not a
+# package" during collection. The explicitly-faked submodules below remain authoritative
+# because a direct sys.modules entry is consulted before __path__-based resolution.
 kestrel_backend = types.ModuleType("kestrel_backend")
+kestrel_backend.__path__ = ["src/kestrel_backend"]
 kestrel_backend_graph = types.ModuleType("kestrel_backend.graph")
+kestrel_backend_graph.__path__ = ["src/kestrel_backend/graph"]
 kestrel_backend_graph_nodes = types.ModuleType("kestrel_backend.graph.nodes")
+kestrel_backend_graph_nodes.__path__ = ["src/kestrel_backend/graph/nodes"]
 
 sys.modules["kestrel_backend"] = kestrel_backend
 sys.modules["kestrel_backend.graph"] = kestrel_backend_graph
@@ -44,6 +52,7 @@ mock_semantic_scholar = types.ModuleType("kestrel_backend.semantic_scholar")
 mock_semantic_scholar.search_papers = None
 mock_semantic_scholar.score_relevance = None
 mock_semantic_scholar.classify_relationship = None
+mock_semantic_scholar.classify_relationship_llm = None  # issue #40: real node imports this (R14)
 mock_semantic_scholar.extract_key_passage = None
 mock_semantic_scholar.format_authors = None
 mock_semantic_scholar.extract_doi = None


### PR DESCRIPTION
Closes #40.

## Problem
`tests/test_literature_grounding.py` replaces `sys.modules["kestrel_backend"]` with a **fake empty module** at import time (to avoid pulling LangGraph via `graph/__init__.py`). Because that fake isn't a real package, any later-collected test doing a real `from kestrel_backend.X import ...` — e.g. `test_logging.py` (`from kestrel_backend.logging_config import ...`) — failed collection with `"'kestrel_backend' is not a package"`, **interrupting the entire pytest run**.

A second, independent break: the fake `semantic_scholar` stub was missing `classify_relationship_llm`, which the real `literature_grounding` node imports (since R14), so `test_literature_grounding.py` also errored at collection.

## Fix (one file, `test_literature_grounding.py`)
- Give each stub package a real `__path__` pointing at the source, so submodules this file does **not** explicitly fake (like `kestrel_backend.logging_config`) resolve to the real code. Explicitly-faked submodules stay authoritative via their `sys.modules` entries.
- Add the missing `classify_relationship_llm` stub to the fake `semantic_scholar`.

## Verification
- Full suite now **collects cleanly: 501 tests, 0 collection errors** (was 2, which interrupted the run).
- `test_literature_grounding.py` + `test_logging.py` run together: **106 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)