### PR TITLE
fix: guard + migrate pathway_enrichment Phase B off broken stdio MCP (#44)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,11 @@ uv sync              # Install/update Python dependencies
 uv run uvicorn src.kestrel_backend.main:app --reload --host 127.0.0.1 --port 8000
 
 # Testing
-cd backend && uv run pytest tests/ -v -m "not integration"
+# Use `python -m pytest` (not bare `uv run pytest`): the venv path contains
+# spaces, which breaks the console-script shebang and silently falls back to
+# system Python → misleading ModuleNotFoundError. See
+# docs/solutions/developer-experience/pytest-venv-path-spaces-module-invocation-2026-06-01.md
+cd backend && uv run python -m pytest tests/ -v -m "not integration"
 ```
 
 ## LangGraph Studio (Local Development)

--- a/backend/src/kestrel_backend/graph/nodes/pathway_enrichment.py
+++ b/backend/src/kestrel_backend/graph/nodes/pathway_enrichment.py
@@ -101,6 +101,8 @@ def _build_inference_user_prompt(selected_entities: list, per_entity: dict[str, 
     blocks = []
     for e in selected_entities:
         data = per_entity.get(e.curie, {})
+        if data.get("errored"):
+            continue  # skip entities whose HTTP prefetch failed — no useful data to embed
         neighbors = []
         for edge in data.get("edges", []):
             if isinstance(edge, dict):
@@ -516,6 +518,7 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
                 "shared_neighbors": [],
                 "biological_themes": [],
                 "direct_findings": two_hop_findings,  # preserve Phase A on timeout (issue #44, R5)
+                "pathway_enrichment_degraded": True,  # disclose: Phase B produced nothing
                 "errors": [f"SDK query timed out after {SDK_QUERY_TIMEOUT}s"],
             }
 
@@ -603,5 +606,6 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
             "shared_neighbors": [],
             "biological_themes": [],
             "direct_findings": two_hop_findings,
+            "pathway_enrichment_degraded": True,  # disclose: Phase B produced nothing
             "errors": [f"Pathway enrichment failed: {str(e)}"],
         }

--- a/backend/src/kestrel_backend/graph/nodes/pathway_enrichment.py
+++ b/backend/src/kestrel_backend/graph/nodes/pathway_enrichment.py
@@ -24,7 +24,7 @@ from ..state import (
     DiscoveryState, SharedNeighbor, BiologicalTheme, Finding
 )
 from ...kestrel_client import multi_hop_query
-from ..sdk_utils import HAS_SDK, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS, query_with_usage
+from ..sdk_utils import HAS_SDK, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS, query_with_usage, classify_mcp_degradation
 from ..pipeline_config import get_pipeline_config
 from ..state_contracts import validate_state, PathwayEnrichmentInput, PathwayEnrichmentOutput
 
@@ -256,6 +256,57 @@ async def find_two_hop_shared_neighbors(
     return shared_neighbors, errors
 
 
+# Expected MCP tools for Phase B; used by the degradation guard (issue #44).
+_PHASE_B_EXPECTED_TOOLS = ["mcp__kestrel__one_hop_query", "mcp__kestrel__get_nodes"]
+
+
+def _build_two_hop_findings(two_hop_neighbors: dict[str, int]) -> list[Finding]:
+    """Build Phase A two-hop Finding objects.
+
+    Computed independently of Phase B so they survive a Phase B degradation or
+    exception (issue #44, R5).
+    """
+    if not two_hop_neighbors:
+        return []
+    top_two_hop = sorted(two_hop_neighbors.items(), key=lambda x: x[1], reverse=True)[:3]
+    two_hop_summary = ", ".join([f"{curie} ({count} inputs)" for curie, count in top_two_hop])
+    return [Finding(
+        entity=", ".join([c for c, _ in top_two_hop]),
+        claim=f"Two-hop connectivity: {two_hop_summary}",
+        tier=2,
+        source="pathway_enrichment_two_hop",
+        confidence="moderate",
+    )]
+
+
+def _degraded_phase_b_result(
+    two_hop_findings: list[Finding],
+    base_errors: list[str],
+    usage_record: Any,
+    reason: str,
+) -> dict[str, Any]:
+    """Shared degraded-result builder (issue #44).
+
+    Drops the unreliable SDK Phase B findings, keeps the real Phase A two-hop
+    findings, and flags the run as degraded. Used for both the MCP-unavailable
+    path (Unit 3) and the HTTP-prefetch-no-data path (Unit 5).
+    """
+    logger.warning(
+        "pathway_enrichment degraded (reason=%s) — dropping SDK shared neighbors, keeping two-hop",
+        reason,
+    )
+    result: dict[str, Any] = {
+        "shared_neighbors": [],
+        "biological_themes": [],
+        "direct_findings": two_hop_findings,
+        "pathway_enrichment_degraded": True,
+        "errors": base_errors + [f"pathway_enrichment Phase B degraded: {reason}"],
+    }
+    if usage_record is not None:
+        result["model_usages"] = [usage_record]
+    return result
+
+
 @validate_state(PathwayEnrichmentInput, PathwayEnrichmentOutput)
 async def run(state: DiscoveryState) -> dict[str, Any]:
     """
@@ -355,6 +406,10 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
             list(two_hop_neighbors.items())[:5]
         )
 
+    # Stage Phase A two-hop findings OUTSIDE the Phase B try so they survive a
+    # Phase B degradation or exception (issue #44, R5).
+    two_hop_findings = _build_two_hop_findings(two_hop_neighbors)
+
     # User prompt with entity count to help LLM budget tool calls
     user_prompt = f"""Analyze these {len(selected_entities)} entities and find shared neighbors:
 
@@ -399,6 +454,7 @@ NOTE: Two-hop analysis already completed separately. Focus on ONE-HOP neighbors 
             return {
                 "shared_neighbors": [],
                 "biological_themes": [],
+                "direct_findings": two_hop_findings,  # preserve Phase A on timeout (issue #44, R5)
                 "errors": [f"SDK query timed out after {SDK_QUERY_TIMEOUT}s"],
             }
 
@@ -415,16 +471,37 @@ NOTE: Two-hop analysis already completed separately. Focus on ONE-HOP neighbors 
         if parse_errors:
             logger.warning("pathway_enrichment parse errors: %s", parse_errors)
 
-        # Create findings from top themes
-        findings: list[Finding] = []
+        # Issue #44: detect MCP-tool degradation. If Phase B ran tool-less and
+        # hallucinated, drop its findings rather than feed fabricated KG claims
+        # downstream. Phase A two-hop findings (HTTP-derived) are preserved.
+        verdict = classify_mcp_degradation(
+            expected_tools=_PHASE_B_EXPECTED_TOOLS,
+            mcp_tool_calls=usage_record.mcp_tool_calls if usage_record else 0,
+            result_text=result_text,
+            available_tools=usage_record.available_tools if usage_record else None,
+        )
+        phase_b_degraded = False
+        if verdict.degraded:
+            if _config.drop_findings_on_degraded:
+                return _degraded_phase_b_result(
+                    two_hop_findings, two_hop_errors, usage_record, f"mcp_{verdict.reason}"
+                )
+            phase_b_degraded = True  # flag for disclosure even though output is kept
+            logger.warning(
+                "pathway_enrichment degraded (reason=%s) but drop_findings_on_degraded=False — keeping output",
+                verdict.reason,
+            )
+
+        # Create findings from top themes (SDK-derived — dropped on degradation)
+        sdk_findings: list[Finding] = []
         for theme in themes[:5]:  # Top 5 themes
             if theme.input_coverage >= 2:
                 non_hub_count = sum(
-                    1 for sn in shared_neighbors 
+                    1 for sn in shared_neighbors
                     if sn.curie in theme.members and not sn.is_hub
                 )
                 category_name = theme.category.replace("biolink:", "")
-                findings.append(Finding(
+                sdk_findings.append(Finding(
                     entity=", ".join(theme.members[:3]),
                     claim=f"Shared {category_name} context: {', '.join(theme.member_names[:3])} connects {theme.input_coverage} input entities",
                     tier=2,
@@ -432,18 +509,8 @@ NOTE: Two-hop analysis already completed separately. Focus on ONE-HOP neighbors 
                     confidence="high" if non_hub_count > 0 else "moderate",
                 ))
 
-        # Add two-hop findings
-        if two_hop_neighbors:
-            # Add finding about two-hop connectivity
-            top_two_hop = sorted(two_hop_neighbors.items(), key=lambda x: x[1], reverse=True)[:3]
-            two_hop_summary = ", ".join([f"{curie} ({count} inputs)" for curie, count in top_two_hop])
-            findings.append(Finding(
-                entity=", ".join([c for c, _ in top_two_hop]),
-                claim=f"Two-hop connectivity: {two_hop_summary}",
-                tier=2,
-                source="pathway_enrichment_two_hop",
-                confidence="moderate",
-            ))
+        # Combine SDK theme findings with the staged Phase A two-hop findings.
+        findings = sdk_findings + two_hop_findings
 
         duration = time.time() - start
         logger.info(
@@ -458,6 +525,7 @@ NOTE: Two-hop analysis already completed separately. Focus on ONE-HOP neighbors 
             "shared_neighbors": shared_neighbors,
             "biological_themes": themes,
             "direct_findings": findings,  # Add to direct_findings via reducer
+            "pathway_enrichment_degraded": phase_b_degraded,
             "errors": all_errors,
         }
         if usage_record is not None:
@@ -467,8 +535,11 @@ NOTE: Two-hop analysis already completed separately. Focus on ONE-HOP neighbors 
     except Exception as e:
         duration = time.time() - start
         logger.error("Pathway enrichment failed after %.1fs: %s", duration, str(e))
+        # Preserve the staged Phase A two-hop findings even on a Phase B exception
+        # (issue #44, R5): emit direct_findings so the operator.add reducer receives them.
         return {
             "shared_neighbors": [],
             "biological_themes": [],
+            "direct_findings": two_hop_findings,
             "errors": [f"Pathway enrichment failed: {str(e)}"],
         }

--- a/backend/src/kestrel_backend/graph/nodes/pathway_enrichment.py
+++ b/backend/src/kestrel_backend/graph/nodes/pathway_enrichment.py
@@ -25,7 +25,7 @@ from ..state import (
 )
 from ...kestrel_client import multi_hop_query
 from .cold_start import get_entity_connections
-from ..sdk_utils import HAS_SDK, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS, query_with_usage, classify_mcp_degradation
+from ..sdk_utils import HAS_SDK, ClaudeAgentOptions, query_with_usage, classify_mcp_degradation
 from ..pipeline_config import get_pipeline_config
 from ..state_contracts import validate_state, PathwayEnrichmentInput, PathwayEnrichmentOutput
 
@@ -41,28 +41,32 @@ MIN_EDGE_COUNT = 20
 # Timeout for SDK query (8 minutes for multi-entity analysis)
 SDK_QUERY_TIMEOUT = 480
 
-# System prompt for pathway enrichment analysis
-PATHWAY_ENRICHMENT_PROMPT = """You are a biomedical knowledge graph analyst finding shared biological context.
+# Limit concurrent SDK inference calls (issue #44 Stage 2; also closes the
+# previously-missing semaphore gap for this node).
+SDK_SEMAPHORE = asyncio.Semaphore(_config.sdk_semaphore)
 
-You have access to these Kestrel MCP tools:
-- one_hop_query: Query neighbors of an entity. Use with curie parameter to get connected nodes.
-- get_nodes: Get details about specific nodes including edge count (degree).
+# Inference system prompt (issue #44): the one-hop neighbors are pre-fetched via HTTP and
+# embedded in the user prompt, so the model has NO tools — it reasons over the provided
+# data and emits a strict shared_neighbors/themes JSON schema.
+#
+# NOTE: this node was migrated off the stdio Kestrel MCP server (`uvx mcp-client-kestrel`,
+# which does not exist on PyPI — see cold_start.py) to direct HTTP. The same broken stdio
+# path is still used by entity_resolution, direct_kg, integration, temporal, and triage;
+# their SDK tiers are silently degraded by the same root cause and should be audited /
+# migrated under a separate issue. The Stage 1 instrumentation (sdk_utils diagnostics)
+# quantifies their exposure in production logs.
+PATHWAY_INFERENCE_PROMPT = """You are a biomedical knowledge graph analyst finding shared biological context.
 
-TASK: For the given list of entities, find neighbors that are shared by 2+ input entities.
+The one-hop neighbors of each input entity have already been retrieved from the Kestrel
+knowledge graph and are provided to you below. You do NOT have tools — reason over the
+provided data only.
 
-STEP 1: For each input entity CURIE, call one_hop_query to get its neighbors.
-        Example: one_hop_query(curie="CHEBI:28757") returns neighbors of fructose.
+TASK: Find neighbors that appear in 2+ input entities' neighbor lists (shared neighbors),
+track which input entities connect to each, and group them by Biolink category into
+biological themes.
 
-STEP 2: Identify neighbors that appear in 2+ entity neighborhoods (shared neighbors).
-        Track which input entities connect to each shared neighbor.
-
-STEP 3: For promising shared neighbors, call get_nodes to check their degree (edge count).
-        If degree > 1000, mark as hub (less specific, connects to everything).
-
-STEP 4: Group shared neighbors by category to identify biological themes.
-
-CRITICAL: Hub nodes (degree >1000) like GO:0005515 (protein binding), GO:0005737 (cytoplasm)
-connect to everything and provide less insight. Flag them clearly.
+Hub nodes (very high degree — e.g. GO:0005515 protein binding, GO:0005737 cytoplasm) connect
+to everything and provide less insight. Mark them with "is_hub": true when you can tell.
 
 Return ONLY a valid JSON object (no other text):
 {
@@ -80,17 +84,43 @@ Return ONLY a valid JSON object (no other text):
   "themes": [
     {
       "category": "biolink:BiologicalProcess",
-      "members": ["GO:0006915", "GO:0006954"],
-      "member_names": ["apoptotic process", "inflammatory response"],
-      "input_coverage": 4,
+      "members": ["GO:0006915"],
+      "member_names": ["apoptotic process"],
+      "input_coverage": 2,
       "top_non_hub": "GO:0006915"
     }
   ]
 }
 
-If no shared neighbors are found after querying, return:
-{"shared_neighbors": [], "themes": []}
+If no shared neighbors are found, return: {"shared_neighbors": [], "themes": []}
 """
+
+
+def _build_inference_user_prompt(selected_entities: list, per_entity: dict[str, dict]) -> str:
+    """Embed the prefetched one-hop neighbors into the inference prompt (issue #44, Stage 2)."""
+    blocks = []
+    for e in selected_entities:
+        data = per_entity.get(e.curie, {})
+        neighbors = []
+        for edge in data.get("edges", []):
+            if isinstance(edge, dict):
+                obj = edge.get("object", {})
+                oid = obj.get("id") if isinstance(obj, dict) else None
+                pred = edge.get("predicate", "")
+                if oid:
+                    neighbors.append(f"{oid} [{pred}]")
+        name = e.resolved_name or e.raw_name
+        neighbor_str = "; ".join(neighbors[:50]) if neighbors else "none"
+        blocks.append(
+            f"### {e.curie} ({name})\n"
+            f"Predicate summary: {data.get('summary', '')}\n"
+            f"Neighbors ({len(neighbors)}): {neighbor_str}"
+        )
+    body = "\n\n".join(blocks)
+    return (
+        f"Analyze these {len(selected_entities)} entities' one-hop neighbors and find "
+        f"neighbors shared by 2+ entities:\n\n{body}\n\nReturn JSON only."
+    )
 
 
 def parse_enrichment_result(
@@ -255,10 +285,6 @@ async def find_two_hop_shared_neighbors(
     )
 
     return shared_neighbors, errors
-
-
-# Expected MCP tools for Phase B; used by the degradation guard (issue #44).
-_PHASE_B_EXPECTED_TOOLS = ["mcp__kestrel__one_hop_query", "mcp__kestrel__get_nodes"]
 
 
 def _build_two_hop_findings(two_hop_neighbors: dict[str, int]) -> list[Finding]:
@@ -427,12 +453,6 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
             "errors": ["Claude Agent SDK not available for pathway enrichment"],
         }
 
-    # Build entity list for the user prompt (include edge counts for context)
-    entity_list = "\n".join([
-        f"- {e.curie} ({e.resolved_name or e.raw_name}, {edge_count_map.get(e.curie, 0)} edges)"
-        for e in selected_entities
-    ])
-
     # Phase A: Two-hop shared neighbor analysis via API (fast, no LLM)
     logger.info("Starting two-hop shared neighbor analysis via API...")
     entity_curies = [e.curie for e in selected_entities if e.curie]
@@ -453,41 +473,39 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
     # Phase B degradation or exception (issue #44, R5).
     two_hop_findings = _build_two_hop_findings(two_hop_neighbors)
 
-    # User prompt with entity count to help LLM budget tool calls
-    user_prompt = f"""Analyze these {len(selected_entities)} entities and find shared neighbors:
-
-{entity_list}
-
-You have {len(selected_entities)} entities to query. Budget your tool calls:
-- Use one_hop_query for each entity (~{len(selected_entities)} calls)
-- Use get_nodes sparingly for key shared neighbors
-- Return JSON when done
-
-NOTE: Two-hop analysis already completed separately. Focus on ONE-HOP neighbors only."""
-
     try:
-        # Configure Kestrel MCP server (stdio-based, same as entity_resolution)
-        kestrel_config = get_kestrel_mcp_config()
+        # Stage 2 (issue #44): fetch one-hop neighbors via HTTP, then reason over them
+        # in-prompt with NO stdio MCP. Mirrors cold_start's data-in-prompt inference.
+        per_entity, no_data = await prefetch_one_hop_neighbors(selected_entities)
+        if no_data:
+            # Fewer than 2 entities returned real neighbor data — running inference on a
+            # sparse prompt would re-hallucinate, so degrade instead (issue #44).
+            return _degraded_phase_b_result(
+                two_hop_findings, two_hop_errors, None, "prefetch_no_data"
+            )
+
+        user_prompt = _build_inference_user_prompt(selected_entities, per_entity)
 
         options = ClaudeAgentOptions(
-            system_prompt=PATHWAY_ENRICHMENT_PROMPT,
-            allowed_tools=["mcp__kestrel__one_hop_query", "mcp__kestrel__get_nodes"],
-            mcp_servers={"kestrel": kestrel_config},
-            max_turns=25,  # Enough for ~N one_hop_query + get_nodes + JSON synthesis
+            system_prompt=PATHWAY_INFERENCE_PROMPT,
+            allowed_tools=[],  # data-in-prompt inference — no MCP tools (issue #44)
+            max_turns=2,
             permission_mode="bypassPermissions",
-            max_buffer_size=10 * 1024 * 1024,  # 10MB buffer for large KG responses
+            max_buffer_size=10 * 1024 * 1024,  # 10MB buffer for embedded KG data
         )
 
-        # Execute the query using query_with_usage with timeout
+        # Execute the inference under the shared SDK semaphore (closes the
+        # previously-missing semaphore gap for this node).
         try:
-            result_text, usage_record = await asyncio.wait_for(
-                query_with_usage(
-                    prompt=user_prompt,
-                    options=options,
-                    node_name="pathway_enrichment",
-                ),
-                timeout=SDK_QUERY_TIMEOUT,
-            )
+            async with SDK_SEMAPHORE:
+                result_text, usage_record = await asyncio.wait_for(
+                    query_with_usage(
+                        prompt=user_prompt,
+                        options=options,
+                        node_name="pathway_enrichment",
+                    ),
+                    timeout=SDK_QUERY_TIMEOUT,
+                )
         except asyncio.TimeoutError:
             duration = time.time() - start
             logger.error(
@@ -514,11 +532,12 @@ NOTE: Two-hop analysis already completed separately. Focus on ONE-HOP neighbors 
         if parse_errors:
             logger.warning("pathway_enrichment parse errors: %s", parse_errors)
 
-        # Issue #44: detect MCP-tool degradation. If Phase B ran tool-less and
-        # hallucinated, drop its findings rather than feed fabricated KG claims
-        # downstream. Phase A two-hop findings (HTTP-derived) are preserved.
+        # Issue #44 (Stage 2): Phase B now uses data-in-prompt inference (allowed_tools=[]),
+        # so the MCP classifier is inert here (expected_tools=[] -> never degraded) and kept
+        # only as a safety net should MCP tools ever be reintroduced. The active protection
+        # against sparse-prompt re-hallucination is the prefetch no_data guard above.
         verdict = classify_mcp_degradation(
-            expected_tools=_PHASE_B_EXPECTED_TOOLS,
+            expected_tools=[],
             mcp_tool_calls=usage_record.mcp_tool_calls if usage_record else 0,
             result_text=result_text,
             available_tools=usage_record.available_tools if usage_record else None,

--- a/backend/src/kestrel_backend/graph/nodes/pathway_enrichment.py
+++ b/backend/src/kestrel_backend/graph/nodes/pathway_enrichment.py
@@ -24,6 +24,7 @@ from ..state import (
     DiscoveryState, SharedNeighbor, BiologicalTheme, Finding
 )
 from ...kestrel_client import multi_hop_query
+from .cold_start import get_entity_connections
 from ..sdk_utils import HAS_SDK, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS, query_with_usage, classify_mcp_degradation
 from ..pipeline_config import get_pipeline_config
 from ..state_contracts import validate_state, PathwayEnrichmentInput, PathwayEnrichmentOutput
@@ -305,6 +306,48 @@ def _degraded_phase_b_result(
     if usage_record is not None:
         result["model_usages"] = [usage_record]
     return result
+
+
+async def prefetch_one_hop_neighbors(entities: list) -> tuple[dict[str, dict], bool]:
+    """Fetch one-hop neighbor data per entity via the HTTP Kestrel client (issue #44, Stage 2).
+
+    Mirrors cold_start's ``get_entity_connections`` (which collapses every failure mode into
+    an empty ``{"edges": []}`` with no ``total_count`` key — so absence of ``total_count``
+    is our per-entity ``errored`` discriminator).
+
+    Returns ``(per_entity, no_data)`` where ``per_entity`` maps curie -> ``{summary, edges,
+    errored}`` and ``no_data`` is True when fewer than 2 entities returned real (non-errored,
+    non-empty) neighbor data. ``no_data`` is the post-migration emptiness signal that keeps
+    the in-prompt inference from running on a sparse, hallucination-prone prompt.
+    """
+    curies = [e.curie for e in entities if e.curie]
+    results = await asyncio.gather(
+        *[get_entity_connections(c) for c in curies], return_exceptions=True
+    )
+    per_entity: dict[str, dict] = {}
+    populated = 0
+    for curie, result in zip(curies, results):
+        if isinstance(result, Exception):
+            logger.warning("prefetch one_hop_query raised for %s: %s", curie, result)
+            per_entity[curie] = {"summary": f"Error: {result}", "edges": [], "errored": True}
+            continue
+        errored = "total_count" not in result  # get_entity_connections drops it on every failure
+        edges = result.get("edges", [])
+        per_entity[curie] = {
+            "summary": result.get("summary", ""),
+            "edges": edges,
+            "errored": errored,
+        }
+        if not errored and edges:
+            populated += 1
+
+    no_data = populated < 2  # shared-neighbor analysis is meaningless below 2 populated entities
+    if no_data:
+        logger.warning(
+            "pathway_enrichment prefetch: only %d/%d entities returned real neighbor data (no-data signal)",
+            populated, len(curies),
+        )
+    return per_entity, no_data
 
 
 @validate_state(PathwayEnrichmentInput, PathwayEnrichmentOutput)

--- a/backend/src/kestrel_backend/graph/pipeline_config.py
+++ b/backend/src/kestrel_backend/graph/pipeline_config.py
@@ -67,6 +67,12 @@ class PathwayEnrichmentConfig(BaseModel):
         "shared-neighbor filtering. Lower than direct_kg (5000) because this "
         "filters neighbors, not entities — a different purpose.",
     )
+    drop_findings_on_degraded: bool = Field(
+        default=True,
+        description="When Phase B is detected as degraded (MCP tools unavailable or "
+        "HTTP prefetch returned no data), drop the unreliable SDK shared-neighbor "
+        "findings instead of letting hallucinated output reach synthesis (issue #44).",
+    )
 
 
 class EntityResolutionConfig(BaseModel):

--- a/backend/src/kestrel_backend/graph/pipeline_config.py
+++ b/backend/src/kestrel_backend/graph/pipeline_config.py
@@ -73,6 +73,11 @@ class PathwayEnrichmentConfig(BaseModel):
         "HTTP prefetch returned no data), drop the unreliable SDK shared-neighbor "
         "findings instead of letting hallucinated output reach synthesis (issue #44).",
     )
+    sdk_semaphore: int = Field(
+        default=4,
+        description="Max concurrent SDK calls for the Phase B data-in-prompt inference "
+        "(issue #44 Stage 2). Mirrors the other SDK nodes' per-node semaphore.",
+    )
 
 
 class EntityResolutionConfig(BaseModel):

--- a/backend/src/kestrel_backend/graph/sdk_utils.py
+++ b/backend/src/kestrel_backend/graph/sdk_utils.py
@@ -15,7 +15,13 @@ logger = logging.getLogger(__name__)
 
 # Centralized SDK availability check — single try/except for all nodes
 try:
-    from claude_agent_sdk import query, ClaudeAgentOptions, ResultMessage  # noqa: F401
+    from claude_agent_sdk import (  # noqa: F401
+        query,
+        ClaudeAgentOptions,
+        ResultMessage,
+        SystemMessage,
+        ToolUseBlock,
+    )
     from claude_agent_sdk.types import McpStdioServerConfig  # noqa: F401
     HAS_SDK = True
 except ImportError:
@@ -25,11 +31,19 @@ except ImportError:
     ClaudeAgentOptions = None  # type: ignore[assignment,misc]
     McpStdioServerConfig = None  # type: ignore[assignment,misc]
 
-    # Sentinel class so isinstance(event, ResultMessage) returns False
-    # rather than raising TypeError when SDK is unavailable
+    # Sentinel classes so isinstance(event, X) returns False rather than raising
+    # TypeError when the SDK is unavailable (issue #44 instrumentation).
     class _ResultMessageStub:  # type: ignore[no-redef]
         pass
     ResultMessage = _ResultMessageStub  # type: ignore[assignment,misc]
+
+    class _SystemMessageStub:  # type: ignore[no-redef]
+        pass
+    SystemMessage = _SystemMessageStub  # type: ignore[assignment,misc]
+
+    class _ToolUseBlockStub:  # type: ignore[no-redef]
+        pass
+    ToolUseBlock = _ToolUseBlockStub  # type: ignore[assignment,misc]
 
 # Kestrel MCP server configuration constants
 KESTREL_COMMAND = "uvx"
@@ -149,13 +163,25 @@ async def query_with_usage(
     cache_creation_tokens = 0
     cache_read_tokens = 0
     has_usage = False
+    mcp_tool_calls = 0  # count of mcp__* tool-use blocks (issue #44 degradation signal)
+    available_tools: list[str] | None = None  # tool names from the SDK init event, if exposed
 
     async for event in query(prompt=prompt, options=options):
-        # Collect text content
-        if hasattr(event, "content"):
+        # Capture the available-tool list from the SDK init event (best-effort;
+        # stays None if this SDK version/stream doesn't expose it). Issue #44.
+        if isinstance(event, SystemMessage) and getattr(event, "subtype", None) == "init":
+            data = getattr(event, "data", None)
+            tools = data.get("tools") if isinstance(data, dict) else None
+            if isinstance(tools, list):
+                available_tools = [t for t in tools if isinstance(t, str)]
+
+        # Collect text content; count MCP tool-use blocks (issue #44).
+        if hasattr(event, "content") and event.content:
             for block in event.content:
                 if hasattr(block, "text"):
                     result_text_parts.append(block.text)
+                elif isinstance(block, ToolUseBlock) and getattr(block, "name", "").startswith("mcp__"):
+                    mcp_tool_calls += 1
 
         # Accumulate usage from ResultMessage (final totals — replaces)
         if isinstance(event, ResultMessage):
@@ -188,8 +214,17 @@ async def query_with_usage(
             has_usage = True
 
     text = "".join(result_text_parts)
+
+    # Diagnostic line so degraded MCP runs are observable across SDK nodes (issue #44).
+    logger.info(
+        "%s SDK call: mcp_tool_calls=%d, available_tools=%s",
+        node_name,
+        mcp_tool_calls,
+        "unknown" if available_tools is None else f"{len(available_tools)} registered",
+    )
+
     record = None
-    if has_usage:
+    if has_usage or mcp_tool_calls or available_tools is not None:
         record = ModelUsageRecord(
             model_name=model_name,
             node_name=node_name,
@@ -197,6 +232,8 @@ async def query_with_usage(
             output_tokens=output_tokens,
             cache_read_tokens=cache_read_tokens,
             cache_creation_tokens=cache_creation_tokens,
+            mcp_tool_calls=mcp_tool_calls,
+            available_tools=available_tools,
         )
 
     return text, record

--- a/backend/src/kestrel_backend/graph/sdk_utils.py
+++ b/backend/src/kestrel_backend/graph/sdk_utils.py
@@ -103,6 +103,10 @@ def classify_mcp_degradation(
     if not expected_tools:
         return McpDegradationVerdict(False, "no_tools_expected", "none")
 
+    phrase_hit = bool(result_text) and any(
+        p in result_text.lower() for p in _MCP_FALLBACK_PHRASES
+    )
+
     # Definitive: the SDK init tool list is known and is missing an expected tool.
     if available_tools is not None:
         missing = [t for t in expected_tools if t not in available_tools]
@@ -110,10 +114,12 @@ def classify_mcp_degradation(
             return McpDegradationVerdict(
                 True, f"tools_missing_from_init:{','.join(missing)}", "definitive"
             )
-
-    phrase_hit = bool(result_text) and any(
-        p in result_text.lower() for p in _MCP_FALLBACK_PHRASES
-    )
+        # All expected tools confirmed present in the init list. Zero calls WITHOUT the
+        # fallback phrase is not structural proof of degradation (the model may have
+        # legitimately skipped tools) — avoid a false positive for non-mandating nodes.
+        # The phrase still trips the structural check below.
+        if mcp_tool_calls == 0 and not phrase_hit:
+            return McpDegradationVerdict(False, "tools_registered_zero_calls", "none")
 
     # Structural: tools were expected but the model made zero MCP tool calls.
     if mcp_tool_calls == 0:

--- a/backend/src/kestrel_backend/graph/sdk_utils.py
+++ b/backend/src/kestrel_backend/graph/sdk_utils.py
@@ -9,6 +9,7 @@ Semaphore definitions and fallback orchestration logic remain per-node
 """
 
 import logging
+from dataclasses import dataclass
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -62,6 +63,66 @@ def get_kestrel_mcp_config() -> Any:
         command=KESTREL_COMMAND,
         args=KESTREL_ARGS,
     )
+
+
+@dataclass(frozen=True)
+class McpDegradationVerdict:
+    """Result of classify_mcp_degradation (issue #44)."""
+
+    degraded: bool
+    reason: str
+    confidence: str  # "definitive" | "high" | "structural" | "none"
+
+
+# Fallback phrases the SDK model emits when MCP tools failed to register. These are a
+# CORROBORATOR only — never the sole trigger (model wording is brittle). Issue #44.
+_MCP_FALLBACK_PHRASES = (
+    "not available in my current tool set",
+    "tools are not available",
+    "are not available in my",
+)
+
+
+def classify_mcp_degradation(
+    expected_tools: list[str],
+    mcp_tool_calls: int,
+    result_text: str = "",
+    available_tools: list[str] | None = None,
+) -> McpDegradationVerdict:
+    """Detect the "MCP tools unavailable -> hallucinated output" condition (issue #44).
+
+    Structural signals are authoritative; the fallback phrase only raises confidence.
+    A node that expects no MCP tools (``expected_tools == []``, e.g. data-in-prompt
+    inference) can never be MCP-degraded.
+
+    NOTE: the bare ``mcp_tool_calls == 0`` signal is only safe for nodes whose prompt
+    *mandates* tool use (e.g. pathway_enrichment requires a one_hop_query per entity).
+    A node where zero tool calls is a legitimate model choice must require the init-list
+    signal or the corroborating phrase instead of the bare count.
+    """
+    if not expected_tools:
+        return McpDegradationVerdict(False, "no_tools_expected", "none")
+
+    # Definitive: the SDK init tool list is known and is missing an expected tool.
+    if available_tools is not None:
+        missing = [t for t in expected_tools if t not in available_tools]
+        if missing:
+            return McpDegradationVerdict(
+                True, f"tools_missing_from_init:{','.join(missing)}", "definitive"
+            )
+
+    phrase_hit = bool(result_text) and any(
+        p in result_text.lower() for p in _MCP_FALLBACK_PHRASES
+    )
+
+    # Structural: tools were expected but the model made zero MCP tool calls.
+    if mcp_tool_calls == 0:
+        if phrase_hit:
+            return McpDegradationVerdict(True, "zero_mcp_tool_calls+phrase", "high")
+        return McpDegradationVerdict(True, "zero_mcp_tool_calls", "structural")
+
+    # Tools were used -> healthy, even if the analysis found nothing.
+    return McpDegradationVerdict(False, "tools_used", "none")
 
 
 # NOTE: create_agent_options is not yet used by existing nodes (they call

--- a/backend/src/kestrel_backend/graph/state.py
+++ b/backend/src/kestrel_backend/graph/state.py
@@ -299,6 +299,10 @@ class ModelUsageRecord(BaseModel):
     output_tokens: int = Field(0, ge=0)
     cache_read_tokens: int = Field(0, ge=0, description="Prompt cache read tokens")
     cache_creation_tokens: int = Field(0, ge=0, description="Prompt cache creation tokens")
+    # MCP tool-availability diagnostics (issue #44). mcp_tool_calls counts mcp__* tool-use
+    # blocks observed; available_tools is the SDK init tool list when exposed (else None).
+    mcp_tool_calls: int = Field(0, ge=0, description="Count of mcp__* tool-use blocks in this call")
+    available_tools: list[str] | None = Field(None, description="Tool names from SDK init event, if exposed")
 
 
 class DiscoveryState(TypedDict, total=False):

--- a/backend/src/kestrel_backend/graph/state.py
+++ b/backend/src/kestrel_backend/graph/state.py
@@ -362,6 +362,9 @@ class DiscoveryState(TypedDict, total=False):
     # === Phase 4a: Pathway Enrichment ===
     shared_neighbors: Annotated[list[SharedNeighbor], operator.add]
     biological_themes: list[BiologicalTheme]
+    # Set True when Phase B (one-hop SDK/HTTP) was dropped as unreliable (issue #44).
+    # Plain single-writer boolean — pathway_enrichment is serial, so no reducer needed.
+    pathway_enrichment_degraded: bool
 
     # === Phase 4b: Integration (Bridges + Gap Analysis) ===
     bridges: Annotated[list[Bridge], operator.add]

--- a/backend/tests/test_pathway_enrichment.py
+++ b/backend/tests/test_pathway_enrichment.py
@@ -1,0 +1,150 @@
+"""Tests for pathway_enrichment Phase B degradation guard + HTTP migration (issue #44)."""
+
+import types
+from unittest.mock import AsyncMock
+
+import pytest
+
+from kestrel_backend.graph.nodes import pathway_enrichment as pe
+from kestrel_backend.graph.state import (
+    BiologicalTheme,
+    ModelUsageRecord,
+    SharedNeighbor,
+)
+
+
+# --- Fixtures / factories ---
+
+def _record(mcp_tool_calls: int, available_tools=None) -> ModelUsageRecord:
+    return ModelUsageRecord(
+        model_name="m",
+        node_name="pathway_enrichment",
+        mcp_tool_calls=mcp_tool_calls,
+        available_tools=available_tools,
+    )
+
+
+def _entity(curie: str, name: str = "N"):
+    return types.SimpleNamespace(curie=curie, method="exact", resolved_name=name, raw_name=name)
+
+
+def _novelty(curie: str, edge_count: int):
+    return types.SimpleNamespace(curie=curie, edge_count=edge_count)
+
+
+def _state():
+    return {
+        "resolved_entities": [_entity("CHEBI:1", "fructose"), _entity("CHEBI:2", "glucose")],
+        "novelty_scores": [_novelty("CHEBI:1", 50), _novelty("CHEBI:2", 60)],
+    }
+
+
+def _theme():
+    return BiologicalTheme(
+        category="biolink:BiologicalProcess",
+        members=["NCBIGene:9"],
+        member_names=["GENE9"],
+        input_coverage=2,
+    )
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    """Patch the always-present collaborators; individual tests patch query_with_usage/parse."""
+    monkeypatch.setattr(pe, "HAS_SDK", True)
+    monkeypatch.setattr(
+        pe, "find_two_hop_shared_neighbors",
+        AsyncMock(return_value=({"NCBIGene:9": 2}, [])),
+    )
+    return monkeypatch
+
+
+# --- Pure helper tests ---
+
+class TestBuildTwoHopFindings:
+    def test_empty(self):
+        assert pe._build_two_hop_findings({}) == []
+
+    def test_nonempty_is_tagged_two_hop(self):
+        out = pe._build_two_hop_findings({"NCBIGene:9": 2})
+        assert len(out) == 1
+        assert out[0].source == "pathway_enrichment_two_hop"
+
+
+class TestDegradedResultBuilder:
+    def test_drops_sdk_keeps_two_hop_and_flags(self):
+        two_hop = pe._build_two_hop_findings({"NCBIGene:9": 2})
+        rec = _record(0)
+        out = pe._degraded_phase_b_result(two_hop, ["base err"], rec, "mcp_zero_mcp_tool_calls")
+        assert out["shared_neighbors"] == []
+        assert out["biological_themes"] == []
+        assert out["direct_findings"] == two_hop
+        assert out["pathway_enrichment_degraded"] is True
+        assert any("degraded" in e for e in out["errors"])
+        assert out["model_usages"] == [rec]
+
+
+# --- run() integration tests ---
+
+class TestRunDegradation:
+    async def test_degraded_drops_sdk_keeps_two_hop(self, patched):
+        patched.setattr(
+            pe, "query_with_usage",
+            AsyncMock(return_value=(
+                "The Kestrel MCP tools are not available in my current tool set.",
+                _record(0),  # zero mcp tool calls
+            )),
+        )
+        # parse would yield SDK neighbors/themes, but degradation must discard them
+        patched.setattr(
+            pe, "parse_enrichment_result",
+            lambda text: (
+                [SharedNeighbor(curie="NCBIGene:9", name="G", category="biolink:Gene",
+                                degree=10, connected_inputs=["CHEBI:1", "CHEBI:2"])],
+                [_theme()],
+                [],
+            ),
+        )
+        out = await pe.run(_state())
+
+        assert out["pathway_enrichment_degraded"] is True
+        assert out["shared_neighbors"] == []
+        assert out["biological_themes"] == []
+        # only the HTTP-derived two-hop finding survives
+        assert [f.source for f in out["direct_findings"]] == ["pathway_enrichment_two_hop"]
+
+    async def test_healthy_keeps_sdk_findings(self, patched):
+        patched.setattr(
+            pe, "query_with_usage",
+            AsyncMock(return_value=('{"ok": true}', _record(2))),  # tools were used
+        )
+        patched.setattr(pe, "parse_enrichment_result", lambda text: ([], [_theme()], []))
+        out = await pe.run(_state())
+
+        assert out["pathway_enrichment_degraded"] is False
+        assert len(out["biological_themes"]) == 1
+        sources = {f.source for f in out["direct_findings"]}
+        assert "pathway_enrichment" in sources           # SDK theme finding kept
+        assert "pathway_enrichment_two_hop" in sources    # two-hop also present
+
+    async def test_drop_disabled_keeps_output_but_flags_degraded(self, patched):
+        patched.setattr(pe._config, "drop_findings_on_degraded", False)
+        patched.setattr(
+            pe, "query_with_usage",
+            AsyncMock(return_value=("not available in my current tool set", _record(0))),
+        )
+        patched.setattr(pe, "parse_enrichment_result", lambda text: ([], [_theme()], []))
+        out = await pe.run(_state())
+
+        # output retained ...
+        assert len(out["biological_themes"]) == 1
+        # ... but the run is still flagged degraded for disclosure
+        assert out["pathway_enrichment_degraded"] is True
+
+    async def test_exception_preserves_two_hop_findings(self, patched):
+        # A Phase B exception must not lose the staged Phase A two-hop findings (R5).
+        patched.setattr(pe, "query_with_usage", AsyncMock(side_effect=ValueError("boom")))
+        out = await pe.run(_state())
+
+        assert out["shared_neighbors"] == []
+        assert [f.source for f in out["direct_findings"]] == ["pathway_enrichment_two_hop"]

--- a/backend/tests/test_pathway_enrichment.py
+++ b/backend/tests/test_pathway_enrichment.py
@@ -9,7 +9,6 @@ from kestrel_backend.graph.nodes import pathway_enrichment as pe
 from kestrel_backend.graph.state import (
     BiologicalTheme,
     ModelUsageRecord,
-    SharedNeighbor,
 )
 
 
@@ -48,6 +47,17 @@ def _theme():
     )
 
 
+def _populated_prefetch():
+    edge = {"object": {"id": "NCBIGene:9"}, "predicate": "biolink:related_to"}
+    return (
+        {
+            "CHEBI:1": {"summary": "related_to: 1", "edges": [edge], "errored": False},
+            "CHEBI:2": {"summary": "related_to: 1", "edges": [edge], "errored": False},
+        },
+        False,  # no_data
+    )
+
+
 @pytest.fixture
 def patched(monkeypatch):
     """Patch the always-present collaborators; individual tests patch query_with_usage/parse."""
@@ -55,6 +65,11 @@ def patched(monkeypatch):
     monkeypatch.setattr(
         pe, "find_two_hop_shared_neighbors",
         AsyncMock(return_value=({"NCBIGene:9": 2}, [])),
+    )
+    # Stage 2: Phase B prefetches one-hop data via HTTP; default to a populated result.
+    monkeypatch.setattr(
+        pe, "prefetch_one_hop_neighbors",
+        AsyncMock(return_value=_populated_prefetch()),
     )
     return monkeypatch
 
@@ -144,37 +159,28 @@ class TestPrefetchOneHopNeighbors:
         assert no_data is True
 
 
-class TestRunDegradation:
-    async def test_degraded_drops_sdk_keeps_two_hop(self, patched):
-        patched.setattr(
-            pe, "query_with_usage",
-            AsyncMock(return_value=(
-                "The Kestrel MCP tools are not available in my current tool set.",
-                _record(0),  # zero mcp tool calls
-            )),
-        )
-        # parse would yield SDK neighbors/themes, but degradation must discard them
-        patched.setattr(
-            pe, "parse_enrichment_result",
-            lambda text: (
-                [SharedNeighbor(curie="NCBIGene:9", name="G", category="biolink:Gene",
-                                degree=10, connected_inputs=["CHEBI:1", "CHEBI:2"])],
-                [_theme()],
-                [],
-            ),
-        )
+class TestRunMigratedPhaseB:
+    """Stage 2 (issue #44): Phase B prefetches via HTTP and reasons in-prompt (no MCP)."""
+
+    async def test_no_data_degrades_and_keeps_two_hop(self, patched):
+        # Prefetch found <2 populated entities → degrade without running inference.
+        patched.setattr(pe, "prefetch_one_hop_neighbors", AsyncMock(return_value=({}, True)))
+        sdk = AsyncMock()
+        patched.setattr(pe, "query_with_usage", sdk)
         out = await pe.run(_state())
 
         assert out["pathway_enrichment_degraded"] is True
         assert out["shared_neighbors"] == []
         assert out["biological_themes"] == []
-        # only the HTTP-derived two-hop finding survives
         assert [f.source for f in out["direct_findings"]] == ["pathway_enrichment_two_hop"]
+        assert any("prefetch_no_data" in e for e in out["errors"])
+        sdk.assert_not_awaited()  # inference is skipped on the no-data path
 
-    async def test_healthy_keeps_sdk_findings(self, patched):
+    async def test_healthy_inference_keeps_sdk_findings(self, patched):
+        # Populated prefetch (default) + parseable inference output → findings kept.
         patched.setattr(
             pe, "query_with_usage",
-            AsyncMock(return_value=('{"ok": true}', _record(2))),  # tools were used
+            AsyncMock(return_value=('{"shared_neighbors": [], "themes": []}', _record(0))),
         )
         patched.setattr(pe, "parse_enrichment_result", lambda text: ([], [_theme()], []))
         out = await pe.run(_state())
@@ -185,19 +191,18 @@ class TestRunDegradation:
         assert "pathway_enrichment" in sources           # SDK theme finding kept
         assert "pathway_enrichment_two_hop" in sources    # two-hop also present
 
-    async def test_drop_disabled_keeps_output_but_flags_degraded(self, patched):
-        patched.setattr(pe._config, "drop_findings_on_degraded", False)
+    async def test_inert_mcp_classifier_does_not_flag_migrated_path(self, patched):
+        # Even if the inference text echoes the fallback phrase, allowed_tools=[] means
+        # the MCP classifier is inert — the run must NOT be flagged degraded.
         patched.setattr(
             pe, "query_with_usage",
-            AsyncMock(return_value=("not available in my current tool set", _record(0))),
+            AsyncMock(return_value=("those tools are not available in my current tool set",
+                                    _record(0))),
         )
         patched.setattr(pe, "parse_enrichment_result", lambda text: ([], [_theme()], []))
         out = await pe.run(_state())
 
-        # output retained ...
-        assert len(out["biological_themes"]) == 1
-        # ... but the run is still flagged degraded for disclosure
-        assert out["pathway_enrichment_degraded"] is True
+        assert out["pathway_enrichment_degraded"] is False
 
     async def test_exception_preserves_two_hop_findings(self, patched):
         # A Phase B exception must not lose the staged Phase A two-hop findings (R5).

--- a/backend/tests/test_pathway_enrichment.py
+++ b/backend/tests/test_pathway_enrichment.py
@@ -86,6 +86,64 @@ class TestDegradedResultBuilder:
 
 # --- run() integration tests ---
 
+def _conns(mapping):
+    """Build an async get_entity_connections stub returning per-curie results."""
+    async def _f(curie):
+        result = mapping[curie]
+        if isinstance(result, Exception):
+            raise result
+        return result
+    return _f
+
+
+def _ok(n_edges: int):
+    """A successful one_hop result (includes total_count, the non-errored marker)."""
+    return {"edges": [{"predicate": "biolink:related_to"}] * n_edges,
+            "summary": f"{n_edges} edges", "total_count": n_edges}
+
+
+def _errored():
+    """A failed one_hop result (no total_count key, like get_entity_connections failures)."""
+    return {"edges": [], "summary": "Query failed"}
+
+
+class TestPrefetchOneHopNeighbors:
+    async def test_two_populated_not_no_data(self, monkeypatch):
+        monkeypatch.setattr(pe, "get_entity_connections",
+                            _conns({"CHEBI:1": _ok(3), "CHEBI:2": _ok(2)}))
+        per_entity, no_data = await pe.prefetch_one_hop_neighbors(
+            [_entity("CHEBI:1"), _entity("CHEBI:2")])
+        assert no_data is False
+        assert per_entity["CHEBI:1"]["errored"] is False
+        assert per_entity["CHEBI:2"]["errored"] is False
+
+    async def test_one_errored_triggers_no_data(self, monkeypatch):
+        monkeypatch.setattr(pe, "get_entity_connections",
+                            _conns({"CHEBI:1": _ok(3), "CHEBI:2": _errored()}))
+        per_entity, no_data = await pe.prefetch_one_hop_neighbors(
+            [_entity("CHEBI:1"), _entity("CHEBI:2")])
+        assert no_data is True  # only 1 of 2 populated
+        assert per_entity["CHEBI:1"]["errored"] is False
+        assert per_entity["CHEBI:2"]["errored"] is True
+
+    async def test_genuine_empty_counts_as_unpopulated(self, monkeypatch):
+        # Non-errored but zero edges → not "real neighbor data" → no_data.
+        monkeypatch.setattr(pe, "get_entity_connections",
+                            _conns({"CHEBI:1": _ok(0), "CHEBI:2": _ok(0)}))
+        per_entity, no_data = await pe.prefetch_one_hop_neighbors(
+            [_entity("CHEBI:1"), _entity("CHEBI:2")])
+        assert no_data is True
+        assert per_entity["CHEBI:1"]["errored"] is False  # not an error, just empty
+
+    async def test_exception_marks_errored(self, monkeypatch):
+        monkeypatch.setattr(pe, "get_entity_connections",
+                            _conns({"CHEBI:1": _ok(3), "CHEBI:2": RuntimeError("boom")}))
+        per_entity, no_data = await pe.prefetch_one_hop_neighbors(
+            [_entity("CHEBI:1"), _entity("CHEBI:2")])
+        assert per_entity["CHEBI:2"]["errored"] is True
+        assert no_data is True
+
+
 class TestRunDegradation:
     async def test_degraded_drops_sdk_keeps_two_hop(self, patched):
         patched.setattr(

--- a/backend/tests/test_pathway_enrichment.py
+++ b/backend/tests/test_pathway_enrichment.py
@@ -205,9 +205,40 @@ class TestRunMigratedPhaseB:
         assert out["pathway_enrichment_degraded"] is False
 
     async def test_exception_preserves_two_hop_findings(self, patched):
-        # A Phase B exception must not lose the staged Phase A two-hop findings (R5).
+        # A Phase B exception must not lose the staged Phase A two-hop findings (R5),
+        # and must flag the run degraded so synthesis can disclose it (Greptile P1).
         patched.setattr(pe, "query_with_usage", AsyncMock(side_effect=ValueError("boom")))
         out = await pe.run(_state())
 
         assert out["shared_neighbors"] == []
+        assert out["pathway_enrichment_degraded"] is True
         assert [f.source for f in out["direct_findings"]] == ["pathway_enrichment_two_hop"]
+
+    async def test_timeout_flags_degraded_and_preserves_two_hop(self, patched):
+        import asyncio
+        patched.setattr(pe, "query_with_usage", AsyncMock(side_effect=asyncio.TimeoutError()))
+        out = await pe.run(_state())
+
+        assert out["pathway_enrichment_degraded"] is True
+        assert out["shared_neighbors"] == []
+        assert [f.source for f in out["direct_findings"]] == ["pathway_enrichment_two_hop"]
+
+
+class TestInferencePromptBuilder:
+    def test_skips_errored_entities(self):
+        # Greptile P2: errored-prefetch entities must not leak their exception text into
+        # the inference prompt as a "Predicate summary".
+        per_entity = {
+            "CHEBI:1": {"summary": "Error: boom", "edges": [], "errored": True},
+            "CHEBI:2": {
+                "summary": "related_to: 1",
+                "edges": [{"object": {"id": "NCBIGene:9"}, "predicate": "biolink:related_to"}],
+                "errored": False,
+            },
+        }
+        prompt = pe._build_inference_user_prompt(
+            [_entity("CHEBI:1"), _entity("CHEBI:2")], per_entity)
+
+        assert "Error: boom" not in prompt
+        assert "CHEBI:1" not in prompt          # errored block skipped entirely
+        assert "CHEBI:2" in prompt and "NCBIGene:9" in prompt

--- a/backend/tests/test_sdk_utils.py
+++ b/backend/tests/test_sdk_utils.py
@@ -380,3 +380,21 @@ class TestClassifyMcpDegradation:
             available_tools=["mcp__kestrel__one_hop_query", "mcp__kestrel__get_nodes"],
         )
         assert v.degraded is False
+
+    def test_tools_registered_zero_calls_no_phrase_not_degraded(self):
+        # init list confirms all expected tools present; zero calls + no phrase → not degraded
+        # (the model may legitimately skip tools — avoids a false positive for non-mandating nodes)
+        v = classify_mcp_degradation(
+            _KESTREL_EXPECTED, mcp_tool_calls=0, result_text="No shared neighbors found.",
+            available_tools=["mcp__kestrel__one_hop_query", "mcp__kestrel__get_nodes"],
+        )
+        assert v.degraded is False
+
+    def test_tools_registered_zero_calls_with_phrase_still_degraded(self):
+        # the phrase corroborator still trips even when the init list confirms tools present
+        v = classify_mcp_degradation(
+            _KESTREL_EXPECTED, mcp_tool_calls=0,
+            result_text="those tools are not available in my current tool set",
+            available_tools=["mcp__kestrel__one_hop_query", "mcp__kestrel__get_nodes"],
+        )
+        assert v.degraded is True

--- a/backend/tests/test_sdk_utils.py
+++ b/backend/tests/test_sdk_utils.py
@@ -12,6 +12,7 @@ from kestrel_backend.graph.sdk_utils import (
     SystemMessage,
     ToolUseBlock,
     chunk,
+    classify_mcp_degradation,
     create_agent_options,
     get_kestrel_mcp_config,
     query_with_usage,
@@ -322,3 +323,60 @@ class TestQueryWithUsageDiagnostics:
         assert record is not None
         assert record.mcp_tool_calls == 1
         assert record.available_tools is None
+
+
+_KESTREL_EXPECTED = ["mcp__kestrel__one_hop_query", "mcp__kestrel__get_nodes"]
+
+
+class TestClassifyMcpDegradation:
+    """Unit 2 (issue #44): structural MCP-degradation classifier."""
+
+    def test_zero_calls_with_phrase_high_confidence(self):
+        v = classify_mcp_degradation(
+            _KESTREL_EXPECTED, mcp_tool_calls=0,
+            result_text="The Kestrel MCP tools are not available in my current tool set.",
+        )
+        assert v.degraded is True
+        assert v.confidence == "high"  # phrase corroborates the structural signal
+
+    def test_zero_calls_no_phrase_structural(self):
+        v = classify_mcp_degradation(
+            _KESTREL_EXPECTED, mcp_tool_calls=0, result_text="Here are some shared pathways.",
+        )
+        assert v.degraded is True
+
+    def test_tools_used_not_degraded(self):
+        # Healthy run: at least one mcp call, even with no shared neighbors found.
+        v = classify_mcp_degradation(_KESTREL_EXPECTED, mcp_tool_calls=3, result_text="")
+        assert v.degraded is False
+
+    def test_empty_expected_never_degraded(self):
+        # Data-in-prompt nodes (allowed_tools=[]) must never be flagged, even with the phrase.
+        v = classify_mcp_degradation(
+            [], mcp_tool_calls=0, result_text="not available in my current tool set",
+        )
+        assert v.degraded is False
+
+    def test_phrase_alone_does_not_trigger(self):
+        # Tools were used but the text contains the phrase → not degraded (phrase is corroborator only).
+        v = classify_mcp_degradation(
+            _KESTREL_EXPECTED, mcp_tool_calls=2,
+            result_text="those tools are not available for everything",
+        )
+        assert v.degraded is False
+
+    def test_definitive_missing_from_init(self):
+        # init tool list lacks an expected tool → definitive degraded, even if a call happened.
+        v = classify_mcp_degradation(
+            _KESTREL_EXPECTED, mcp_tool_calls=1, result_text="",
+            available_tools=["mcp__kestrel__one_hop_query", "Bash"],  # get_nodes missing
+        )
+        assert v.degraded is True
+        assert v.confidence == "definitive"
+
+    def test_all_expected_present_and_used_not_degraded(self):
+        v = classify_mcp_degradation(
+            _KESTREL_EXPECTED, mcp_tool_calls=2, result_text="",
+            available_tools=["mcp__kestrel__one_hop_query", "mcp__kestrel__get_nodes"],
+        )
+        assert v.degraded is False

--- a/backend/tests/test_sdk_utils.py
+++ b/backend/tests/test_sdk_utils.py
@@ -9,6 +9,8 @@ from kestrel_backend.graph.sdk_utils import (
     KESTREL_ARGS,
     KESTREL_COMMAND,
     ResultMessage,
+    SystemMessage,
+    ToolUseBlock,
     chunk,
     create_agent_options,
     get_kestrel_mcp_config,
@@ -245,3 +247,78 @@ class TestQueryWithUsage:
 
         with pytest.raises(RuntimeError, match="SDK is not available"):
             await query_with_usage("p", MagicMock(), "test")
+
+
+# --- Helper factories for MCP-diagnostics events (Unit 1, issue #44) ---
+
+def _make_tool_use_event(name: str):
+    """Create a mock event carrying a single ToolUseBlock content block."""
+    block = MagicMock(spec=ToolUseBlock)  # spec => isinstance True, no .text attr
+    block.name = name
+    event = MagicMock(spec=[])  # no .usage
+    event.content = [block]
+    return event
+
+
+def _make_init_event(tools):
+    """Create a mock SystemMessage(subtype='init', data={'tools': [...]})."""
+    event = MagicMock(spec=SystemMessage)
+    event.subtype = "init"
+    event.data = {"tools": tools}
+    return event
+
+
+class TestQueryWithUsageDiagnostics:
+    """Unit 1 (issue #44): MCP tool-availability diagnostics on ModelUsageRecord."""
+
+    async def test_counts_mcp_tool_calls(self, monkeypatch):
+        """Only mcp__* tool-use blocks are counted; non-mcp tools are ignored."""
+        events = [
+            _make_init_event(["Bash", "mcp__kestrel__one_hop_query", "mcp__kestrel__get_nodes"]),
+            _make_tool_use_event("mcp__kestrel__one_hop_query"),
+            _make_tool_use_event("Bash"),  # not counted
+            _make_tool_use_event("mcp__kestrel__get_nodes"),
+            _make_text_event("done"),
+            _make_result_message({"input_tokens": 1, "output_tokens": 1,
+                                  "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}),
+        ]
+        monkeypatch.setattr("kestrel_backend.graph.sdk_utils.query", lambda **kw: _mock_query_gen(events))
+        monkeypatch.setattr("kestrel_backend.graph.sdk_utils.HAS_SDK", True)
+
+        text, record = await query_with_usage("p", MagicMock(), "pathway_enrichment")
+
+        assert text == "done"
+        assert record is not None
+        assert record.mcp_tool_calls == 2
+        assert record.available_tools == ["Bash", "mcp__kestrel__one_hop_query", "mcp__kestrel__get_nodes"]
+
+    async def test_zero_mcp_tool_calls(self, monkeypatch):
+        """A run with no tool-use blocks reports mcp_tool_calls == 0 (the degraded signal)."""
+        events = [
+            _make_text_event("I cannot use those tools"),
+            _make_result_message({"input_tokens": 1, "output_tokens": 1,
+                                  "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}),
+        ]
+        monkeypatch.setattr("kestrel_backend.graph.sdk_utils.query", lambda **kw: _mock_query_gen(events))
+        monkeypatch.setattr("kestrel_backend.graph.sdk_utils.HAS_SDK", True)
+
+        _, record = await query_with_usage("p", MagicMock(), "pathway_enrichment")
+
+        assert record is not None
+        assert record.mcp_tool_calls == 0
+
+    async def test_available_tools_none_without_init_event(self, monkeypatch):
+        """When no SystemMessage init event is present, available_tools degrades to None."""
+        events = [
+            _make_tool_use_event("mcp__kestrel__one_hop_query"),
+            _make_result_message({"input_tokens": 1, "output_tokens": 1,
+                                  "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}),
+        ]
+        monkeypatch.setattr("kestrel_backend.graph.sdk_utils.query", lambda **kw: _mock_query_gen(events))
+        monkeypatch.setattr("kestrel_backend.graph.sdk_utils.HAS_SDK", True)
+
+        _, record = await query_with_usage("p", MagicMock(), "pathway_enrichment")
+
+        assert record is not None
+        assert record.mcp_tool_calls == 1
+        assert record.available_tools is None

--- a/docs/plans/2026-06-01-001-fix-pathway-enrichment-mcp-degradation-plan.md
+++ b/docs/plans/2026-06-01-001-fix-pathway-enrichment-mcp-degradation-plan.md
@@ -1,0 +1,324 @@
+---
+title: "fix: Guard + migrate pathway_enrichment Phase B off broken stdio MCP (#44)"
+type: fix
+status: active
+date: 2026-06-01
+deepened: 2026-06-01
+---
+
+# fix: Guard + migrate pathway_enrichment Phase B off broken stdio MCP (#44)
+
+## Overview
+
+Issue #44 reports that the `pathway_enrichment` Phase B SDK agent intermittently announces *"The Kestrel MCP tools … are not available in my current tool set"* and then hallucinates one-hop analysis from training-data knowledge. A multi-agent investigation (see Sources) found the cause is **not** a race: the SDK stdio MCP server is configured to launch `uvx mcp-client-kestrel` (`graph/sdk_utils.py:35-36`), but **that package does not exist on PyPI** — already discovered and documented in `graph/nodes/cold_start.py:13-18`, where PR #24 migrated cold_start to direct HTTP for exactly this reason. The tools never register; the agent's report is literally true; the "intermittency" is just `uvx` cold-resolution failing different ways per spawn.
+
+This plan is organized as two work stages, **delivered together in a single PR** (decision below). Landing the guard and the migration at once means real HTTP data flows from the moment it merges, so there is no interim window where Phase B renders an empty enrichment section:
+1. **Guard + instrumentation** (low-risk, additive): detect the degraded condition structurally, drop the hallucinated findings, flag the run as degraded, and add diagnostics at the shared SDK layer so the same latent failure becomes observable across all SDK nodes.
+2. **HTTP migration** (durable fix): convert Phase B to fetch one-hop data via the HTTP Kestrel client and reason over it in-prompt, mirroring the proven `cold_start` / PR #24 pattern — eliminating the stdio MCP dependency entirely.
+
+## Problem Frame
+
+`pathway_enrichment` runs two sub-analyses: **Phase A** two-hop shared-neighbor analysis over the **HTTP** client (`find_two_hop_shared_neighbors` → `multi_hop_query`, `pathway_enrichment.py:170-256,342-348`) which always works, and **Phase B** one-hop analysis via the **SDK + stdio MCP** (`pathway_enrichment.py:370-440`) which is the only stdio-MCP call and is broken. "Kestrel is operational" in the issue refers to the healthy HTTP endpoint and says nothing about the stdio subprocess. Under `permission_mode="bypassPermissions"` and `max_turns=25`, the tool-less agent fills the gap by fabricating shared neighbors, which then flow into Integration and Synthesis as if KG-grounded — a correctness/credibility risk in a research-grade pipeline.
+
+## Requirements Trace
+
+- R1. Hallucinated `pathway_enrichment` (Phase B) output must not propagate to Integration/Synthesis. (#44 core risk)
+- R1b. The same broken stdio path exists in five other SDK nodes; that pipeline-wide hallucination exposure is explicitly out of scope here, acknowledged, and tracked under a separate issue. Stage 1 instrumentation quantifies it. (R1 is scoped to one node — it is not a pipeline-wide guarantee.)
+- R2. When Phase B is degraded, the run must be flagged so downstream nodes and the UI can disclose the gap.
+- R3. The degraded condition must be detectable from a structural signal, not a brittle string match alone.
+- R4. Phase B must obtain real one-hop KG data instead of relying on the nonexistent stdio MCP server (durable fix).
+- R5. Phase A two-hop findings (real, HTTP-derived) must be preserved even when Phase B is dropped.
+- R6. No behavioral change to the other five SDK nodes in this work; surface their shared latent exposure for separate follow-up.
+
+## Scope Boundaries
+
+- Not changing Phase A (`find_two_hop_shared_neighbors`, HTTP) — it works.
+- Not changing the HTTP `kestrel_client`, `graph/builder.py` topology, or working nodes' semaphores.
+- Not touching classic-mode `agent.py:86` stdio config (separate surface, classic mode).
+- Not adding a feature to detect *every* form of SDK misbehavior — scope is MCP-tool-unavailability degradation.
+
+### Deferred to Separate Tasks
+
+- **Migrate the other five SDK nodes off the broken stdio MCP** (`entity_resolution`, `direct_kg`, `integration`, `temporal`, `triage` — all call `get_kestrel_mcp_config()` + `mcp_servers={"kestrel": …}`): file a new issue. They have HTTP primary tiers that mask the SDK-tier degradation to varying degrees; each needs an individual audit. Stage 1 instrumentation here will quantify their exposure first. **Verify the "HTTP primary tier" claim per node before relying on it** — two cases are higher-severity than Phase B: (a) if `entity_resolution`'s SDK tier has no HTTP fallback, degraded CURIE resolution would poison *every* downstream node (including the fixed `pathway_enrichment`); (b) `integration` is both a *consumer* of pathway_enrichment output and itself a broken stdio node, so even after this plan its own SDK call can still hallucinate into Synthesis.
+- **Add `pathway_enrichment` to the `get_semaphore` map** (`pipeline_config.py:207-215` omits it): becomes moot once Stage 2 acquires `SDK_SEMAPHORE` directly (mirroring cold_start), so handled inside Unit 5 rather than as standalone work.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **Canonical HTTP precedent:** `graph/nodes/cold_start.py:1-18,460,490` — `allowed_tools=[]`, prefetch KG data via HTTP `call_kestrel_tool(...)`, `max_turns=1`, `async with SDK_SEMAPHORE`, reason over real data in-prompt. Stage 2 mirrors this exactly. Do not invent a new approach.
+- **Broken config:** `graph/sdk_utils.py:35-50` (`KESTREL_COMMAND="uvx"`, `KESTREL_ARGS=["mcp-client-kestrel"]`, `get_kestrel_mcp_config()` builds `McpStdioServerConfig` with no `env`).
+- **SDK stream loop:** `graph/sdk_utils.py:120-202` `query_with_usage` — iterates `async for event in query(...)`, collects text + usage; the natural place to also count `mcp__*` tool-use blocks and capture the init tool list.
+- **Phase B target:** `graph/nodes/pathway_enrichment.py:370-440` (options, `wait_for` timeout, parse, findings build); output dict keys `shared_neighbors` / `biological_themes` / `errors`.
+- **Usage record:** `graph/state.py:287` `ModelUsageRecord` — extend with optional diagnostics fields (additive, non-breaking).
+- **Two-tier patterns** in `direct_kg.py` show how nodes blend HTTP Tier-1 with SDK Tier-2 — context for the deferred multi-node migration.
+
+### Institutional Learnings
+
+- `docs/solutions/developer-experience/pytest-venv-path-spaces-module-invocation-2026-06-01.md` — run backend tests with `uv run python -m pytest` (the venv-path-spaces shebang trap); applies to executing this plan's tests.
+- `cold_start.py` docstring is itself the institutional record of the `mcp-client-kestrel`-doesn't-exist discovery + the HTTP remedy.
+
+### External References
+
+- None required — strong local precedent (`cold_start` / PR #24). The investigation workflow served as the deep research.
+
+## Key Technical Decisions
+
+- **Drop + flag degraded (no retry).** The earlier "retry once" idea is abandoned: retry cannot recover a nonexistent package and would only double latency under the 480s timeout. Dropping the fabricated findings while preserving Phase A is the correctness-safe default. (Reversal of an initial choice, justified by the root-cause finding.)
+- **Guard/instrumentation live in `graph/sdk_utils.py` (shared), behavior change piloted on pathway_enrichment only.** Gives cross-node observability now without widening blast radius.
+- **Structural signal is authoritative; phrase is a corroborator.** Degraded = expected tools were allowlisted AND zero `mcp__*` tool calls occurred (or the init tool list lacks them). The fallback phrase only raises confidence/logging. This avoids brittleness and false positives.
+- **Empty allowlist never degrades.** The classifier keys off a non-empty `expected_tools`. Post-migration Phase B uses `allowed_tools=[]` (data-in-prompt), so the guard correctly never fires there and remains an inert safety net.
+- **Phase B migration mirrors cold_start, including `SDK_SEMAPHORE`.** This simultaneously fixes the missing-semaphore gap (`pipeline_config.py:207-215`) without retrofitting working nodes.
+- **Behind a config flag** (`drop_findings_on_degraded`, default `True`) for rollback, consistent with the repo's `pipeline_config` flag convention.
+- **Single-PR delivery** (both stages together). Because the HTTP migration lands in the same PR, real Phase B data flows on merge — so `drop_findings_on_degraded=True` is a safe default with no interim window where the enrichment section renders empty. The MCP-degradation guard becomes a rarely-firing safety net; the Stage-2 emptiness guard is what actually protects the migrated node.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Root cause? Broken `uvx mcp-client-kestrel` stdio server (H1), not a race — confirmed by `cold_start.py:13-18` + PR #24 + an empirical `uvx` resolution check in the investigation.
+- Guard action? Drop + flag degraded (user decision).
+- Scope and delivery? Both work stages in a **single PR** (user decision) — guard + HTTP migration land together, so there is no interim window of degraded/empty enrichment output.
+
+### Deferred to Implementation
+
+- Exact SDK event/attribute that carries the "available tools at init" list — capture best-effort; degrade to `None` if the SDK version doesn't expose it. The `mcp__*` tool-use **count** is the reliable structural signal regardless.
+- Whether `parse_enrichment_result` can be reused unchanged for the migrated in-prompt inference output, or needs a light prompt/parse adaptation to keep schema parity. (Note: it silently returns empty on `JSONDecodeError` — a malformed migrated response degrades to empty, which must be counted as "no data" by the emptiness guard, not as a healthy empty result.)
+- Whether the LangGraph `operator.add` reducer treats an **absent** `direct_findings` key as a no-op contribution (current `except` handler omits it). This determines whether the Unit 3 independence fix must *explicitly* add `direct_findings=<staged two-hop>` to the rewritten `except` branch (assume yes — emit it explicitly).
+- The concrete **interface shape** between Unit 4's emptiness signal and Unit 5's guard (per-entity `errored: bool` + a populated-entity count, vs. a sentinel return). Pin it in Unit 4's return type so Unit 5 can't misread "errored-empty" as "healthy-empty."
+- Whether the emptiness guard counts populated entities **before or after** hub-filtering. Counting raw non-errored entities lets an exactly-2-entity run where one entity's neighbors are *all* hubs slip past the gate (rare at `edge_count >= 20`, and Phase A two-hop still grounds the output, so degraded-but-not-fabricated). If cheap, count post-hub-filter *usable* neighbors instead.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```
+Phase B today (broken):
+  options{ allowed_tools=[mcp__kestrel__*], mcp_servers={kestrel: uvx mcp-client-kestrel} }
+     └─ query_with_usage ──► stdio subprocess FAILS to launch ──► 0 tools ──► model hallucinates
+                                                                                  └─► fabricated shared_neighbors ─► Integration/Synthesis  ❌
+
+Stage 1 (guard + instrumentation):
+  query_with_usage now also reports: mcp_tool_calls, available_tools
+     └─ classify_mcp_degradation(expected=[mcp__kestrel__*], calls=0, text, available)
+            └─ degraded=true ─► drop SDK findings, KEEP Phase A two-hop, set degraded flag, log diagnostic  ✅
+
+Stage 2 (durable fix, mirrors cold_start):
+  prefetch one-hop via HTTP call_kestrel_tool(...)  ─►  options{ allowed_tools=[], SDK_SEMAPHORE, max_turns~1 }
+     └─ model reasons over REAL data in-prompt ─► real shared_neighbors (expected_tools=[] ⇒ guard inert)  ✅
+```
+
+## Implementation Units
+
+### Stage 1 — Guard + Instrumentation (implement first within the single PR)
+
+- [ ] **Unit 1: Capture MCP tool-availability diagnostics in `query_with_usage`**
+
+**Goal:** Make every SDK node's tool registration and MCP tool-call count observable, without changing any node's behavior.
+
+**Requirements:** R3 (foundation), R6 (observability for deferred work)
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `backend/src/kestrel_backend/graph/sdk_utils.py` (the `query_with_usage` event loop, ~120-202)
+- Modify: `backend/src/kestrel_backend/graph/state.py` (`ModelUsageRecord`, ~287 — add optional `mcp_tool_calls: int = 0`, `available_tools: list[str] | None = None`)
+- Test: `backend/tests/test_sdk_utils.py`
+
+**Approach:**
+- In the `async for event` loop, count tool-use blocks using the **codebase-proven** predicate, not a string `type` check: `isinstance(block, ToolUseBlock) and block.name.startswith("mcp__")` (mirror `agent.py:429-430`). `ToolUseBlock` is a dataclass with `name`/`input`/`id` and **no `.type` attribute** — a `block.type == "tool_use"` check would always count 0 and false-flag every healthy run as degraded. Import `ToolUseBlock` into the central SDK import block in `sdk_utils.py` (it is not currently imported there).
+- Best-effort capture the init tool list: the SDK delivers it as `SystemMessage(subtype="init", data={...})`, which has `.data` (not `.content`), so the current `hasattr(event, "content")` loop skips it. Add a branch `if isinstance(event, SystemMessage) and event.subtype == "init": available_tools = event.data.get(...)`. Import `SystemMessage` too. Keep the `None` fallback for SDK versions/streams that omit it — the tool-use **count** remains the authoritative signal.
+- **Absent-SDK safety:** add `ToolUseBlock` and `SystemMessage` to the `except ImportError` branch as **sentinel stub classes** (a dummy `class`, exactly like the existing `_ResultMessageStub` at `sdk_utils.py:28-32`), **not** `= None`. With `= None`, the new `isinstance(...)` checks would raise `TypeError` when `HAS_SDK is False` (e.g. in tests, or any caller reaching the loop without the SDK). The existing `query_with_usage` early-returns before the loop when `HAS_SDK is False` (`sdk_utils.py:141`), so production is safe, but the stub pattern keeps the instrumentation and its tests robust.
+- Because `ModelUsageRecord` is **frozen** (`ConfigDict(frozen=True)`, `state.py:294`), pass both new fields as **constructor arguments** at the single construction site (`sdk_utils.py:193-200`) — not via post-construction assignment, which would raise. Emit one diagnostic log line per node (registered? / call count). Keep the `(text, record)` return arity unchanged so existing callers are unaffected.
+
+**Execution note:** Test-first — pure, deterministic given a fake event stream. Include a test that feeds a real-shaped `ToolUseBlock` so a healthy stream increments the count (guards against the false-positive-degraded trap above).
+
+**Patterns to follow:** `agent.py:429-430` (`isinstance(block, ToolUseBlock)` tool detection); existing usage-accumulation loop in the same function; `ModelUsageRecord` construction at `sdk_utils.py:193-200`.
+
+**Test scenarios:**
+- Happy path: stream with three `mcp__kestrel__*` `tool_use` blocks → `record.mcp_tool_calls == 3`.
+- Edge case: stream with no `tool_use` blocks → `mcp_tool_calls == 0`.
+- Edge case: init/system event exposes a tool list → `available_tools` populated; init event absent → `available_tools is None` with no error.
+- Integration: an existing caller that unpacks `(text, record)` still works (no arity change).
+
+**Verification:** `ModelUsageRecord` carries accurate `mcp_tool_calls` for representative streams; a diagnostic line is logged per SDK call; no existing `query_with_usage` caller breaks.
+
+- [ ] **Unit 2: Shared MCP-degradation classifier in `sdk_utils.py`**
+
+**Goal:** One reusable decision function that flags the "tools unavailable → hallucinated" condition from structural signals.
+
+**Requirements:** R1, R3
+
+**Dependencies:** Unit 1 (consumes `mcp_tool_calls` / `available_tools`)
+
+**Files:**
+- Modify: `backend/src/kestrel_backend/graph/sdk_utils.py` (add `classify_mcp_degradation(...)` returning a small verdict object: `degraded: bool`, `reason: str`, `confidence: str`)
+- Test: `backend/tests/test_sdk_utils.py`
+
+**Approach:**
+- Inputs: `expected_tools` (the allowlist), `mcp_tool_calls`, `result_text`, `available_tools` (optional).
+- Degraded when `expected_tools` is non-empty AND (`available_tools` is known and lacks an expected tool → definitive) OR (`mcp_tool_calls == 0` → structural). The fallback-phrase regex (`not available in my current tool set` / `are not available`) is a corroborator that raises confidence and is logged — never the sole trigger.
+- When `expected_tools` is empty → always `degraded=False` (protects data-in-prompt nodes like cold_start and post-migration Phase B).
+- **Caveat for shared reuse:** the bare `mcp_tool_calls == 0` signal is only safe for nodes whose prompt *mandates* tool use (pathway_enrichment's `PATHWAY_ENRICHMENT_PROMPT` STEP 1 requires a `one_hop_query` per entity, so a healthy run always has ≥1 call). For a node where zero tool calls is a legitimate model choice, count==0 would false-positive — such nodes must require the init-list signal OR the corroborating phrase, not bare count. Carry this constraint into the deferred multi-node migration issue.
+
+**Execution note:** Test-first — pure logic.
+
+**Patterns to follow:** small pure helpers already in `sdk_utils.py` (e.g. `chunk`).
+
+**Test scenarios:**
+- Error path: expected non-empty + zero calls + phrase present → degraded, high confidence.
+- Error path: expected non-empty + zero calls + no phrase → degraded (structural).
+- Happy path: expected non-empty + ≥1 call → not degraded (honest run, even with zero shared neighbors).
+- Edge case: `expected_tools == []` + zero calls → not degraded (data-in-prompt node).
+- Edge case: `available_tools` provided and missing an expected tool, phrase absent → degraded (definitive, pre-first-turn signal).
+
+**Verification:** classifier returns correct verdicts across the matrix; an honest no-results run with tools available is never flagged; an empty allowlist is never flagged.
+
+- [ ] **Unit 3: Apply drop-on-degraded guard + `degraded` flag in pathway_enrichment Phase B**
+
+**Goal:** Stop fabricated Phase B findings from propagating; disclose the degraded run; preserve Phase A.
+
+**Requirements:** R1, R2, R5
+
+**Dependencies:** Units 1, 2
+
+**Files:**
+- Modify: `backend/src/kestrel_backend/graph/nodes/pathway_enrichment.py` (Phase B, after parse, ~405-440)
+- Modify: `backend/src/kestrel_backend/graph/state.py` — `DiscoveryState` has **no** degraded field today, so add one explicitly: name it `pathway_enrichment_degraded: bool` (default `False`). Use a **plain boolean, no reducer** — `pathway_enrichment` is a *serial* node (both `direct_kg`/`cold_start` branches edge **into** it; it is not a concurrent writer of its own output, `builder.py:154-155`), so single-writer last-write semantics are correct. Do **not** reach for `Annotated[list, operator.add]`. (A `degraded_nodes: list` would need that reducer; a per-node boolean avoids the question.)
+- Modify: `backend/src/kestrel_backend/graph/pipeline_config.py` — add a `drop_findings_on_degraded: bool = True` field to the **existing** `PathwayEnrichmentConfig` (`pipeline_config.py:61`). It is already registered on `PipelineConfig` (`:182`) — do **not** create a new class or re-register.
+- Test: `backend/tests/test_pathway_enrichment.py` (new)
+
+**Approach:**
+- After `query_with_usage` + `parse_enrichment_result`, call `classify_mcp_degradation(expected_tools=["mcp__kestrel__one_hop_query","mcp__kestrel__get_nodes"], mcp_tool_calls=record.mcp_tool_calls, result_text, available_tools=record.available_tools)`.
+- If degraded and `config.drop_findings_on_degraded`: discard the **SDK-derived** `shared_neighbors`, `biological_themes`, and SDK-derived `findings`; **keep the Phase A two-hop findings** (HTTP-derived); set the degraded marker; emit a structured degraded-run log (node, tripped signal, offending tool list); add an explanatory `errors`/notice entry.
+- **Discriminator (named):** SDK theme findings carry `source="pathway_enrichment"` (`pathway_enrichment.py:431`); Phase A two-hop findings carry `source="pathway_enrichment_two_hop"` (`:444`). On degrade, build findings from the two-hop set only and skip the SDK theme-findings loop (`:419-433`); return `shared_neighbors=[]` and `biological_themes=[]`. Do the filtering **inside** `run()` before assembling the result dict. The three output keys differ in reducer semantics: `direct_findings` is cross-node **additive** (`operator.add`, `state.py:348`) so SDK findings must be filtered *before* emit (additive reducers can't subtract after merge); `shared_neighbors` is additive but pathway-owned (emitting `[]` adds nothing — safe); `biological_themes` has **no** reducer (`state.py:360`) and is single-writer, so emitting `[]` is a clean overwrite — do **not** add `operator.add` to it.
+- **Independence fix (must be complete):** the two-hop *neighbors* are already computed outside the `try` (`pathway_enrichment.py:342-348`), but the two-hop **Finding objects**, the `result_dict` assembly, and the `return` all sit *inside* the Phase B `try` (~`:435-465`), and the `except` handler (`:467-474`) returns a hardcoded `{shared_neighbors:[], biological_themes:[], errors:[…]}` with **no `direct_findings` key at all**. So merely "computing two-hop outside the try" does not satisfy R5 — a Phase B exception still drops the two-hop findings. The fix must also: (a) stage the two-hop `Finding` objects in an enclosing-scope variable, and (b) **rewrite the `except` handler to return `direct_findings=<staged two-hop findings>`** (and confirm whether an absent `direct_findings` key is a reducer no-op vs. required — see Deferred). Add a test that a Phase B *exception* (not just a degraded classification) preserves two-hop findings.
+- **Shared degraded helper:** factor the degraded side-effects (set `pathway_enrichment_degraded=True`, keep two-hop, emit notice + structured log) into a small helper that takes an explicit `reason`. Call it here with `reason="mcp_unavailable"`; Unit 5's emptiness path reuses it with `reason="prefetch_no_data"` instead of routing through the MCP classifier (whose "zero mcp calls" reason is misleading for a no-MCP node).
+
+**Execution note:** Characterization-first — capture the current Phase B output schema before changing it, so the drop path and the healthy path are both pinned.
+
+**Patterns to follow:** existing config-flag pattern (`DirectKGConfig.multi_hop_enabled`, `IntegrationConfig`); the existing timeout-return shape in Phase B (`pathway_enrichment.py:399-403`).
+
+**Test scenarios:**
+- Error path: degraded transcript (zero `mcp__*` calls + fallback phrase) → output has degraded marker, no SDK `shared_neighbors`/`biological_themes`, Phase A two-hop findings retained.
+- Happy path: healthy transcript (≥1 tool call, valid JSON) → not degraded, SDK findings present.
+- Edge case: `drop_findings_on_degraded=False` → output retained but degraded still logged (flag regression guard).
+- Error path: Phase B raises an exception → Phase A two-hop findings are still present in the output (independence fix; not only the degraded-classification path).
+- Edge case: `HAS_SDK is False` → existing placeholder path unchanged.
+
+**Verification:** with a simulated fallback transcript the pipeline carries `degraded=true` and zero fabricated SDK neighbors while retaining real two-hop findings; with a healthy transcript behavior is unchanged.
+
+### Stage 2 — HTTP migration of Phase B (durable fix; same PR)
+
+- [ ] **Unit 4: HTTP one-hop prefetch for Phase B entities**
+
+**Goal:** Fetch real one-hop neighbor data via HTTP rather than MCP tools.
+
+**Requirements:** R4
+
+**Dependencies:** Stage 1 units (guard in place as safety net)
+
+**Files:**
+- Modify: `backend/src/kestrel_backend/graph/nodes/pathway_enrichment.py` (new prefetch helper, e.g. `prefetch_one_hop_neighbors(entities)`)
+- Test: `backend/tests/test_pathway_enrichment.py`
+
+**Approach:**
+- Mirror `cold_start`'s `get_entity_connections` (`cold_start.py:148-224`): for each selected entity, `call_kestrel_tool("one_hop_query", {...})` via the HTTP client; `asyncio.gather(..., return_exceptions=True)`; optionally `get_nodes` for degree/hub flags. Build a structured neighbor summary for the prompt. Reuse hub thresholds from `pipeline_config`.
+- `pathway_enrichment.py` does **not** yet import `call_kestrel_tool` (only `multi_hop_query`) — add the import. Use the **HTTP param shape** from `get_entity_connections` (`call_kestrel_tool("one_hop_query", {"start_node_ids": …})`), **not** the `one_hop_query(curie=…)` signature shown in `PATHWAY_ENRICHMENT_PROMPT` (that's the MCP-tool form; copying it would pass the wrong argument).
+- **Emptiness signal (feeds Unit 5's guard) — threshold matters:** every Phase B entity is *guaranteed dense* (`edge_count >= MIN_EDGE_COUNT = 20`, filtered at `pathway_enrichment.py:299`), so an empty one-hop result for such an entity is almost never genuine sparsity — it is overwhelmingly an HTTP/parse/API failure. But `get_entity_connections` collapses *all* failure modes (query-failed, no-content, parse-error, API-error, exception) into the **same** `{"edges": [], …}` shape, indistinguishable from a real empty. Two consequences: (a) propagate a per-entity **`errored: bool`** so success is not merely inferred from non-empty `edges`; (b) the guard must fire when **fewer than 2 entities returned real (non-errored) neighbor data**, not only when *all* are empty — shared-neighbor analysis is meaningless below 2 populated entities, and with the documented 2-entity minimum a *single* silent failure already makes the prompt sparse and hallucination-prone.
+
+**Patterns to follow:** `cold_start.py:148-224` (`get_entity_connections`: `call_kestrel_tool("one_hop_query", …)` with per-entity exception handling); `cold_start.py:440-460` (the gather site).
+
+**Test scenarios:**
+- Happy path: mocked `call_kestrel_tool` → neighbors parsed and grouped per entity.
+- Error path: one entity's call raises → that entity is marked `errored=True` (distinct from a genuine empty result) + a warning; other entities still succeed.
+- Error path: fewer than 2 entities return real non-errored data (e.g. 1 of 2 silently fails) → prefetch reports the "no data" emptiness signal, even though one entity succeeded.
+- Edge case: hub neighbors filtered/flagged per the configured threshold.
+
+**Verification:** given mocked HTTP responses, the helper returns per-entity one-hop neighbor data with hub handling and resilient error behavior.
+
+- [ ] **Unit 5: Convert Phase B SDK call to data-in-prompt inference (no MCP)**
+
+**Goal:** Replace the broken stdio MCP SDK config with cold_start-style inference over prefetched data.
+
+**Requirements:** R4, R5
+
+**Dependencies:** Unit 4
+
+**Files:**
+- Modify: `backend/src/kestrel_backend/graph/nodes/pathway_enrichment.py` (Phase B options + prompt; add an inference prompt constant if needed; define a module-level `SDK_SEMAPHORE`)
+- Modify: `backend/src/kestrel_backend/graph/pipeline_config.py` (add an `sdk_semaphore` field to `PathwayEnrichmentConfig` — it currently has only `hub_threshold`)
+- Test: `backend/tests/test_pathway_enrichment.py`
+
+**Approach:**
+- `pathway_enrichment.py` has **no** module-level `SDK_SEMAPHORE` today, and `PathwayEnrichmentConfig` has no `sdk_semaphore` field. So "acquire `SDK_SEMAPHORE`" requires first adding the config field and defining `SDK_SEMAPHORE = asyncio.Semaphore(_config.sdk_semaphore)` at module level, mirroring `cold_start.py:42`. Do **not** add `pathway_enrichment` to the `get_semaphore()` map (`pipeline_config.py:201-216`) — the module-level `SDK_SEMAPHORE` pattern is canonical (cold_start uses it directly and never calls `get_semaphore()`); leaving the map alone avoids introducing a `ValueError` surface.
+- Build options with `allowed_tools=[]`, small `max_turns` (1–2), `async with SDK_SEMAPHORE` (this also closes the missing-semaphore gap), and **no** `mcp_servers` / `get_kestrel_mcp_config`. Feed the Unit 4 prefetched data into an inference prompt; parse to the same output schema (`shared_neighbors`, `biological_themes`) via `parse_enrichment_result` (adapt prompt/parse only as needed for parity).
+- **Post-migration emptiness guard:** the MCP classifier is inert here (`expected_tools == []` ⇒ never degraded) **by design** — so it no longer protects this node. Add an independent check: if Unit 4's prefetch reports the "no data" emptiness signal (**fewer than 2 entities returned real non-errored neighbor data**), mark Phase B degraded via the **shared helper with `reason="prefetch_no_data"`** (Unit 3) and skip inference rather than running it on a sparse prompt and re-hallucinating. Do **not** route this through the MCP classifier. State the interaction in code comments.
+
+**Execution note:** Characterization-first — assert output-schema parity with the pre-migration healthy path.
+
+**Patterns to follow:** `cold_start.py:481-495` (`allowed_tools=[]`, `max_turns=1`, `SDK_SEMAPHORE`, inference prompt with embedded KG data, `HAS_SDK` graceful fallback).
+
+**Test scenarios:**
+- Happy path: mocked prefetch + mocked SDK JSON → `shared_neighbors` derived from real data; schema parity with pre-migration.
+- Edge case: `HAS_SDK is False` → graceful return mirroring cold_start.
+- Integration: migrated Phase B output merges with Phase A two-hop findings exactly as before.
+- Error path: prefetch reports the no-data emptiness signal (fewer than 2 entities populated, e.g. 1 of 2 silently errored) → Phase B marked degraded (`reason="prefetch_no_data"`), inference is **not** run, Phase A two-hop findings retained.
+- Regression: the MCP classifier (Unit 2) does not flag the migrated path (`expected_tools=[]`); the emptiness guard is what protects it now.
+
+**Verification:** Phase B produces real one-hop-derived shared neighbors with no stdio MCP dependency; degraded never set on the healthy migrated path; combined output matches the prior schema.
+
+- [ ] **Unit 6: Retire pathway_enrichment's stdio config usage + record the pipeline-wide finding**
+
+**Goal:** Remove the dead stdio path from this node and surface the broader latent exposure for separate follow-up.
+
+**Requirements:** R6
+
+**Dependencies:** Unit 5
+
+**Files:**
+- Modify: `backend/src/kestrel_backend/graph/nodes/pathway_enrichment.py` (drop now-unused `get_kestrel_mcp_config` / `KESTREL_*` imports; add a comment)
+- Optional: a short `docs/solutions/` note via `ce:compound` after merge
+
+**Approach:**
+- Ensure `pathway_enrichment` no longer imports or calls `get_kestrel_mcp_config`. Add a comment noting that `entity_resolution`, `direct_kg`, `integration`, `temporal`, and `triage` still use the same broken `uvx mcp-client-kestrel` stdio path and should be audited/migrated under a separate issue. **Do not modify those nodes.**
+
+**Test expectation:** none — import-cleanliness only; behavior covered by Unit 5 tests.
+
+**Verification:** `pathway_enrichment` has no remaining reference to the stdio MCP config; a follow-up issue is filed for the other five nodes.
+
+## System-Wide Impact
+
+- **Interaction graph:** `direct_kg ∥ cold_start → pathway_enrichment → integration → … → synthesis` (`builder.py:48,154-155`). The degraded flag set in Unit 3 must be readable by Integration/Synthesis (and ideally the UI) for disclosure. **Scope note:** emitting the flag is in scope; *rendering* it (synthesis text + a UI badge) is a follow-up — no current consumer reads it, so R2 is satisfied at the "flag emitted" level, not yet "surfaced to the user." Track the disclosure-rendering as a small follow-up.
+- **Error propagation:** degraded is a *handled* state, not an exception — Phase A findings and the rest of the pipeline continue; only fabricated SDK findings are suppressed.
+- **State lifecycle risks:** the `pathway_enrichment_degraded` marker is a new defaulted (`False`) single-writer boolean — no reducer, so it can't trigger a concurrent-update error and existing merges are unaffected. `ModelUsageRecord` gains optional defaulted fields only.
+- **API surface parity:** the classifier + instrumentation live in `sdk_utils.py`, so the other five SDK nodes can adopt them later with no duplication — but this plan does not wire their behavior.
+- **Integration coverage:** a test that drives Phase B degraded and asserts Integration/Synthesis do **not** ingest fabricated neighbors is the highest-value cross-layer check (Unit 3).
+- **Unchanged invariants:** Phase A HTTP analysis, the HTTP `kestrel_client`, working nodes' SDK calls, and `builder.py` topology are explicitly unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Dropping Phase B reduces enrichment when degraded | Phase A HTTP two-hop still contributes real neighbors; Stage 2 removes the degradation source entirely |
+| `ModelUsageRecord` shape change breaks callers | Additive optional fields only; return arity of `query_with_usage` unchanged |
+| Classifier false-positive on data-in-prompt nodes | Empty `expected_tools` never degrades — covered by an explicit test |
+| HTTP migration changes how Phase B gets data | Mirror the proven `cold_start`/PR #24 pattern; schema-parity tests; guard ships first as safety net |
+| Scope creep into the other five broken nodes | Hard scope boundary; instrumentation quantifies their exposure for a separate issue |
+| SDK doesn't expose an init tool list on this version | Tool-use **count** is the reliable signal; init list is best-effort and may be `None` |
+
+## Documentation / Operational Notes
+
+- Run tests with `cd backend && uv run python -m pytest tests/ -v -m "not integration"` (see the venv-path-spaces learning).
+- After merge, a `ce:compound` note documenting the `mcp-client-kestrel`-doesn't-exist root cause + the guard/HTTP remedy would compound well (the cold_start docstring is the only current record).
+- The Stage 1 diagnostics will, in production logs, reveal whether the other five SDK nodes are also silently degraded — use that to prioritize the deferred migration issue.
+
+## Sources & References
+
+- Investigation: 6-agent root-cause workflow `investigate-mcp-tools-unavailable` (run `wf_d2cea02f-039`), this session — ranked hypotheses, guard design, instrumentation, scope/risk.
+- Issue: #44 (Investigate: LLM SDK phase reports MCP tools unavailable)
+- Precedent: PR #24 (cold_start HTTP migration); `backend/src/kestrel_backend/graph/nodes/cold_start.py:1-18,440-495`
+- Broken config: `backend/src/kestrel_backend/graph/sdk_utils.py:35-50,120-202`
+- Phase B: `backend/src/kestrel_backend/graph/nodes/pathway_enrichment.py:170-256,342-440`
+- Semaphore gap: `backend/src/kestrel_backend/graph/pipeline_config.py:207-215`
+- Related learning: `docs/solutions/developer-experience/pytest-venv-path-spaces-module-invocation-2026-06-01.md`

--- a/docs/solutions/developer-experience/pytest-venv-path-spaces-module-invocation-2026-06-01.md
+++ b/docs/solutions/developer-experience/pytest-venv-path-spaces-module-invocation-2026-06-01.md
@@ -1,0 +1,188 @@
+---
+title: "Run pytest as a module: venv-path spaces break console-script shebangs"
+date: 2026-06-01
+category: docs/solutions/developer-experience
+module: backend/testing
+problem_type: developer_experience
+component: testing_framework
+severity: high
+applies_when:
+  - "A uv/Poetry/venv project is checked out under a path containing spaces (Google Drive, My Drive, macOS Library/Mobile Documents, OneDrive, Dropbox)"
+  - "pytest/ruff/mypy/alembic raise ModuleNotFoundError for a dependency that IS installed"
+  - "sys.executable resolves to system Python (/usr/bin/python3) instead of the project .venv"
+  - "A test stubs a package via sys.modules and unrelated test files fail during collection"
+root_cause: config_error
+resolution_type: workflow_improvement
+related_components:
+  - documentation
+  - tooling
+tags:
+  - pytest
+  - uv
+  - venv
+  - shebang
+  - path-with-spaces
+  - module-invocation
+  - test-isolation
+  - sys-modules-stub
+---
+
+# Run pytest as a module: venv-path spaces break console-script shebangs
+
+## Context
+
+The kraken-chatbot backend lives under a cloud-synced checkout whose absolute path contains spaces:
+
+```
+/home/trentleslie/trentleslie@gmail.com/Google Drive/projects/kraken-chatbot/backend
+```
+
+The venv (`backend/.venv`) is managed by `uv`. The canonical test command documented in the project `CLAUDE.md` is:
+
+```bash
+cd backend && uv run pytest tests/ -v -m "not integration"
+```
+
+That form fails confusingly: `ModuleNotFoundError` for dependencies that are demonstrably installed (`pydantic`, `langgraph`, `ftfy`), or pytest silently runs under system Python `/usr/bin/python3` instead of the venv.
+
+**Root cause — fragile shebang in console-script launchers.** When `uv` installs a console-script entry point like `pytest`, it writes `.venv/bin/pytest` as a tiny launcher whose first line is a shebang pointing at the absolute interpreter path:
+
+```
+#!/home/trentleslie/.../Google Drive/projects/kraken-chatbot/backend/.venv/bin/python
+```
+
+The kernel's `execve`/shebang (`#!`) handling does not robustly support spaces in the interpreter path — on Linux it takes the path up to the first space as the interpreter and treats the remainder as a single argument, so a space in the venv directory means it looks for a truncated, non-existent interpreter. The launch falls through to system Python, which lacks the project's dependencies, producing the misleading `ModuleNotFoundError`. The packages aren't missing — the wrong interpreter is running.
+
+> Note: in this particular checkout the baked-in shebang was *also* a stale path from a previous sync root (`Insync/...`). A console-script shebang is hard-coded at venv-creation time, so it can be stale **or** space-containing — either way the conclusion is the same: never rely on the `.venv/bin/<tool>` shebang; invoke the tool as a module.
+
+**A second, independent trap in the same investigation (issue #40).** `backend/tests/test_literature_grounding.py` installs fake stub modules into `sys.modules` so its unit tests don't import heavy real dependencies. The original stub for the `kestrel_backend` package was an empty module with no `__path__`. Because that bare module shadowed the real installed package, Python could no longer resolve *real* submodules that other test files import (e.g. `kestrel_backend.logging_config`, used by `test_logging.py`). The result was a pytest **collection** error across unrelated test modules — not an assertion failure inside the literature tests — which is far harder to attribute to its source.
+
+## Guidance
+
+**Run the tool as a module, not as a console script**, so interpreter selection bypasses the shebang entirely:
+
+```bash
+cd backend && uv run python -m pytest tests/ -v -m "not integration"
+```
+
+`uv run python` resolves the venv interpreter directly (no shebang parsed), and `-m pytest` imports the `pytest` package inside that already-correct interpreter. The space-in-path problem never arises. The same applies to every other console-script tool: prefer `uv run python -m ruff`, `... -m mypy`, `... -m alembic`, etc.
+
+**Diagnose which interpreter actually ran** before trusting any pass/fail result:
+
+```bash
+# Which interpreter does the module form use? (should be the .venv python)
+cd backend && uv run python -c "import sys; print(sys.executable)"
+
+# Compare the two invocation forms — the script form may launch the wrong python (or fail):
+cd backend && uv run python -m pytest --version   # module form (correct)
+cd backend && uv run pytest --version             # script form (fragile shebang)
+
+# Inspect the offending launcher's shebang directly:
+cd backend && head -1 .venv/bin/pytest
+```
+
+If `sys.executable` points anywhere other than `.../backend/.venv/bin/python`, you are not running against the project venv and any `ModuleNotFoundError` is a false signal.
+
+**For sys.modules stubbing**, when you fake a *package* (not a leaf module) to dodge heavy imports, give the stub a real `__path__` so the package's genuine submodules stay importable, and complete the stubbed surface every importer touches:
+
+```python
+import sys, types
+
+# Stub EVERY package level down to the real submodule, each with a real __path__.
+# A one-level stub is not enough: faking only `kestrel_backend` still yields
+# "'kestrel_backend.graph' is not a package" because the intermediate node also
+# needs __path__.
+for name, path in [
+    ("kestrel_backend", "src/kestrel_backend"),
+    ("kestrel_backend.graph", "src/kestrel_backend/graph"),
+    ("kestrel_backend.graph.nodes", "src/kestrel_backend/graph/nodes"),
+]:
+    mod = types.ModuleType(name)
+    mod.__path__ = [path]          # keep real submodules resolvable
+    sys.modules[name] = mod
+```
+
+A direct `sys.modules["pkg.sub"] = fake` entry is consulted *before* `__path__`-based resolution, so explicitly-faked submodules remain authoritative while everything you didn't fake falls through to the real source.
+
+## Why This Matters
+
+- **The failure lies about its cause.** A `ModuleNotFoundError` for an installed package sends developers down a dependency-reinstall rabbit hole (`uv sync`, deleting `.venv`, pinning versions) when the real fix is changing how the runner is launched. (session history) The first attempt here was to add `pythonpath = ["src"]` to `pyproject.toml`; it fixed pytest's *import path* but immediately surfaced `ModuleNotFoundError: No module named 'langgraph'`, which finally exposed that pytest was running under `/usr/bin/python3`, not the venv.
+- **The canonical doc steers people into the trap.** `CLAUDE.md` documents the `uv run pytest` (script) form. Every developer and agent who follows the docs faithfully hits the bug. A wrong-by-default command is worse than no command — it manufactures confidence in a broken path.
+- **Cloud-synced dev directories make this common, not exotic.** "Google Drive", "My Drive", macOS "Library/Mobile Documents", OneDrive, and Dropbox all put spaces in paths. Any uv/Poetry/venv project checked out under one is exposed.
+- **sys.modules stubbing has spooky action at a distance.** A bad stub in *one* test file breaks *collection* of *other, unrelated* test files. The `__path__` discipline prevents a whole class of hard-to-localize collection failures.
+
+## When to Apply
+
+Use the **`python -m` module form** whenever a uv/Poetry/venv project sits under a spaced path, or when a console-script tool raises `ModuleNotFoundError` for a confirmed-installed dependency, or when `sys.executable` resolves to system Python. It is the safe default for *all* console-script entry points, not just pytest.
+
+Use the **stub `__path__` discipline** whenever a test injects fake *packages* into `sys.modules` and other test files import real submodules of that package, or when you see pytest **collection** errors (e.g. `'<pkg>' is not a package`) in modules unrelated to the one doing the stubbing.
+
+## Examples
+
+**Before — script form, fragile shebang (documented but broken):**
+
+```bash
+$ cd backend && uv run pytest tests/ -v -m "not integration"
+ModuleNotFoundError: No module named 'langgraph'
+# ...yet the package is installed:
+$ cd backend && uv run python -c "import langgraph; print('ok')"
+ok        # it IS there — wrong interpreter was launched
+
+$ head -1 backend/.venv/bin/pytest
+#!/home/trentleslie/.../Google Drive/projects/kraken-chatbot/backend/.venv/bin/python
+#                      ^^^^^^^^^^^^ spaces here break kernel shebang parsing
+```
+
+**After — module form, shebang bypassed:**
+
+```bash
+$ cd backend && uv run python -m pytest tests/ -v -m "not integration"
+# collects and runs against the venv interpreter; deps resolve correctly
+
+$ cd backend && uv run python -c "import sys; print(sys.executable)"
+/home/.../Google Drive/projects/kraken-chatbot/backend/.venv/bin/python   # correct venv
+```
+
+**Before — empty package stub shadows the real package (breaks unrelated collection):**
+
+```python
+import sys, types
+
+# BAD: no __path__ → real submodules (kestrel_backend.logging_config, etc.)
+# become unresolvable; test_logging.py fails at COLLECTION, not assertion.
+kestrel_backend = types.ModuleType("kestrel_backend")
+sys.modules["kestrel_backend"] = kestrel_backend
+```
+
+**After — real `__path__` plus a complete stubbed surface (from `backend/tests/test_literature_grounding.py`):**
+
+```python
+import sys, types
+
+# Give EACH package level a real __path__ so submodules this file does NOT fake
+# (e.g. kestrel_backend.logging_config, imported by test_logging.py) still resolve
+# to the real source instead of failing collection with "'<pkg>' is not a package".
+kestrel_backend = types.ModuleType("kestrel_backend")
+kestrel_backend.__path__ = ["src/kestrel_backend"]
+kestrel_backend_graph = types.ModuleType("kestrel_backend.graph")
+kestrel_backend_graph.__path__ = ["src/kestrel_backend/graph"]
+kestrel_backend_graph_nodes = types.ModuleType("kestrel_backend.graph.nodes")
+kestrel_backend_graph_nodes.__path__ = ["src/kestrel_backend/graph/nodes"]
+sys.modules["kestrel_backend"] = kestrel_backend
+sys.modules["kestrel_backend.graph"] = kestrel_backend_graph
+sys.modules["kestrel_backend.graph.nodes"] = kestrel_backend_graph_nodes
+
+# Then complete the surface every importer touches. The real node imports
+# classify_relationship_llm (issue #40), so the leaf stub must define it too:
+mock_semantic_scholar = types.ModuleType("kestrel_backend.semantic_scholar")
+mock_semantic_scholar.classify_relationship = None
+mock_semantic_scholar.classify_relationship_llm = None   # issue #40: real node imports this
+sys.modules["kestrel_backend.semantic_scholar"] = mock_semantic_scholar
+```
+
+**Doc fix (the meta-learning):** the `CLAUDE.md` test command should use `uv run python -m pytest ...` so the canonical command no longer steers developers into the broken path.
+
+## Related
+
+- `../best-practices/langgraph-json-src-layout-import-2026-05-06.md` — sibling Python import/module-resolution lesson (different root cause; "see also")
+- GitHub issue #40 — test_logging.py collection error from the `sys.modules` stub

--- a/docs/solutions/logic-errors/repair-dont-strip-utf8-mojibake-in-citation-fields-2026-06-01.md
+++ b/docs/solutions/logic-errors/repair-dont-strip-utf8-mojibake-in-citation-fields-2026-06-01.md
@@ -1,0 +1,153 @@
+---
+title: "Repair, don't strip: UTF-8 mojibake in citation fields"
+date: 2026-06-01
+category: docs/solutions/logic-errors
+module: kestrel_backend.graph
+problem_type: logic_error
+component: assistant
+symptoms:
+  - "Citation fields (title, authors, key_passage) rendered UTF-8 mojibake, e.g. â€™ for a curly apostrophe"
+  - "Double-encoded sequences like Ã¢Â€Â\" appeared in place of em-dashes"
+  - "The prior char-class strip deleted legitimate em-dashes and apostrophes from clean citations"
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+related_components:
+  - assistant
+  - service_object
+tags:
+  - mojibake
+  - utf-8
+  - encoding
+  - ftfy
+  - pydantic-v2
+  - field-validator
+  - literature-grounding
+  - citations
+---
+
+# Repair, don't strip: UTF-8 mojibake in citation fields
+
+> `component: assistant` is the closest schema enum; the true component is the
+> LangGraph discovery pipeline's literature-grounding node (`graph/state.py`,
+> `graph/nodes/literature_grounding.py`), for which no enum value exists.
+
+## Problem
+
+Citation text fields (`title`, `authors`, `key_passage`) produced by the literature-grounding stage of the discovery pipeline rendered with UTF-8 mojibake — text where bytes from one encoding were interpreted under a different codec (GitHub issue #39). The source text arrives from external literature APIs (OpenAlex, Exa, Semantic Scholar, PubMed), which is where the bad encoding originates.
+
+## Symptoms
+
+- **Single-encoded** mojibake: `Rabbani's group` rendering as `Rabbaniâ€™s group`; corrupted em-dashes.
+- **Double-encoded** mojibake (the harder case): `dose — response curve` rendering as `dose Ã¢Â€Â" response curve` — a UTF-8 em-dash mis-decoded as Latin-1, re-encoded as UTF-8, then mis-decoded again (observed in real citations, Rabbani 2021).
+- Legitimate punctuation was *simultaneously being lost* by the old "fix" (see below).
+- The garbage propagated from the markdown references table into the frontend.
+
+## What Didn't Work
+
+The prior code in `backend/src/kestrel_backend/graph/nodes/literature_grounding.py` cleaned the passage with a **character-class strip**:
+
+```python
+relevance = re.sub(r'[âÂ€™""—–]+', '', relevance)  # Strip UTF-8 mojibake artifacts
+```
+
+Two failures:
+
+1. **It deleted legitimate characters.** The class included `—` (em-dash), `'` (apostrophe), and `–` (en-dash) — valid in real citation text. A genuine em-dash in `"dose — response curve"` got erased along with the corruption.
+2. **It never decoded anything.** Stripping suspect bytes does not *repair* a wrong-codec interpretation. For the double-encoded `Ã¢Â€Â"` sequence, the regex only chewed off lead bytes, leaving mangled remnants rather than the intended `—`.
+
+It also ran only on `key_passage` during table construction, leaving `title` and `authors` unremediated, and addressed nothing at the data boundary.
+
+## Solution
+
+Repair the text instead of stripping it, at the point of model construction so every downstream consumer sees clean data.
+
+**Before** — lossy char-class strip inside the table builder (`literature_grounding.py`):
+
+```python
+relevance = re.sub(r'[âÂ€™""—–]+', '', relevance)  # deletes legit em-dashes/quotes, decodes nothing
+```
+
+**After** — strip removed from `literature_grounding.py`, with a comment recording why; mojibake is now repaired upstream at construction.
+
+**After** — a Pydantic v2 `mode="before"` field validator on `LiteratureSupport` in `backend/src/kestrel_backend/graph/state.py`:
+
+```python
+import ftfy  # module-level: ImportError surfaces at import time, not per-construction
+
+# Deeply double-encoded UTF-8 mojibake that ftfy cannot fully resolve on its own
+# (observed in literature citations, e.g. Rabbani 2021). Applied BEFORE ftfy.fix_text.
+_MOJIBAKE_REPLACEMENTS = {
+    'Ã¢Â€Â"': "—",   # em-dash
+    "Ã¢Â€Â™": "'",   # apostrophe
+}
+
+class LiteratureSupport(BaseModel):
+    # ...
+    @field_validator("title", "authors", "key_passage", mode="before")
+    @classmethod
+    def _repair_mojibake(cls, v: Any) -> Any:
+        if not isinstance(v, str) or not v:
+            return v
+        for bad, good in _MOJIBAKE_REPLACEMENTS.items():
+            v = v.replace(bad, good)
+        # NOTE: fix_text defaults to unescape_html="auto", which decodes HTML
+        # entities when no tags are present. Fine here (table builder escapes the
+        # cell), but pass unescape_html=False if copying this into a context that
+        # renders the value as HTML. See "Known follow-up caveat" below.
+        return ftfy.fix_text(v)
+```
+
+**After** — dependency added in `backend/pyproject.toml`: `"ftfy>=6.3.1"`.
+
+Design notes (reflecting review feedback):
+- `import ftfy` is at **module level**, so an `ImportError` surfaces at import time, not on first model construction, and the module isn't re-imported per instantiation.
+- The explicit `_MOJIBAKE_REPLACEMENTS` map runs **first** (double-encoded cases), **then** `ftfy.fix_text` cleans the remaining single-encoding cases.
+- The non-`str`/empty guard passes `None`/non-string input through untouched.
+- **The literal byte sequences in `_MOJIBAKE_REPLACEMENTS` (and in the test below) are byte-sensitive.** Pasting them through a non-UTF-8 editor, chat client, or re-encoding terminal can silently alter the bytes — at which point the key no longer matches and the repair no-ops. Verify these literals survived the paste byte-for-byte (e.g. `python -c "print('Ã¢Â€Â\"'.encode())"`).
+
+## Why This Works
+
+**Mojibake is a decoding problem, not a content problem.** The bytes are correct; they were interpreted under the wrong codec (UTF-8 read as Latin-1, sometimes twice). The fix *re-decodes / repairs* the text — reversing the bad interpretation — rather than deleting odd-looking bytes.
+
+- `ftfy.fix_text` detects common single-encoding mojibake and reverses the mis-decode, restoring `'` and `—` while leaving genuinely-correct characters (real em-dashes, accents like `café`) intact. Because it repairs rather than strips, it is non-destructive.
+- The double-encoded case `Ã¢Â€Â"` is too far gone for ftfy to unwind reliably (once bytes are encoded twice, charset detection alone can't recover them), so the explicit map repairs those exact sequences first.
+- Stripping is inherently lossy: it cannot distinguish a corrupted em-dash from a legitimate one, so it must erase both or neither. Repairing the encoding sidesteps that false choice.
+- Doing the repair in a `mode="before"` validator centralizes it at the data boundary — every `LiteratureSupport` is clean by construction, so no downstream consumer needs its own ad-hoc sanitizer.
+
+## Prevention
+
+The regression test asserts **both** that the bad bytes are gone *and* that the correct character is present (a positive assertion, not mere absence), and separately verifies legitimate punctuation/accents survive. From `backend/tests/test_literature_grounding.py`:
+
+```python
+def test_repairs_mojibake_in_text_fields(self):
+    moj_em = "—".encode("utf-8").decode("latin-1")    # em-dash mojibake
+    moj_apos = "’".encode("utf-8").decode("latin-1")  # apostrophe mojibake
+    lit = LiteratureSupport(
+        paper_id="p", year=2021, authors=f"Rabbani{moj_apos}s group",
+        title=f"Lipid{moj_em}diabetes link",
+        key_passage="real em-dash — and café",
+    )
+    assert lit.title == "Lipid—diabetes link"   # single-encoding mojibake repaired
+    assert moj_em not in lit.title              # negative pair: bad bytes gone
+    assert "Rabbani" in lit.authors and moj_apos not in lit.authors
+    assert "café" in lit.key_passage            # legitimate accented text preserved
+    assert "—" in lit.key_passage               # legitimate em-dash preserved (not stripped)
+
+    lit2 = LiteratureSupport(paper_id="p2", year=2021, authors="A",
+                             title='dose Ã¢Â€Â" response curve')
+    assert "Ã¢" not in lit2.title   # double-mojibake lead bytes removed
+    assert "—" in lit2.title        # replaced with the correct em-dash
+```
+
+Generalizable rules:
+- **Assert the positive, not just the negative.** `assert "—" in title` would fail against the old strip-based code; an absence-only check (`assert "Ã¢" not in title`) would pass it. Pair both to pin down "repaired correctly," not just "garbage removed."
+- **Include a preservation case** (`café`, a real `—`) so a future over-aggressive sanitizer that re-introduces stripping fails the test.
+- **Cover both corruption tiers** — single-encoded (`.encode("utf-8").decode("latin-1")`) and the literal double-encoded sequence from the real issue.
+
+**Known follow-up caveat (session history):** `ftfy.fix_text` runs with default `unescape_html="auto"`, which decodes HTML entities (`&lt;`, `&gt;`, …) when the input contains no HTML tags — a transformation the old char-class strip never performed. Since `build_references_table()` does not HTML-escape the title/citation column (it escapes only `\n`, `\r`, `|`), an entity-encoded title could in principle reach the `synthesis_report` markdown shipped to the frontend. Severity is bounded by the frontend renderer's HTML policy. If hardening: pass `unescape_html=False` to `fix_text`, or HTML-escape the citation column in the table builder.
+
+## Related Issues
+
+- GitHub issue #39 — UTF-8 mojibake in literature citations (fixed in PR #59)
+- `../best-practices/verify-temporal-provenance-before-kg-holdout-eval-2026-05-29.md` — touches the same file (`literature_grounding.py`), orthogonal concern (date-filtering for temporal eval)


### PR DESCRIPTION
## Summary

Fixes #44. The `pathway_enrichment` Phase B SDK agent intermittently reported *"The Kestrel MCP tools are not available in my current tool set"* and then hallucinated one-hop analysis. A multi-agent investigation found the root cause is **not** a race: the stdio MCP server is configured to launch `uvx mcp-client-kestrel`, **a package that does not exist on PyPI** (already documented in `cold_start.py`; PR #24 migrated cold_start off it). The tools never register; the model fabricates from training data. The same broken stdio path is used by **all six SDK nodes** — pathway_enrichment is just the most visible (Phase A always survives because it uses the HTTP client).

Ships in one PR, two stages:

### Stage 1 — guard + instrumentation (stop hallucination propagation, make it observable)
- `query_with_usage` now counts `mcp__*` tool-use blocks and captures the SDK init tool list, surfaced on `ModelUsageRecord` (`mcp_tool_calls`, `available_tools`) + a per-node diagnostic log — observability across all six SDK nodes.
- `classify_mcp_degradation` shared classifier: structural signal authoritative (zero mcp calls / init-list missing); fallback phrase corroborates only; empty allowlist never degrades.
- Phase B drops the hallucinated SDK findings when degraded (`drop_findings_on_degraded`, default true) and sets `pathway_enrichment_degraded`. Phase A two-hop findings are staged outside the Phase B `try` and emitted on the happy, degraded, timeout, **and** exception paths (R5 — fixes a latent bug where an exception silently dropped them).

### Stage 2 — durable fix: HTTP migration of Phase B
- `prefetch_one_hop_neighbors` fetches one-hop data via the HTTP Kestrel client (mirrors `cold_start.get_entity_connections`), with a per-entity `errored` flag and a `no_data` signal (fewer than 2 entities with real data).
- Phase B now reasons over prefetched data in-prompt: `allowed_tools=[]`, `SDK_SEMAPHORE` (new `sdk_semaphore` config, also closes the missing-semaphore gap), no `mcp_servers`. The prefetch `no_data` guard (shared degraded helper, `reason=prefetch_no_data`) replaces the now-inert MCP classifier.
- Removed the dead stdio imports + old tool-use prompt.

## Scope / follow-up
- The five other SDK nodes (`entity_resolution`, `direct_kg`, `integration`, `temporal`, `triage`) still use the same broken stdio path — out of scope here, flagged in code for a **separate audit issue** (Stage 1 instrumentation quantifies their exposure in prod logs). `integration` and `entity_resolution` are higher-severity (verify HTTP-fallback per node first).
- Rendering the `degraded` flag in synthesis/UI is a small follow-up (flag is emitted, not yet surfaced).

## Testing
- 96 new/updated unit tests pass across `test_sdk_utils`, `test_pathway_enrichment`, `test_state_contracts`, `test_pipeline_config`.
- Verified **zero new failures**: the `test_langgraph_prototype` failure set is identical on this branch and `origin/dev` (24 pre-existing failures, all ColdStart/Synthesis/network-403, none from this change).
- Plan + 3-round document review in `docs/plans/2026-06-01-001-fix-pathway-enrichment-mcp-degradation-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
