### PR TITLE
fix(citations): repair UTF-8 mojibake with ftfy (#39)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "sqlalchemy>=2.0.0",
     "psycopg2-binary>=2.9.0",
     "PyJWT[crypto]>=2.8.0",
+    "ftfy>=6.3.1",
 ]
 
 [dependency-groups]

--- a/backend/src/kestrel_backend/graph/nodes/literature_grounding.py
+++ b/backend/src/kestrel_backend/graph/nodes/literature_grounding.py
@@ -210,7 +210,8 @@ def build_references_table(hypotheses: list[Hypothesis]) -> str:
         relevance = re.sub(r'\[.*?\]\(.*?\)', '', relevance)  # Strip markdown links
         relevance = re.sub(r'<[^>]+>', '', relevance)  # Strip HTML tags
         relevance = re.sub(r'[#*>`~]', '', relevance)  # Strip markdown formatting chars
-        relevance = re.sub(r'[âÂ€™""—–]+', '', relevance)  # Strip UTF-8 mojibake artifacts
+        # Mojibake is repaired at LiteratureSupport construction now (issue #39); the old
+        # char-class strip here also deleted legitimate em-dashes/quotes, so it's removed.
         relevance = re.sub(r'\s+', ' ', relevance).strip()  # Collapse whitespace
         if not relevance:
             relevance = "—"

--- a/backend/src/kestrel_backend/graph/state.py
+++ b/backend/src/kestrel_backend/graph/state.py
@@ -8,6 +8,7 @@ The Annotated[list[X], operator.add] pattern enables parallel writes to list fie
 from typing import TypedDict, Literal, Annotated, Any
 from pydantic import BaseModel, Field, ConfigDict, field_validator
 import operator
+import ftfy
 
 
 # Deeply double-encoded UTF-8 mojibake sequences that ftfy cannot fully resolve on its
@@ -250,7 +251,6 @@ class LiteratureSupport(BaseModel):
         """
         if not isinstance(v, str) or not v:
             return v
-        import ftfy
         for bad, good in _MOJIBAKE_REPLACEMENTS.items():
             v = v.replace(bad, good)
         return ftfy.fix_text(v)

--- a/backend/src/kestrel_backend/graph/state.py
+++ b/backend/src/kestrel_backend/graph/state.py
@@ -5,9 +5,18 @@ Uses TypedDict for LangGraph compatibility with Pydantic models for validation.
 The Annotated[list[X], operator.add] pattern enables parallel writes to list fields.
 """
 
-from typing import TypedDict, Literal, Annotated
-from pydantic import BaseModel, Field, ConfigDict
+from typing import TypedDict, Literal, Annotated, Any
+from pydantic import BaseModel, Field, ConfigDict, field_validator
 import operator
+
+
+# Deeply double-encoded UTF-8 mojibake sequences that ftfy cannot fully resolve on its
+# own (observed in literature citations, e.g. Rabbani 2021). Applied before ftfy.fix_text,
+# which then repairs the common single-encoding cases. (issue #39)
+_MOJIBAKE_REPLACEMENTS = {
+    'Ã¢Â€Â"': "—",   # em-dash
+    "Ã¢Â€Â™": "'",   # apostrophe
+}
 
 
 class EntityResolution(BaseModel):
@@ -228,6 +237,23 @@ class LiteratureSupport(BaseModel):
     source: Literal["kg", "openalex", "s2", "exa", "pubmed"] = Field(
         default="s2", description="Source of this literature reference"
     )
+
+    @field_validator("title", "authors", "key_passage", mode="before")
+    @classmethod
+    def _repair_mojibake(cls, v: Any) -> Any:
+        """Repair UTF-8 mojibake in citation text at construction so it is clean
+        everywhere downstream — references table and frontend (issue #39).
+
+        Explicit replacements catch deeply double-encoded punctuation that ftfy can't
+        fully resolve; ftfy.fix_text handles common single-encoding mojibake and leaves
+        legitimate text (em-dashes, accents) intact.
+        """
+        if not isinstance(v, str) or not v:
+            return v
+        import ftfy
+        for bad, good in _MOJIBAKE_REPLACEMENTS.items():
+            v = v.replace(bad, good)
+        return ftfy.fix_text(v)
 
 
 # =============================================================================

--- a/backend/tests/test_literature_grounding.py
+++ b/backend/tests/test_literature_grounding.py
@@ -247,6 +247,26 @@ class TestLiteratureSupportModel:
         assert lit.relationship == "supporting"
         assert lit.doi is None  # Optional field
 
