### PR TITLE
fix(assessment): set/frozenset serializer + glob variance discovery (#46, #47)

### DIFF
--- a/backend/src/kestrel_backend/assessment/capture.py
+++ b/backend/src/kestrel_backend/assessment/capture.py
@@ -49,6 +49,9 @@ def _serialize_value(value: Any) -> Any:
         return {k: _serialize_value(v) for k, v in value.items()}
     if isinstance(value, tuple):
         return [_serialize_value(item) for item in value]
+    if isinstance(value, (set, frozenset)):
+        # Sort for deterministic JSON output; key=str tolerates heterogeneous members (issue #46)
+        return sorted((_serialize_value(item) for item in value), key=str)
     # Fallback: convert to string
     return str(value)
 

--- a/backend/src/kestrel_backend/assessment/capture.py
+++ b/backend/src/kestrel_backend/assessment/capture.py
@@ -50,8 +50,13 @@ def _serialize_value(value: Any) -> Any:
     if isinstance(value, tuple):
         return [_serialize_value(item) for item in value]
     if isinstance(value, (set, frozenset)):
-        # Sort for deterministic JSON output; key=str tolerates heterogeneous members (issue #46)
-        return sorted((_serialize_value(item) for item in value), key=str)
+        # Deterministic JSON output: numbers sort numerically, everything else by str,
+        # grouped by type name so heterogeneous members never compare across types
+        # (issue #46; key avoids lexicographic int ordering like [1, 10, 2]).
+        return sorted(
+            (_serialize_value(item) for item in value),
+            key=lambda x: (type(x).__name__, x if isinstance(x, (int, float)) else str(x)),
+        )
     # Fallback: convert to string
     return str(value)
 

--- a/backend/src/kestrel_backend/assessment/variance.py
+++ b/backend/src/kestrel_backend/assessment/variance.py
@@ -222,23 +222,21 @@ def compute_all_tolerance_bands(
         query_text = q["query"]
         qh = qhash(query_text)
 
-        # Find all output files for this query
+        # Find all output files for this query via glob, so a missing middle run
+        # (e.g. run 3 of 5 failed to write) does not silently truncate later runs.
+        # Run order is irrelevant to the variance stats; sorted() only makes iteration
+        # deterministic. (issue #47)
         run_outputs = []
         run_metrics = []
-        run_num = 1
 
-        while True:
-            output_path = output_dir / "outputs" / f"{qh}_run{run_num}.json"
-            if not output_path.exists():
-                break
+        for output_path in sorted((output_dir / "outputs").glob(f"{qh}_run*.json")):
             output_data = json.loads(output_path.read_text())
             if "error" not in output_data or output_data.get("error") is None:
                 metrics = extract_metrics(output_data)
                 run_metrics.append(metrics)
                 run_outputs.append(output_data)
             else:
-                logger.warning("Skipping failed run %d for query '%s'", run_num, query_text[:50])
-            run_num += 1
+                logger.warning("Skipping failed run %s for query '%s'", output_path.name, query_text[:50])
 
         if not run_metrics:
             logger.warning("No successful runs for query '%s'", query_text[:50])

--- a/backend/tests/test_assessment_capture.py
+++ b/backend/tests/test_assessment_capture.py
@@ -69,6 +69,12 @@ class TestSerializeState:
         result = _serialize_state(state)
         assert result == {"pair": ["a", "b"]}
 
+    def test_serialize_set_to_sorted_list(self):
+        """Issue #46: set/frozenset serialize to a deterministic sorted list,
+        not the str() fallback like "{'a', 'b'}"."""
+        assert _serialize_value({"b", "a", "c"}) == ["a", "b", "c"]
+        assert _serialize_value(frozenset({3, 1, 2})) == [1, 2, 3]
+
 
 class TestQueryHash:
     """Test deterministic query hashing."""

--- a/backend/tests/test_assessment_capture.py
+++ b/backend/tests/test_assessment_capture.py
@@ -74,6 +74,8 @@ class TestSerializeState:
         not the str() fallback like "{'a', 'b'}"."""
         assert _serialize_value({"b", "a", "c"}) == ["a", "b", "c"]
         assert _serialize_value(frozenset({3, 1, 2})) == [1, 2, 3]
+        # integers must sort numerically, not lexicographically ([1, 10, 2]) — Greptile #58
+        assert _serialize_value({1, 10, 2}) == [1, 2, 10]
 
 
 class TestQueryHash:

--- a/backend/tests/test_assessment_variance.py
+++ b/backend/tests/test_assessment_variance.py
@@ -194,3 +194,33 @@ class TestSelectCanonicalRun:
         idx, output = select_canonical_run(runs, outputs)
         assert idx == 0
         assert output == {"run": 0}
+
+
+class TestComputeAllToleranceBands:
+    """Test the file-discovery layer that reads stored run outputs."""
+
+    def test_missing_middle_run_not_truncated(self, tmp_path):
+        """Issue #47: a missing run in the middle (run 3 of 5) must not silently
+        drop the later runs (4, 5) — glob discovery instead of break-on-first-gap."""
+        from kestrel_backend.assessment.variance import compute_all_tolerance_bands
+        from kestrel_backend.assessment.capture import query_hash
+
+        query = "test query for variance truncation"
+        qh = query_hash(query)
+        outputs = tmp_path / "outputs"
+        outputs.mkdir(parents=True)
+
+        # Runs 1, 2, 4, 5 exist on disk; run 3 is absent (e.g. failed to write).
+        for run in (1, 2, 4, 5):
+            (outputs / f"{qh}_run{run}.json").write_text(json.dumps({
+                "resolved_entities": [{"curie": "X:1"}],
+                "direct_findings": [],
+            }))
+
+        all_bands = compute_all_tolerance_bands(tmp_path, [{"query": query}])
+        assert qh in all_bands
+
+        # All 4 present runs must be counted — the old break-on-missing loop stopped
+        # at run 2 when run 3 was absent, yielding run_count == 2.
+        assert all_bands[qh]["run_count"] == 4
+        assert all_bands[qh]["metric_bands"]["resolved_entity_count"]["n"] == 4


### PR DESCRIPTION
Closes #46. Closes #47.

Two small, defensive fixes in the assessment module, both originally flagged in the PR #45 Greptile review.

## #46 — set/frozenset serialization
`_serialize_value()` (`assessment/capture.py`) handled list/dict/tuple but not `set`/`frozenset`, so a set value would fall through to `str()` and serialize as `"{'a', 'b'}"` instead of JSON. Added a branch returning a **deterministic sorted list** (`key=str` tolerates heterogeneous members).

## #47 — variance run discovery no longer truncates
`compute_all_tolerance_bands()` (`assessment/variance.py`) used a `while True` loop that **broke on the first missing run file**, so a missing middle run (e.g. run 3 of 5) silently dropped runs 4–5 from the variance bands. Replaced with `glob("{qh}_run*.json")`, which counts all present runs regardless of gaps.

## Tests
- `set`/`frozenset` → sorted list serialization.
- Variance with run 3 missing (runs 1, 2, 4, 5 present) asserts `run_count == 4` — i.e. later runs are not truncated.
- Both assessment test files pass (30 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)