+    def test_repairs_mojibake_in_text_fields(self):
+        """Issue #39: UTF-8 mojibake in citation text is repaired; legit text preserved."""
+        moj_em = "—".encode("utf-8").decode("latin-1")    # em-dash mojibake
+        moj_apos = "’".encode("utf-8").decode("latin-1")  # apostrophe mojibake
+        lit = LiteratureSupport(
+            paper_id="p", year=2021, authors=f"Rabbani{moj_apos}s group",
+            title=f"Lipid{moj_em}diabetes link",
+            key_passage="real em-dash — and café",
+        )
+        assert lit.title == "Lipid—diabetes link"  # single-encoding mojibake repaired
+        assert moj_em not in lit.title
+        assert "Rabbani" in lit.authors and moj_apos not in lit.authors
+        assert "café" in lit.key_passage  # legitimate accented text preserved
+        assert "—" in lit.key_passage     # legitimate em-dash preserved (not stripped)
+
+        # deeply double-encoded sequence from the issue (Rabbani 2021)
+        lit2 = LiteratureSupport(paper_id="p2", year=2021, authors="A",
+                                 title='dose Ã¢Â€Â" response curve')
+        assert "Ã¢" not in lit2.title  # double-mojibake lead bytes removed
+
     def test_literature_support_with_doi(self):
         """Test LiteratureSupport with DOI."""
         lit = LiteratureSupport(

--- a/backend/tests/test_literature_grounding.py
+++ b/backend/tests/test_literature_grounding.py
@@ -266,6 +266,7 @@ class TestLiteratureSupportModel:
         lit2 = LiteratureSupport(paper_id="p2", year=2021, authors="A",
                                  title='dose Ã¢Â€Â" response curve')
         assert "Ã¢" not in lit2.title  # double-mojibake lead bytes removed
+        assert "—" in lit2.title       # replaced with the correct em-dash
 
     def test_literature_support_with_doi(self):
         """Test LiteratureSupport with DOI."""

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -425,6 +425,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e6/79/d4f20e91327c98096d605646bdc6a5ffedae820f38d378d3515c42ec5e60/forbiddenfruit-0.1.4.tar.gz", hash = "sha256:e3f7e66561a29ae129aac139a85d610dbf3dd896128187ed5454b6421f624253", size = 43756 }
 
 [[package]]
+name = "ftfy"
+version = "6.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a5/d3/8650919bc3c7c6e90ee3fa7fd618bf373cbbe55dff043bd67353dbb20cd8/ftfy-6.3.1.tar.gz", hash = "sha256:9b3c3d90f84fb267fe64d375a07b7f8912d817cf86009ae134aa03e1819506ec", size = 308927 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/6e/81d47999aebc1b155f81eca4477a616a70f238a2549848c38983f3c22a82/ftfy-6.3.1-py3-none-any.whl", hash = "sha256:7c70eb532015cd2f9adb53f101fb6c7945988d023a085d127d1573dc49dd0083", size = 44821 },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.72.0"
 source = { registry = "https://pypi.org/simple" }
@@ -838,6 +850,7 @@ dependencies = [
     { name = "asyncpg" },
     { name = "claude-agent-sdk" },
     { name = "fastapi" },
+    { name = "ftfy" },
     { name = "httpx" },
     { name = "langfuse" },
     { name = "langgraph" },
@@ -869,6 +882,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "claude-agent-sdk", specifier = ">=0.1.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "ftfy", specifier = ">=6.3.1" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "langfuse", specifier = ">=2.0.0" },
     { name = "langgraph", specifier = ">=0.2.0" },
@@ -2317,6 +2331,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072 },
     { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104 },
     { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112 },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825 },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #39.

## Problem
Literature citations showed UTF-8 mojibake (e.g. `Ã¢Â€Â"` in the Rabbani 2021 citation). The existing sanitizer **stripped** a fixed character class `[âÂ€™""—–]` from passages, which:
- **deleted legitimate** em-dashes and curly quotes, and
- **missed** double-encoded sequences (`Ã`/`¢` lead bytes).

## Fix — repair, don't strip
A `field_validator` on `LiteratureSupport` runs `ftfy.fix_text()` on `title`/`authors`/`key_passage` **at construction**, so text is clean everywhere downstream — the references table **and** the frontend — not just the table.

- `ftfy.fix_text` repairs the common single-encoding mojibake (em-dash, en-dash, accents, quotes) and **leaves legitimate text intact** (verified: real `—`, `café`, curly quotes preserved/normalized).
- A small explicit-replacement map handles the deeply double-encoded punctuation ftfy can't fully resolve (the documented `Ã¢Â€Â"` → `—`, `Ã¢Â€Â™` → `'`).
- The redundant + harmful char-class strip in `build_references_table` is removed.

Adds the `ftfy` dependency.

## Tests
- Single-encoding mojibake repaired in title/authors.
- Legitimate accented text + em-dash preserved.
- Double-encoded lead bytes removed.
- Full literature-grounding suite: 98 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)