### PR TITLE
fix: migrate the five remaining SDK nodes off the broken stdio MCP (#61)

### DIFF
--- a/backend/src/kestrel_backend/graph/nodes/direct_kg.py
+++ b/backend/src/kestrel_backend/graph/nodes/direct_kg.py
@@ -31,7 +31,6 @@ from ...kestrel_client import call_kestrel_tool, multi_hop_query
 from ..state import (
     DiscoveryState, Finding, DiseaseAssociation, PathwayMembership, NoveltyScore
 )
-from ..sdk_utils import HAS_SDK, query_with_usage, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS
 from ..pipeline_config import get_pipeline_config
 from ..state_contracts import validate_state, DirectKGInput, DirectKGOutput
 
@@ -46,50 +45,11 @@ _config = get_pipeline_config().direct_kg
 # Ranking presets to use (Kestrel API supports these)
 PRESETS = ["established", "hidden_gems"]
 
-# Semaphore to limit concurrent SDK calls (Tier 2 only)
-SDK_SEMAPHORE = asyncio.Semaphore(_config.sdk_semaphore)
-
 # Semaphore bounding the new multi-hop fan-out against the shared Kestrel server
 # (Tier-1 one-hop calls use a bare gather with no cap; the demo-slice multi-hop calls
 # must not saturate the connection pool — see plan RC6). Uses a dedicated config value so
 # it stays independent of batch_size (which controls Tier-2 SDK batching).
 MULTI_HOP_SEMAPHORE = asyncio.Semaphore(_config.multi_hop_semaphore)
-
-# System prompt for direct KG analysis (Tier 2 LLM fallback)
-DIRECT_KG_PROMPT = """You are a biomedical knowledge graph analyst. For the given entity (CURIE),
-use one_hop_query to retrieve and analyze its relationships.
-
-Query for THREE types of associations:
-1. Disease associations - use one_hop_query with end_category filter for biolink:Disease
-2. Pathway/biological process - filter for biolink:Pathway or biolink:BiologicalProcess
-3. Protein interactions (for genes) - filter for biolink:Protein or biolink:Gene
-
-For each association found, extract:
-- The predicate type (e.g., biolink:treats, biolink:gene_associated_with_condition)
-- The source database from edge provenance if available
-- Any PMIDs in the edge data
-
-CRITICAL: If a neighbor has very high connectivity (mentioned as having many edges or
-appearing frequently), flag it as a potential hub. Hub nodes create spurious associations.
-
-Return ONLY a valid JSON object (no other text):
-{
-  "diseases": [
-    {"curie": "MONDO:...", "name": "...", "predicate": "...", "source": "...", "pmids": [], "is_hub": false}
-  ],
-  "pathways": [
-    {"curie": "GO:...", "name": "...", "predicate": "...", "source": "..."}
-  ],
-  "interactions": [
-    {"curie": "...", "name": "...", "predicate": "..."}
-  ],
-  "hub_flags": ["CURIE1", "CURIE2"]
-}
-
-If the query returns no results or fails, return:
-{"diseases": [], "pathways": [], "interactions": [], "hub_flags": []}
-"""
-
 
 # =============================================================================
 # Deduplication and Merging Helpers
@@ -533,84 +493,6 @@ def parse_direct_kg_result(
     return diseases, pathways, findings, hub_flags
 
 
-async def analyze_single_entity(
-    curie: str,
-    raw_name: str
-) -> tuple[list[DiseaseAssociation], list[PathwayMembership], list[Finding], list[str], list[str], Any]:
-    """
-    Tier 2: Analyze a single entity using Claude Agent SDK with LLM reasoning.
-
-    This is the fallback path when Tier 1 API calls fail.
-
-    Returns:
-        tuple of (diseases, pathways, findings, hub_flags, errors, ModelUsageRecord | None)
-    """
-    if not HAS_SDK:
-        return (
-            [],
-            [],
-            [Finding(
-                entity=curie,
-                claim=f"Direct KG analysis pending for {raw_name} (SDK unavailable)",
-                tier=1,
-                source="direct_kg",
-                confidence="low",
-            )],
-            [],
-            [],
-            None,
-        )
-
-    try:
-        async with SDK_SEMAPHORE:
-            kestrel_config = get_kestrel_mcp_config()
-
-            options = ClaudeAgentOptions(
-                system_prompt=DIRECT_KG_PROMPT,
-                allowed_tools=[
-                    "mcp__kestrel__one_hop_query",
-                    "mcp__kestrel__get_nodes",
-                    "mcp__kestrel__get_edges",
-                ],
-                mcp_servers={"kestrel": kestrel_config},
-                max_turns=4,
-                permission_mode="bypassPermissions",
-                max_buffer_size=10 * 1024 * 1024,
-            )
-
-            result_text, usage_record = await query_with_usage(
-                prompt=f"Analyze entity: {raw_name} ({curie})",
-                options=options,
-                node_name="direct_kg",
-            )
-        diseases, pathways, findings, hub_flags = parse_direct_kg_result(curie, raw_name, result_text)
-
-        logger.info(
-            "Tier 2 direct_kg '%s': diseases=%d, pathways=%d, findings=%d",
-            curie, len(diseases), len(pathways), len(findings)
-        )
-
-        return diseases, pathways, findings, hub_flags, [], usage_record
-
-    except Exception as e:
-        error_msg = f"Tier 2 direct_kg failed for {curie}: {str(e)}"
-        logger.error(error_msg)
-        return (
-            [],
-            [],
-            [Finding(
-                entity=curie,
-                claim=f"Analysis failed for {raw_name}: {str(e)[:100]}",
-                tier=1,
-                source="direct_kg",
-                confidence="low",
-            )],
-            [],
-            [error_msg],
-            None,
-        )
-
-
 # =============================================================================
 # Helper Functions
 # =============================================================================
@@ -805,42 +687,28 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
     logger.info("Tier 1 (API) analyzed %d/%d unique entities in %.1fs",
                 tier1_success, len(unique_curies), tier1_duration)
 
-    # ========== TIER 2: LLM Fallback ==========
-    model_usages = []
-    if tier2_needed_curies and HAS_SDK:
-        tier2_start = time.time()
-        logger.info("Tier 2 (LLM): Processing %d unique entities that failed Tier 1",
-                    len(tier2_needed_curies))
+    # ========== TIER 2 removed — honest no-findings (#61) ==========
+    # The Tier-2 LLM fallback configured the broken stdio MCP (uvx mcp-client-kestrel,
+    # not on PyPI), so its tools never registered and it could only emit associations
+    # not grounded in the KG. analyze_via_api returns None only on a *total* failure
+    # (per-call errors are swallowed with `continue`), so a fresh one_hop_query would
+    # re-fail the same endpoint with the same args. Entities whose Tier 1 failed now
+    # honestly yield NO direct_kg findings rather than hallucinated ones; they remain
+    # None in all_results. (A transient-failure prefetch is a post-deploy follow-on if
+    # logs ever justify it — out of scope here.)
+    model_usages: list = []
+    if tier2_needed_curies:
         for curie in tier2_needed_curies:
             logger.info(
-                "FALLBACK_EVENT node=direct_kg entity=%s reason=tier1_api_failed tier=2",
+                "FALLBACK_EVENT node=direct_kg entity=%s reason=tier1_api_failed "
+                "action=no_findings tier=2_dropped",
                 curie,
             )
-
-        for batch in chunk(tier2_needed_curies, _config.batch_size):
-            batch_tasks = []
-            for curie in batch:
-                raw_name = get_raw_name_for_curie(curie, novelty_scores, resolved_entities)
-                batch_tasks.append(analyze_single_entity(curie, raw_name))
-
-            batch_results = await asyncio.gather(*batch_tasks, return_exceptions=True)
-
-            for curie, result in zip(batch, batch_results):
-                indices = curie_to_indices[curie]
-                if isinstance(result, Exception):
-                    errors.append(f"Tier 2 failed for {curie}: {str(result)}")
-                elif result is not None:
-                    # Extract usage record from the 6th element of the tuple
-                    usage_record = result[5] if len(result) > 5 else None
-                    # Pass the 5-element tuple (without usage) to all_results
-                    result_without_usage = result[:5]
-                    for idx in indices:
-                        all_results[idx] = result_without_usage
-                    if usage_record is not None:
-                        model_usages.append(usage_record)
-
-        tier2_duration = time.time() - tier2_start
-        logger.info("Tier 2 (LLM) completed in %.1fs", tier2_duration)
+        logger.info(
+            "Tier 1 failed for %d/%d unique entities; yielding no direct_kg findings "
+            "for them (honest no-findings, #61)",
+            len(tier2_needed_curies), len(unique_curies),
+        )
 
     # Aggregate results
     all_diseases: list[DiseaseAssociation] = []

--- a/backend/src/kestrel_backend/graph/nodes/entity_resolution.py
+++ b/backend/src/kestrel_backend/graph/nodes/entity_resolution.py
@@ -28,7 +28,7 @@ from typing import Any
 
 from ...kestrel_client import call_kestrel_tool
 from ..state import DiscoveryState, EntityResolution
-from ..sdk_utils import HAS_SDK, query_with_usage, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS
+from ..sdk_utils import HAS_SDK, query_with_usage, ClaudeAgentOptions, chunk
 from ..pipeline_config import get_pipeline_config
 from ..state_contracts import validate_state, EntityResolutionInput, EntityResolutionOutput
 
@@ -39,57 +39,53 @@ _config = get_pipeline_config().entity_resolution
 # Semaphore to serialize SDK calls and prevent concurrent CLI spawn issues
 SDK_SEMAPHORE = asyncio.Semaphore(_config.sdk_semaphore)
 
-# Enhanced prompt for entity resolution with retry strategies
+# Selection prompt (#61): the broken stdio MCP search tools are gone. We now do the
+# variant searches over HTTP ourselves and hand the model a CANDIDATE list to SELECT
+# from — it no longer searches the KG.
 RESOLUTION_PROMPT = """You are an expert biomedical entity resolver for the Kestrel knowledge graph.
 
 ## Your Task
-Resolve the given entity name to its canonical CURIE (Compact URI) identifier.
+You are given an entity name and a list of CANDIDATE nodes already retrieved from the
+knowledge graph. SELECT the single best candidate CURIE for the entity, or return null
+if none of the candidates actually refer to the entity.
 
-## Resolution Strategy (try in order)
-1. **Exact match**: Use hybrid_search with the exact entity name first
-2. **Synonym search**: If no result, try common synonyms:
-   - Chemical abbreviations: "BHBA" → "beta-hydroxybutyrate" → "3-hydroxybutyric acid"
-   - Gene aliases: Many genes have multiple symbols
-3. **Gene symbol handling**: For all-caps 2-6 character names (like KIF6, NLGN1, TP53):
-   - These are likely gene symbols → search directly, expect NCBIGene CURIEs
-4. **Metabolite variants**: Try without prefixes/suffixes:
-   - "N-lactoyl phenylalanine" → also try "lactoylphenylalanine"
-   - "16-hydroxypalmitate" → also try "hydroxypalmitate"
-5. **Partial matching**: Use text_search for fuzzy matches if hybrid_search fails
+## Matching guidance
+- Match on meaning, not just string equality: synonyms, spelling/hyphenation variants,
+  gene symbols, and chemical-name variants all count.
+  - "N-lactoyl phenylalanine" matches a "lactoylphenylalanine" node
+  - "16-hydroxypalmitate" matches "16-hydroxypalmitic acid"
+  - A gene symbol (all caps, 2-6 chars, e.g. KIF6) matches its NCBIGene node
+- Prefer the most specific, highest-scoring candidate that genuinely refers to the entity.
 
-## Important
-- Always try at least 2-3 search variations before giving up
-- Gene symbols (all caps, 2-6 chars) are common - search as-is
-- Metabolites may need chemical name variations
+## Hard rules
+- You MUST pick a `curie` value from the provided candidates verbatim, or return null.
+- Do NOT invent, complete, or correct a CURIE. If nothing fits, return null — never guess.
 
 ## Output Format
 Return ONLY valid JSON (no other text):
-{"curie": "PREFIX:ID", "name": "Canonical Name", "category": "biolink:Category", "confidence": 0.95}
+{"curie": "PREFIX:ID", "confidence": 0.95}
 
-If truly not found after trying all strategies:
-{"curie": null, "name": null, "category": null, "confidence": 0.0}"""
+If no candidate fits:
+{"curie": null, "confidence": 0.0}"""
 
-# More aggressive retry prompt for failed entities
-RETRY_PROMPT = """You are an expert biomedical entity resolver. This entity FAILED initial resolution - try harder!
+# Retry uses the same selection task with a more permissive matching posture (the entity
+# already failed the score threshold, so accept good synonym/variant matches).
+RETRY_PROMPT = """You are an expert biomedical entity resolver. This entity was hard to resolve.
 
-## Aggressive Search Strategies
-1. **Alternative spellings**: Try with/without hyphens, spaces, prefixes (N-, 16-, etc.)
-2. **Chemical synonyms**: Search IUPAC names, common names, and abbreviations
-3. **Partial matches**: Use text_search with key substrings
-4. **Category hints**: If it looks like a gene (all caps, 2-6 chars), search gene databases
-5. **Metabolite variations**: Strip numeric prefixes, try base compound names
+You are given an entity name and a list of CANDIDATE nodes retrieved from the knowledge
+graph via several spelling/synonym variant searches. SELECT the single best candidate, being
+generous about synonym, hyphenation, numeric-prefix, IUPAC/common-name, and gene-symbol
+variants — but only if the candidate genuinely refers to the same entity.
 
-## Examples of successful resolutions
-- "N-lactoyl phenylalanine" → try "lactoylphenylalanine", "lactoyl-phenylalanine"
-- "16-hydroxypalmitate" → try "hydroxypalmitate", "hydroxypalmitic acid"
-- "hexadecanedioate" → try "hexadecanedioic acid", "C16-DC"
-- "KIF6" → search as gene symbol directly (NCBIGene)
+## Hard rules
+- You MUST pick a `curie` value from the provided candidates verbatim, or return null.
+- Do NOT invent, complete, or correct a CURIE. If nothing genuinely matches, return null.
 
 ## Output
 Return ONLY valid JSON:
-{"curie": "PREFIX:ID", "name": "Canonical Name", "category": "biolink:Category", "confidence": 0.95}
+{"curie": "PREFIX:ID", "confidence": 0.95}
 
-If truly not found: {"curie": null, "name": null, "category": null, "confidence": 0.0}"""
+If no candidate fits: {"curie": null, "confidence": 0.0}"""
 
 
 
@@ -256,68 +252,191 @@ def parse_resolution_result(entity: str, result_text: str) -> EntityResolution:
     )
 
 
+# Max candidates shown to the selector (bounds prompt size; membership is checked
+# against exactly this shown set).
+_CANDIDATE_CAP = 25
+
+
+def _resolution_variants(entity: str) -> list[str]:
+    """Spelling/synonym variants to broaden the candidate search.
+
+    Approximates (server-side) the variant reformulation the old max_turns=5 SDK loop
+    did: raw + de-hyphenated + hyphen-removed + numeric/short-prefix-stripped +
+    gene-symbol form. NOTE: this is a fixed, finite list — a strict subset of the live
+    loop's open-ended reformulation — so recall must be gated against a hand-labeled
+    fixture before merge (see plan #61).
+    """
+    variants: list[str] = []
+
+    def add(v: str) -> None:
+        v = v.strip()
+        if v and v not in variants:
+            variants.append(v)
+
+    add(entity)
+    add(entity.replace("-", " "))   # de-hyphenated
+    add(entity.replace("-", ""))    # hyphen-removed
+    add(re.sub(r"^[0-9A-Za-z]{1,3}-", "", entity))  # strip a leading "N-"/"16-"/"3-" prefix
+    if 2 <= len(entity) <= 6 and entity.isalnum():
+        add(entity.upper())         # gene-symbol form
+    return variants
+
+
+def _canonical_curie(curie: str | None) -> str | None:
+    """Canonical form for the R1a membership check: uppercase prefix + trim.
+
+    Fuzzy/equivalent-namespace matching is intentionally NOT done — a lenient match
+    could admit a different node that merely normalizes alike.
+    """
+    if not curie:
+        return None
+    c = curie.strip()
+    if ":" in c:
+        prefix, _, local = c.partition(":")
+        return f"{prefix.upper()}:{local}"
+    return c.upper()
+
+
+def _extract_search_results(data: Any, search_text: str) -> list:
+    """Pull the results list out of a Kestrel ``{search_text: [results]}`` envelope.
+
+    Same envelope hybrid_search and text_search return (both route through
+    call_kestrel_tool; see resolve_via_api).
+    """
+    if isinstance(data, dict):
+        results = data.get(search_text) or data.get(search_text.lower()) or []
+        if not results and len(data) == 1:
+            results = list(data.values())[0]
+        return results or []
+    return data or []
+
+
+async def prefetch_resolution_candidates(entity: str, limit: int = 10) -> list[dict]:
+    """Tier-2 prefetch (#61): issue multiple HTTP variant searches and dedup into a
+    candidate set. Replaces the broken MCP variant-search loop.
+
+    Each variant is searched via BOTH hybrid_search and text_search (``limit > 1``);
+    results are deduped by canonical CURIE, keeping the highest-scoring instance.
+    Returns ``[{curie, name, category, score}]`` sorted best-score first.
+    """
+    candidates: dict[str, dict] = {}  # canonical curie -> candidate
+    for variant in _resolution_variants(entity):
+        for tool in ("hybrid_search", "text_search"):
+            try:
+                result = await call_kestrel_tool(tool, {"search_text": variant, "limit": limit})
+            except Exception as e:
+                logger.debug("Prefetch '%s' via %s failed: %s", variant, tool, e)
+                continue
+            if result.get("isError"):
+                continue
+            content = result.get("content", [])
+            if not content:
+                continue
+            text = content[0].get("text", "") if isinstance(content[0], dict) else str(content[0])
+            try:
+                data = json.loads(text)
+            except json.JSONDecodeError:
+                continue
+            for row in _extract_search_results(data, variant):
+                if not isinstance(row, dict):
+                    continue
+                curie = row.get("id") or row.get("curie")
+                canon = _canonical_curie(curie)
+                if not canon:
+                    continue
+                score = float(row.get("score", 0) or 0)
+                cats = row.get("categories", [])
+                existing = candidates.get(canon)
+                if existing is None or score > existing["score"]:
+                    candidates[canon] = {
+                        "curie": curie,
+                        "name": row.get("name") or row.get("label"),
+                        "category": cats[0] if cats else row.get("category"),
+                        "score": score,
+                    }
+    return sorted(candidates.values(), key=lambda c: c["score"], reverse=True)
+
+
 async def resolve_single_entity(entity: str, is_retry: bool = False) -> tuple[EntityResolution, Any]:
     """
-    Resolve a single entity name to a CURIE using Claude Agent SDK.
+    Tier 2 (#61): resolve via HTTP candidate prefetch + SDK selection.
 
-    Args:
-        entity: The entity name to resolve
-        is_retry: If True, use more aggressive retry prompt
+    Replaces the broken stdio-MCP variant-search loop: we issue the variant searches
+    over HTTP ourselves (``prefetch_resolution_candidates``), then ask the SDK — with
+    NO tools — to SELECT the best candidate.
+
+    Correctness (R1a): the returned CURIE is validated against the prefetched candidate
+    set (exact canonical match); a CURIE not in the set → method="failed" (never a
+    fabricated CURIE). Empty candidate set or transport failure → method="failed"
+    WITHOUT invoking the SDK. On a valid selection we surface the CANDIDATE's own
+    curie/name/category — never the model's emitted strings.
 
     Returns tuple of (EntityResolution, ModelUsageRecord | None).
-    EntityResolution has method="failed" on any error.
     """
+    failed = EntityResolution(
+        raw_name=entity, curie=None, resolved_name=None,
+        category=None, confidence=0.0, method="failed",
+    )
+
+    # HTTP prefetch — variant searches build the candidate set.
+    candidates = await prefetch_resolution_candidates(entity)
+    if not candidates:
+        # No real data → honest failure (no fabrication, no SDK call).
+        return (failed, None)
+
     if not HAS_SDK:
-        # SDK not available - return mock for testing
-        return (EntityResolution(
-            raw_name=entity,
-            curie=None,
-            resolved_name=None,
-            category=None,
-            confidence=0.0,
-            method="failed",
-        ), None)
+        return (failed, None)
+
+    shown = candidates[:_CANDIDATE_CAP]
+    by_canon = {_canonical_curie(c["curie"]): c for c in shown}
+    candidate_lines = "\n".join(
+        f'- curie={c["curie"]} | name={c["name"]!r} | category={c["category"]}'
+        for c in shown
+    )
+    select_prompt = (
+        f"Entity to resolve: {entity}\n\n"
+        f"Candidates (choose the best `curie` verbatim, or null):\n{candidate_lines}"
+    )
 
     try:
         async with SDK_SEMAPHORE:
-            kestrel_config = get_kestrel_mcp_config()
-
-            # Use more aggressive prompt for retry attempts
-            prompt_to_use = RESOLUTION_PROMPT
-            if is_retry:
-                prompt_to_use = RETRY_PROMPT
-
             options = ClaudeAgentOptions(
-                system_prompt=prompt_to_use,
-                allowed_tools=[
-                    "mcp__kestrel__hybrid_search",
-                    "mcp__kestrel__text_search",
-                    "mcp__kestrel__get_nodes",
-                    "mcp__kestrel__get_node_info",
-                    "mcp__kestrel__get_neighbors",
-                ],
-                mcp_servers={"kestrel": kestrel_config},
-                max_turns=5,  # Increased from 2 to allow iterative search refinement
+                system_prompt=RETRY_PROMPT if is_retry else RESOLUTION_PROMPT,
+                allowed_tools=[],  # data-in-prompt selection; no KG tools
+                max_turns=1,
                 permission_mode="bypassPermissions",
-                max_buffer_size=10 * 1024 * 1024,  # 10MB buffer for large KG responses
+                max_buffer_size=10 * 1024 * 1024,
             )
-
             result_text, usage_record = await query_with_usage(
-                prompt=f"Resolve: {entity}",
+                prompt=select_prompt,
                 options=options,
                 node_name="entity_resolution",
             )
-            return parse_resolution_result(entity, result_text), usage_record
-
     except Exception as e:
-        return (EntityResolution(
-            raw_name=entity,
-            curie=None,
-            resolved_name=None,
-            category=None,
-            confidence=0.0,
-            method="failed",
-        ), None)
+        logger.warning("Tier 2 select for '%s' failed: %s", entity, str(e))
+        return (failed, None)
+
+    # Parse the model's selection (curie + confidence → method).
+    parsed = parse_resolution_result(entity, result_text)
+    chosen = by_canon.get(_canonical_curie(parsed.curie)) if parsed.curie else None
+    if chosen is None:
+        # R1a: model returned null OR a CURIE not in the candidate set → honest failure.
+        if parsed.curie:
+            logger.warning(
+                "Tier 2 '%s': model selected out-of-candidate CURIE %s — rejected (R1a)",
+                entity, parsed.curie,
+            )
+        return (failed, usage_record)
+
+    # Surface the CANDIDATE's own fields (never the model's emitted strings).
+    return (EntityResolution(
+        raw_name=entity,
+        curie=chosen["curie"],
+        resolved_name=chosen["name"],
+        category=chosen["category"],
+        confidence=parsed.confidence,
+        method=parsed.method,
+    ), usage_record)
 
 
 

--- a/backend/src/kestrel_backend/graph/nodes/entity_resolution.py
+++ b/backend/src/kestrel_backend/graph/nodes/entity_resolution.py
@@ -378,13 +378,15 @@ async def resolve_single_entity(entity: str, is_retry: bool = False) -> tuple[En
         category=None, confidence=0.0, method="failed",
     )
 
+    # Without the SDK we can't run the selection step, so fail fast before spending
+    # any HTTP round-trips on the prefetch.
+    if not HAS_SDK:
+        return (failed, None)
+
     # HTTP prefetch — variant searches build the candidate set.
     candidates = await prefetch_resolution_candidates(entity)
     if not candidates:
         # No real data → honest failure (no fabrication, no SDK call).
-        return (failed, None)
-
-    if not HAS_SDK:
         return (failed, None)
 
     shown = candidates[:_CANDIDATE_CAP]
@@ -455,9 +457,10 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
       - Uses entity_aliases dict to find alternative names
       - Avoids expensive LLM calls for entities with known aliases
 
-    Tier 2 (LLM): Falls back to Claude Agent SDK for remaining failed entities
-      - Handles complex synonyms, abbreviations, partial matches
-      - Uses standard prompt first, then aggressive retry prompt
+    Tier 2 (LLM): HTTP prefetch + SDK selection for remaining failed entities (#61)
+      - Multi-variant HTTP searches (hybrid_search + text_search) build a candidate set
+      - SDK selects the best candidate from the list (allowed_tools=[], max_turns=1)
+      - R1a: the returned CURIE must be a member of the prefetched candidate set
 
     Returns resolved_entities list and any errors encountered.
     """

--- a/backend/src/kestrel_backend/graph/nodes/integration.py
+++ b/backend/src/kestrel_backend/graph/nodes/integration.py
@@ -27,7 +27,7 @@ from ..state import (
     EntityResolution
 )
 from ...kestrel_client import multi_hop_query, call_kestrel_tool
-from ..sdk_utils import HAS_SDK, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS, query_with_usage
+from ..sdk_utils import HAS_SDK, ClaudeAgentOptions, query_with_usage
 from ..state_contracts import validate_state, IntegrationInput, IntegrationOutput
 from ..pipeline_config import get_pipeline_config
 
@@ -515,7 +515,13 @@ def parse_integration_result(
             gaps.append(GapEntity(
                 name=g.get("name", "Unknown"),
                 category=g.get("category", "biolink:NamedThing"),
-                curie=g.get("curie"),
+                # R1b (#61): NEVER surface a model-authored CURIE as a KG fact.
+                # Gaps are "expected but ABSENT" — the model's `curie` is
+                # ungrounded training-data recall, yet synthesis renders it as a
+                # backtick CURIE indistinguishable from a real one. Null it at
+                # construction (GapEntity is frozen, so this can't be a later
+                # mutation). The gap is conveyed by name/category/expected_reason.
+                curie=None,
                 expected_reason=g.get("expected_reason", ""),
                 absence_interpretation=g.get(
                     "absence_interpretation",
@@ -631,9 +637,6 @@ Analyze these findings to identify cross-type bridges and expected-but-absent en
         # Phase B: Gap analysis using LLM (reasoning-intensive)
         logger.info("Starting LLM-based gap analysis...")
 
-        # Configure Kestrel MCP server (stdio-based, same as entity_resolution)
-        kestrel_config = get_kestrel_mcp_config()
-
         # Updated prompt focused on gap analysis only
         gap_analysis_prompt = f"""{INTEGRATION_PROMPT}
 
@@ -677,13 +680,12 @@ Return ONLY a valid JSON object:
 If no gaps found, return: {{"gaps": []}}
 """
 
+        # Gap analysis reasons over the in-prompt findings only — no KG tools (#61).
+        # The stdio MCP never launched, so these tools never registered; gap
+        # analysis has only ever reasoned over the provided context. allowed_tools=[]
+        # removes the doomed spawn with no behavioral change. Bridges are HTTP (Phase A).
         options = ClaudeAgentOptions(
-            allowed_tools=[
-                "mcp__kestrel__one_hop_query",
-                "mcp__kestrel__hybrid_search",
-                "mcp__kestrel__get_nodes",
-            ],
-            mcp_servers={"kestrel": kestrel_config},
+            allowed_tools=[],
             max_turns=5,
             permission_mode="bypassPermissions",
         )

--- a/backend/src/kestrel_backend/graph/nodes/temporal.py
+++ b/backend/src/kestrel_backend/graph/nodes/temporal.py
@@ -29,7 +29,7 @@ from ..state import (
     DiscoveryState, TemporalClassification, Finding,
     DiseaseAssociation, PathwayMembership, InferredAssociation, Bridge
 )
-from ..sdk_utils import HAS_SDK, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS, query_with_usage
+from ..sdk_utils import HAS_SDK, ClaudeAgentOptions, query_with_usage
 from ..state_contracts import validate_state, TemporalInput, TemporalOutput
 
 logger = logging.getLogger(__name__)
@@ -288,12 +288,13 @@ Classify each finding by its temporal relationship to disease progression.
 """
 
     try:
-        # Configure Kestrel MCP server (stdio-based, same as entity_resolution)
-        kestrel_config = get_kestrel_mcp_config()
-
+        # Reason over the in-prompt study context only — no KG tools (#61).
+        # The stdio MCP never launched (uvx mcp-client-kestrel is not on PyPI),
+        # so the prior "just for validation" tool was a doomed spawn on every
+        # call; allowed_tools=[] removes it with no behavioral loss. The full
+        # prompt stays in the user turn (parity-preserving; intentional).
         options = ClaudeAgentOptions(
-            allowed_tools=["mcp__kestrel__one_hop_query"],  # Minimal - just for validation
-            mcp_servers={"kestrel": kestrel_config},
+            allowed_tools=[],
             max_turns=3,  # Lightweight reasoning-focused node
             permission_mode="bypassPermissions",
         )

--- a/backend/src/kestrel_backend/graph/nodes/triage.py
+++ b/backend/src/kestrel_backend/graph/nodes/triage.py
@@ -29,12 +29,9 @@ from typing import Any
 
 from ...kestrel_client import call_kestrel_tool
 from ..state import DiscoveryState, NoveltyScore, EntityResolution
-from ..pipeline_config import get_pipeline_config
 from ..state_contracts import validate_state, TriageInput, TriageOutput
 
 logger = logging.getLogger(__name__)
-
-_config = get_pipeline_config().triage
 
 
 # Classification thresholds
@@ -149,10 +146,13 @@ def classify_by_edge_count(edge_count: int) -> str:
 @validate_state(TriageInput, TriageOutput)
 async def run(state: DiscoveryState) -> dict[str, Any]:
     """
-    Triage resolved entities by KG connectivity using two-tier approach.
+    Triage resolved entities by KG connectivity using Tier-1 HTTP only (#61).
 
-    Tier 1 (API): Direct one_hop_query with mode="preview" for all entities
-    Tier 2 (LLM): Falls back to Claude Agent SDK for any failures
+    Tier 1 (API): Direct one_hop_query with mode="preview" for all entities,
+      with a single in-place retry for transient isError/exception failures.
+      Deterministic failures (empty content, bad JSON) are not retried.
+      Entities whose count still fails after the retry default to cold_start
+      (the broken stdio-MCP Tier-2 LLM fallback was removed).
 
     Returns:
         novelty_scores: List of NoveltyScore objects

--- a/backend/src/kestrel_backend/graph/nodes/triage.py
+++ b/backend/src/kestrel_backend/graph/nodes/triage.py
@@ -24,35 +24,17 @@ to route entities to the appropriate analysis branches (direct_kg or cold_start)
 import asyncio
 import json
 import logging
-import re
 import time
 from typing import Any
 
 from ...kestrel_client import call_kestrel_tool
 from ..state import DiscoveryState, NoveltyScore, EntityResolution
-from ..sdk_utils import HAS_SDK, query_with_usage, ClaudeAgentOptions, McpStdioServerConfig, get_kestrel_mcp_config, chunk, KESTREL_COMMAND, KESTREL_ARGS
 from ..pipeline_config import get_pipeline_config
 from ..state_contracts import validate_state, TriageInput, TriageOutput
 
 logger = logging.getLogger(__name__)
 
 _config = get_pipeline_config().triage
-
-# Semaphore to serialize SDK calls and prevent concurrent CLI spawn issues
-SDK_SEMAPHORE = asyncio.Semaphore(_config.sdk_semaphore)
-
-# Concise prompt for edge counting
-EDGE_COUNT_PROMPT = """You are a knowledge graph edge counter.
-Given a CURIE, use one_hop_query to retrieve its neighbors.
-Count the total number of edges (relationships) returned.
-
-Return ONLY a valid JSON object with this exact structure (no other text):
-{"curie": "PREFIX:ID", "edge_count": N}
-
-If the query fails or returns no results, return:
-{"curie": "PREFIX:ID", "edge_count": 0}
-
-Be extremely concise. No explanations."""
 
 
 # Classification thresholds
@@ -66,12 +48,19 @@ async def count_edges_via_api(entity: EntityResolution) -> NoveltyScore | None:
     Tier 1: Count edges via direct Kestrel API call.
 
     Uses one_hop_query with mode="preview" which returns results_count (edge count).
-    Returns None if API fails (triggering Tier 2 fallback).
+    Returns None if the count fails (the caller then defaults the entity to
+    cold_start).
+
+    A single in-place retry covers genuinely *time-varying* failures (server
+    ``isError`` / exception) so a transient hiccup does not silently downgrade a
+    well-characterized entity to cold_start (#61). *Deterministic* per-CURIE
+    failures (empty content, unparseable JSON) are NOT retried — an identical-args
+    retry would re-fail — and fall to the cold_start default by returning None.
     """
     curie = entity.curie
     raw_name = entity.raw_name
 
-    # Skip entities that failed resolution
+    # Skip entities that failed resolution (deterministic — no query, no retry)
     if not curie or entity.method == "failed":
         return NoveltyScore(
             curie=curie or raw_name,
@@ -80,50 +69,69 @@ async def count_edges_via_api(entity: EntityResolution) -> NoveltyScore | None:
             classification="cold_start",
         )
 
-    try:
-        # Call one_hop_query with preview mode - returns counts instead of full data
-        result = await call_kestrel_tool("one_hop_query", {
-            "start_node_ids": curie,
-            "mode": "preview",
-            "direction": "both",
-            "limit": 10000,  # High limit to get accurate count
-        })
-
-        is_error = result.get("isError", False)
-        content = result.get("content", [])
-
-        if is_error or not content:
-            logger.debug("Tier 1 triage '%s': API error or no content", curie)
-            return None
-
-        # Parse response
-        text = content[0].get("text", "") if isinstance(content[0], dict) else str(content[0])
-
+    max_attempts = 2  # one retry, for transient failures only
+    for attempt in range(max_attempts):
         try:
-            data = json.loads(text)
-        except json.JSONDecodeError:
-            logger.debug("Tier 1 triage '%s': Could not parse JSON", curie)
-            return None
+            # Call one_hop_query with preview mode - returns counts instead of full data
+            result = await call_kestrel_tool("one_hop_query", {
+                "start_node_ids": curie,
+                "mode": "preview",
+                "direction": "both",
+                "limit": 10000,  # High limit to get accurate count
+            })
 
-        # results_count is the edge count
-        edge_count = int(data.get("results_count", 0))
-        classification = classify_by_edge_count(edge_count)
+            is_error = result.get("isError", False)
+            content = result.get("content", [])
 
-        logger.info(
-            "Tier 1 triage '%s': edges=%d, classification=%s",
-            curie, edge_count, classification
-        )
+            if is_error:
+                # Transient server-side error — retry once, then give up.
+                logger.debug(
+                    "Tier 1 triage '%s': API isError (attempt %d/%d)",
+                    curie, attempt + 1, max_attempts,
+                )
+                continue
 
-        return NoveltyScore(
-            curie=curie,
-            raw_name=raw_name,
-            edge_count=edge_count,
-            classification=classification,
-        )
+            if not content:
+                # Deterministic empty response for this CURIE — do not retry.
+                logger.debug("Tier 1 triage '%s': no content", curie)
+                return None
 
-    except Exception as e:
-        logger.warning("Tier 1 triage '%s': Exception - %s", curie, str(e))
-        return None
+            # Parse response
+            text = content[0].get("text", "") if isinstance(content[0], dict) else str(content[0])
+
+            try:
+                data = json.loads(text)
+            except json.JSONDecodeError:
+                # Deterministic malformed response — do not retry.
+                logger.debug("Tier 1 triage '%s': Could not parse JSON", curie)
+                return None
+
+            # results_count is the edge count
+            edge_count = int(data.get("results_count", 0))
+            classification = classify_by_edge_count(edge_count)
+
+            logger.info(
+                "Tier 1 triage '%s': edges=%d, classification=%s",
+                curie, edge_count, classification
+            )
+
+            return NoveltyScore(
+                curie=curie,
+                raw_name=raw_name,
+                edge_count=edge_count,
+                classification=classification,
+            )
+
+        except Exception as e:
+            # Transient (timeout / connection) — retry once, then give up.
+            logger.warning(
+                "Tier 1 triage '%s': Exception (attempt %d/%d) - %s",
+                curie, attempt + 1, max_attempts, str(e),
+            )
+            continue
+
+    # All attempts exhausted on transient failures → cold_start default (None).
+    return None
 
 
 def classify_by_edge_count(edge_count: int) -> str:
@@ -136,101 +144,6 @@ def classify_by_edge_count(edge_count: int) -> str:
         return "sparse"
     else:
         return "cold_start"
-
-
-def parse_edge_count_result(curie: str, raw_name: str, result_text: str) -> NoveltyScore:
-    """Parse LLM response into NoveltyScore object."""
-    try:
-        # Try to extract JSON from the response
-        json_match = re.search(r"\{[^{}]+\}", result_text)
-        if json_match:
-            data = json.loads(json_match.group())
-            edge_count = int(data.get("edge_count", 0))
-            return NoveltyScore(
-                curie=curie,
-                raw_name=raw_name,
-                edge_count=edge_count,
-                classification=classify_by_edge_count(edge_count),
-            )
-    except (json.JSONDecodeError, ValueError, TypeError):
-        pass
-
-    # Fallback for parse failures - treat as cold_start
-    return NoveltyScore(
-        curie=curie,
-        raw_name=raw_name,
-        edge_count=0,
-        classification="cold_start",
-    )
-
-
-async def count_edges_single(entity: EntityResolution) -> tuple[NoveltyScore, Any]:
-    """
-    Count edges for a single resolved entity using Claude Agent SDK.
-
-    Returns tuple of (NoveltyScore, ModelUsageRecord | None).
-    NoveltyScore has edge_count=0 (cold_start) on any error.
-    """
-    curie = entity.curie
-    raw_name = entity.raw_name
-
-    # Skip entities that failed resolution
-    if not curie or entity.method == "failed":
-        return (NoveltyScore(
-            curie=curie or raw_name,
-            raw_name=raw_name,
-            edge_count=0,
-            classification="cold_start",
-        ), None)
-
-    if not HAS_SDK:
-        # SDK not available - return mock for testing
-        return (NoveltyScore(
-            curie=curie,
-            raw_name=raw_name,
-            edge_count=0,
-            classification="cold_start",
-        ), None)
-
-    try:
-        async with SDK_SEMAPHORE:
-            kestrel_config = get_kestrel_mcp_config()
-
-            options = ClaudeAgentOptions(
-                system_prompt=EDGE_COUNT_PROMPT,
-                allowed_tools=[
-                    "mcp__kestrel__one_hop_query",
-                    "mcp__kestrel__get_nodes",
-                ],
-                mcp_servers={"kestrel": kestrel_config},
-                max_turns=2,
-                permission_mode="bypassPermissions",
-                max_buffer_size=10 * 1024 * 1024,  # 10MB buffer for large KG responses
-            )
-
-            result_text, usage_record = await query_with_usage(
-                prompt=f"Count edges for: {curie}",
-                options=options,
-                node_name="triage",
-            )
-
-        # Debug logging for triage edge counting
-        if not result_text:
-            logger.warning("Triage got empty result_text for %s", curie)
-        else:
-            logger.debug("Triage result for %s: %s", curie, result_text[:200] if len(result_text) > 200 else result_text)
-
-        return parse_edge_count_result(curie, raw_name, result_text), usage_record
-
-    except Exception as e:
-        logger.warning("Edge counting failed for %s: %s", curie, str(e))
-        return (NoveltyScore(
-            curie=curie,
-            raw_name=raw_name,
-            edge_count=0,
-            classification="cold_start",
-        ), None)
-
 
 
 @validate_state(TriageInput, TriageOutput)
@@ -300,61 +213,28 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
         tier1_success, len(valid_entities), tier1_duration
     )
 
-    # ========== TIER 2: LLM Edge Counting ==========
+    # ========== Tier 2 removed — failed counts default to cold_start (#61) ==========
+    # The Tier-2 LLM edge-counting fallback configured the broken stdio MCP, so with
+    # no working tools it could only guess a number. count_edges_via_api now retries
+    # once on *transient* failures (server isError / exception); any entity that still
+    # failed (None) is left unset here and backfilled to cold_start by the no-None
+    # block below — never an SDK-guessed count.
+    #
+    # NOTE (honest reroute): classify_by_edge_count has no 'unknown' bucket, so a count
+    # that fails even after the retry → edge_count=0 → cold_start, and route_after_triage
+    # sends it to the cold-start analogue branch instead of direct_kg. A genuinely
+    # well-characterized entity whose count failed is therefore downgraded. This is
+    # PRE-EXISTING behavior (the prior default was already cold_start); the migration
+    # does not worsen it, it just reaches the same default without a fabricated number.
     model_usages: list = []
-    if tier1_failed_indices and HAS_SDK:
-        tier2_start = time.time()
-        failed_entities = [valid_entities[i] for i in tier1_failed_indices]
-        logger.info(
-            "Tier 2 (LLM): Processing %d entities that failed Tier 1",
-            len(failed_entities)
-        )
+    if tier1_failed_indices:
         for idx in tier1_failed_indices:
             entity = valid_entities[idx]
             logger.info(
-                "FALLBACK_EVENT node=triage entity=%s curie=%s reason=tier1_edge_count_failed tier=2",
-                entity.raw_name if hasattr(entity, 'raw_name') else str(entity),
-                entity.curie if hasattr(entity, 'curie') else 'unknown',
-            )
-
-        tier2_results = []
-        for batch in chunk(failed_entities, _config.batch_size):
-            batch_results = await asyncio.gather(
-                *[count_edges_single(e) for e in batch],
-                return_exceptions=True,
-            )
-            tier2_results.extend(batch_results)
-
-        # Map results back
-        for idx, result in zip(tier1_failed_indices, tier2_results):
-            if isinstance(result, Exception):
-                errors.append(f"Edge counting failed for {valid_entities[idx].curie}: {str(result)}")
-                all_scores[idx] = NoveltyScore(
-                    curie=valid_entities[idx].curie or valid_entities[idx].raw_name,
-                    raw_name=valid_entities[idx].raw_name,
-                    edge_count=0,
-                    classification="cold_start",
-                )
-            else:
-                score, usage_record = result
-                all_scores[idx] = score
-                if usage_record is not None:
-                    model_usages.append(usage_record)
-
-        tier2_duration = time.time() - tier2_start
-        tier2_success = sum(1 for i in tier1_failed_indices if all_scores[i] and all_scores[i].edge_count > 0)
-        logger.info(
-            "Tier 2 (LLM) counted edges for %d/%d entities in %.1fs",
-            tier2_success, len(tier1_failed_indices), tier2_duration
-        )
-    elif tier1_failed_indices:
-        # SDK not available - mark remaining as cold_start
-        for idx in tier1_failed_indices:
-            all_scores[idx] = NoveltyScore(
-                curie=valid_entities[idx].curie or valid_entities[idx].raw_name,
-                raw_name=valid_entities[idx].raw_name,
-                edge_count=0,
-                classification="cold_start",
+                "FALLBACK_EVENT node=triage entity=%s curie=%s "
+                "reason=tier1_edge_count_failed action=default_cold_start tier=2_dropped",
+                getattr(entity, "raw_name", str(entity)),
+                getattr(entity, "curie", "unknown"),
             )
 
     # Ensure no None values

--- a/backend/src/kestrel_backend/graph/sdk_utils.py
+++ b/backend/src/kestrel_backend/graph/sdk_utils.py
@@ -23,14 +23,12 @@ try:
         SystemMessage,
         ToolUseBlock,
     )
-    from claude_agent_sdk.types import McpStdioServerConfig  # noqa: F401
     HAS_SDK = True
 except ImportError:
     HAS_SDK = False
     # Define stubs so importing code doesn't need conditional imports
     query = None  # type: ignore[assignment]
     ClaudeAgentOptions = None  # type: ignore[assignment,misc]
-    McpStdioServerConfig = None  # type: ignore[assignment,misc]
 
     # Sentinel classes so isinstance(event, X) returns False rather than raising
     # TypeError when the SDK is unavailable (issue #44 instrumentation).
@@ -46,23 +44,11 @@ except ImportError:
         pass
     ToolUseBlock = _ToolUseBlockStub  # type: ignore[assignment,misc]
 
-# Kestrel MCP server configuration constants
-KESTREL_COMMAND = "uvx"
-KESTREL_ARGS = ["mcp-client-kestrel"]
-
-
-def get_kestrel_mcp_config() -> Any:
-    """Create a McpStdioServerConfig for the Kestrel MCP server.
-
-    Returns the config object, or None if the SDK is not available.
-    """
-    if not HAS_SDK or McpStdioServerConfig is None:
-        return None
-    return McpStdioServerConfig(
-        type="stdio",
-        command=KESTREL_COMMAND,
-        args=KESTREL_ARGS,
-    )
+# NOTE (#61): the Kestrel *stdio* MCP config (get_kestrel_mcp_config, KESTREL_COMMAND,
+# KESTREL_ARGS, and the McpStdioServerConfig re-export) was removed. It pointed at
+# `uvx mcp-client-kestrel`, a package that does not exist on PyPI, so the subprocess
+# could never launch. All discovery-pipeline SDK nodes now use HTTP data-in-prompt
+# inference (allowed_tools=[]). Classic-mode agent.py keeps its own _get_kestrel_mcp_config.
 
 
 @dataclass(frozen=True)

--- a/backend/tests/test_langgraph_prototype.py
+++ b/backend/tests/test_langgraph_prototype.py
@@ -1149,6 +1149,36 @@ class TestIntegrationNode:
         assert len(gaps) == 0
         assert len(errors) > 0
 
+    def test_parse_integration_result_nulls_model_gap_curie(self):
+        """R1b (#61): a model-emitted gap CURIE is nulled, never surfaced as a KG fact.
+
+        Gaps are "expected but absent" — a CURIE the model emits is ungrounded
+        training-data recall. It must be dropped at construction so synthesis can
+        never render it indistinguishably from a real KG CURIE. The gap is still
+        conveyed by name/category/expected_reason.
+        """
+        json_response = '''
+        {
+            "bridges": [],
+            "gaps": [
+                {
+                    "name": "BCAAs",
+                    "category": "biolink:ChemicalEntity",
+                    "curie": "CHEBI:22918",
+                    "expected_reason": "Canonical early markers of T2D conversion",
+                    "absence_interpretation": "Not measured in cohort",
+                    "is_informative": true
+                }
+            ]
+        }
+        '''
+        bridges, gaps, errors = integration.parse_integration_result(json_response)
+
+        assert len(gaps) == 1
+        assert gaps[0].curie is None  # model-emitted CHEBI:22918 must be dropped
+        assert gaps[0].name == "BCAAs"  # gap still conveyed by name
+        assert len(errors) == 0
+
     def test_summarize_diseases(self):
         """Test disease summary generation for prompt."""
         diseases = [

--- a/backend/tests/test_langgraph_prototype.py
+++ b/backend/tests/test_langgraph_prototype.py
@@ -1245,6 +1245,44 @@ class TestTemporalNode:
         assert result["temporal_classifications"] == []
         assert "No findings available" in result["errors"][0]
 
+    @pytest.mark.asyncio
+    async def test_sdk_options_have_no_mcp_tools(self):
+        """Temporal builds SDK options with allowed_tools=[] and no mcp_servers (#61).
+
+        The stdio MCP never launched; the migration must remove the doomed-spawn
+        config while still producing classifications.
+        """
+        captured: dict = {}
+
+        def fake_options(**kwargs):
+            captured.update(kwargs)
+            return object()
+
+        async def fake_query(prompt, options, node_name):
+            return ('{"classifications": []}', None)
+
+        state: DiscoveryState = {
+            "is_longitudinal": True,
+            "duration_years": 5,
+            "disease_associations": [
+                DiseaseAssociation(
+                    entity_curie="CHEBI:17234",
+                    disease_curie="MONDO:0005148",
+                    disease_name="Type 2 Diabetes",
+                    predicate="biolink:related_to",
+                    source="test",
+                )
+            ],
+        }
+        with patch.object(temporal, "HAS_SDK", True), \
+                patch.object(temporal, "ClaudeAgentOptions", fake_options), \
+                patch.object(temporal, "query_with_usage", fake_query):
+            result = await temporal.run(state)
+
+        assert captured.get("allowed_tools") == []
+        assert "mcp_servers" not in captured
+        assert "temporal_classifications" in result
+
     def test_parse_temporal_result_valid_json(self):
         """Parse valid temporal classification JSON."""
         json_response = '''

--- a/backend/tests/test_langgraph_prototype.py
+++ b/backend/tests/test_langgraph_prototype.py
@@ -440,17 +440,30 @@ class TestDirectKGNode:
         assert findings == []
 
     @pytest.mark.asyncio
-    async def test_direct_kg_with_sdk_unavailable(self):
-        """Test graceful handling when SDK is not available."""
-        with patch.object(direct_kg, 'HAS_SDK', False):
-            state: DiscoveryState = {
-                "well_characterized_curies": ["CHEBI:17234"],
-                "moderate_curies": [],
-                "novelty_scores": [NoveltyScore(curie="CHEBI:17234", raw_name="glucose", edge_count=300, classification="well_characterized")],
-            }
+    async def test_tier1_failure_yields_no_findings(self):
+        """#61: when Tier-1 HTTP fails (returns None), the entity yields NO direct_kg
+        findings — honest no-findings, not a fabricated SDK fallback.
+
+        Replaces the old SDK-unavailable 'pending stub' behavior: the broken stdio
+        MCP Tier-2 fallback has been removed. analyze_via_api returns None only on
+        total failure, so there is nothing honest left to do but contribute no
+        findings for that entity.
+        """
+        async def fake_analyze_via_api(curie, raw_name):
+            return None  # simulate total Tier-1 failure
+
+        state: DiscoveryState = {
+            "well_characterized_curies": ["CHEBI:17234"],
+            "moderate_curies": [],
+            "novelty_scores": [NoveltyScore(curie="CHEBI:17234", raw_name="glucose", edge_count=300, classification="well_characterized")],
+        }
+        with patch.object(direct_kg, "analyze_via_api", fake_analyze_via_api):
             result = await direct_kg.run(state)
-            assert len(result["direct_findings"]) == 1
-            assert "SDK unavailable" in result["direct_findings"][0].claim
+
+        # No fabricated associations for the failed entity
+        assert result["direct_findings"] == []
+        assert result["disease_associations"] == []
+        assert result["pathway_memberships"] == []
 
 
 # =============================================================================
@@ -1659,10 +1672,7 @@ class TestIntegration:
     @pytest.mark.asyncio
     async def test_direct_kg_with_real_api(self):
         """Test direct_kg with actual Kestrel API calls."""
-        # Skip if SDK not available
-        if not direct_kg.HAS_SDK:
-            pytest.skip("Claude Agent SDK not available")
-
+        # direct_kg is HTTP-only (Tier-1 Kestrel API); no SDK dependency (#61)
         state: DiscoveryState = {
             "well_characterized_curies": ["CHEBI:17234"],  # glucose
             "moderate_curies": [],

--- a/backend/tests/test_langgraph_prototype.py
+++ b/backend/tests/test_langgraph_prototype.py
@@ -237,15 +237,6 @@ class TestTriageNode:
         assert triage.classify_by_edge_count(0) == "cold_start"
 
     @pytest.mark.asyncio
-    async def test_parse_edge_count_result(self):
-        """Test JSON parsing from edge count response."""
-        json_response = '{"curie": "CHEBI:17234", "edge_count": 250}'
-        result = triage.parse_edge_count_result("CHEBI:17234", "glucose", json_response)
-        assert result.curie == "CHEBI:17234"
-        assert result.edge_count == 250
-        assert result.classification == "well_characterized"
-
-    @pytest.mark.asyncio
     async def test_empty_resolved_entities(self):
         """Empty resolved entities should return empty scores."""
         state: DiscoveryState = {"resolved_entities": []}
@@ -270,8 +261,12 @@ class TestTriageNode:
         assert "unknown_entity" in result["cold_start_curies"]
 
     @pytest.mark.asyncio
-    async def test_triage_with_mocked_sdk(self):
-        """Test full triage with mocked edge counting."""
+    async def test_triage_with_mocked_tier1(self):
+        """Test full triage with mocked Tier-1 HTTP edge counting (#61).
+
+        Triage is now HTTP-only (count_edges_via_api); the SDK Tier-2 fallback
+        was removed. Mock the Tier-1 path directly.
+        """
         mock_score = NoveltyScore(
             curie="CHEBI:17234",
             raw_name="glucose",
@@ -279,7 +274,7 @@ class TestTriageNode:
             classification="well_characterized",
         )
 
-        with patch.object(triage, 'count_edges_single', return_value=(mock_score, None)):
+        with patch.object(triage, 'count_edges_via_api', return_value=mock_score):
             state: DiscoveryState = {
                 "resolved_entities": [
                     EntityResolution(
@@ -295,6 +290,55 @@ class TestTriageNode:
             result = await triage.run(state)
             assert len(result["novelty_scores"]) == 1
             assert "CHEBI:17234" in result["well_characterized_curies"]
+
+    @pytest.mark.asyncio
+    async def test_tier1_transient_failure_recovered_by_retry(self):
+        """#61: a transient per-call failure (isError) is recovered by the single
+        in-place retry — the entity keeps its real count, no cold_start reroute."""
+        ok_payload = {
+            "isError": False,
+            "content": [{"text": '{"results_count": 300}'}],
+        }
+        err_payload = {"isError": True, "content": []}
+        calls = {"n": 0}
+
+        async def flaky_call(tool_name, params):
+            calls["n"] += 1
+            return err_payload if calls["n"] == 1 else ok_payload
+
+        entity = EntityResolution(
+            raw_name="glucose", curie="CHEBI:17234", resolved_name="D-glucose",
+            category="biolink:ChemicalEntity", confidence=0.95, method="exact",
+        )
+        with patch.object(triage, "call_kestrel_tool", side_effect=flaky_call):
+            score = await triage.count_edges_via_api(entity)
+
+        assert calls["n"] == 2  # retried once
+        assert score is not None
+        assert score.edge_count == 300
+        assert score.classification == "well_characterized"
+
+    @pytest.mark.asyncio
+    async def test_tier1_persistent_failure_routes_to_cold_start(self):
+        """#61: a count that fails even after the retry → None → the entity
+        defaults to cold_start in run(), never an SDK-guessed number."""
+        async def always_error(tool_name, params):
+            return {"isError": True, "content": []}
+
+        entity = EntityResolution(
+            raw_name="glucose", curie="CHEBI:17234", resolved_name="D-glucose",
+            category="biolink:ChemicalEntity", confidence=0.95, method="exact",
+        )
+        with patch.object(triage, "call_kestrel_tool", side_effect=always_error):
+            score = await triage.count_edges_via_api(entity)
+            assert score is None  # both attempts failed
+
+            state: DiscoveryState = {"resolved_entities": [entity]}
+            result = await triage.run(state)
+
+        # Failed count defaults the entity to cold_start (documented reroute)
+        assert "CHEBI:17234" in result["cold_start_curies"]
+        assert "CHEBI:17234" not in result["well_characterized_curies"]
 
 
 # =============================================================================

--- a/backend/tests/test_langgraph_prototype.py
+++ b/backend/tests/test_langgraph_prototype.py
@@ -13,6 +13,7 @@ Run with: uv run pytest tests/test_langgraph_prototype.py -v
 
 import pytest
 import asyncio
+import json
 from unittest.mock import AsyncMock, patch, MagicMock
 
 from src.kestrel_backend.graph.builder import (
@@ -128,6 +129,102 @@ class TestEntityResolutionNode:
         assert len(chunks[0]) == 6
         assert len(chunks[1]) == 6
         assert len(chunks[2]) == 3
+
+    # ----- #61: Tier-2 HTTP prefetch + SDK select + R1a membership -----
+
+    @pytest.mark.asyncio
+    async def test_prefetch_dedups_candidates_by_canonical_curie(self):
+        """Prefetch issues variant x {hybrid,text} searches and dedups by canonical
+        CURIE, keeping the highest score."""
+        async def fake_call(tool, params):
+            st = params["search_text"]
+            # Same node surfaces from every variant/tool, with varying score + casing.
+            score = 1.5 if tool == "hybrid_search" else 0.9
+            return {"isError": False, "content": [{"text": json.dumps({
+                st: [{"id": "chebi:17234", "name": "D-glucose",
+                      "categories": ["biolink:ChemicalEntity"], "score": score}]
+            })}]}
+
+        with patch.object(entity_resolution, "call_kestrel_tool", side_effect=fake_call):
+            cands = await entity_resolution.prefetch_resolution_candidates("glucose")
+
+        assert len(cands) == 1                      # deduped despite multiple calls
+        assert cands[0]["curie"] == "chebi:17234"
+        assert cands[0]["score"] == 1.5             # best score kept
+
+    @pytest.mark.asyncio
+    async def test_resolve_selects_from_candidates_and_surfaces_candidate_fields(self):
+        """Happy path: SDK selects a candidate CURIE; we surface the CANDIDATE's
+        curie/name/category (not the model's emitted strings)."""
+        candidates = [{"curie": "CHEBI:17234", "name": "D-glucose",
+                       "category": "biolink:ChemicalEntity", "score": 1.4}]
+
+        async def fake_query(prompt, options, node_name):
+            # Model echoes a slightly different-cased curie + no name/category.
+            return ('{"curie": "chebi:17234", "confidence": 0.95}', None)
+
+        with patch.object(entity_resolution, "prefetch_resolution_candidates",
+                          return_value=candidates), \
+                patch.object(entity_resolution, "HAS_SDK", True), \
+                patch.object(entity_resolution, "query_with_usage", fake_query):
+            resolution, _ = await entity_resolution.resolve_single_entity("glucose")
+
+        assert resolution.curie == "CHEBI:17234"          # candidate's canonical-cased curie
+        assert resolution.resolved_name == "D-glucose"    # candidate's name, not model's
+        assert resolution.method == "exact"
+
+    @pytest.mark.asyncio
+    async def test_resolve_no_candidates_fails_without_sdk_call(self):
+        """Empty candidate set → method='failed' and the SDK is never invoked."""
+        sdk_called = {"n": 0}
+
+        async def spy_query(prompt, options, node_name):
+            sdk_called["n"] += 1
+            return ("{}", None)
+
+        with patch.object(entity_resolution, "prefetch_resolution_candidates",
+                          return_value=[]), \
+                patch.object(entity_resolution, "HAS_SDK", True), \
+                patch.object(entity_resolution, "query_with_usage", spy_query):
+            resolution, _ = await entity_resolution.resolve_single_entity("nonsense")
+
+        assert resolution.method == "failed"
+        assert resolution.curie is None
+        assert sdk_called["n"] == 0
+
+    @pytest.mark.asyncio
+    async def test_resolve_rejects_out_of_candidate_curie_r1a(self):
+        """R1a: a model-emitted CURIE NOT in the candidate set is rejected → failed,
+        never surfaced as a resolved fact."""
+        candidates = [{"curie": "CHEBI:17234", "name": "D-glucose",
+                       "category": "biolink:ChemicalEntity", "score": 1.4}]
+
+        async def fake_query(prompt, options, node_name):
+            # Plausible training-data CURIE that was never a candidate.
+            return ('{"curie": "CHEBI:99999", "confidence": 0.97}', None)
+
+        with patch.object(entity_resolution, "prefetch_resolution_candidates",
+                          return_value=candidates), \
+                patch.object(entity_resolution, "HAS_SDK", True), \
+                patch.object(entity_resolution, "query_with_usage", fake_query):
+            resolution, _ = await entity_resolution.resolve_single_entity("glucose")
+
+        assert resolution.method == "failed"
+        assert resolution.curie is None  # hallucinated CURIE rejected
+
+    @pytest.mark.asyncio
+    async def test_resolve_transport_failure_fails(self):
+        """Prefetch transport failure (all variant queries error) → no candidates →
+        method='failed', never a false resolution."""
+        async def boom(tool, params):
+            raise RuntimeError("connection refused")
+
+        with patch.object(entity_resolution, "call_kestrel_tool", side_effect=boom), \
+                patch.object(entity_resolution, "HAS_SDK", True):
+            resolution, _ = await entity_resolution.resolve_single_entity("glucose")
+
+        assert resolution.method == "failed"
+        assert resolution.curie is None
 
 
 # =============================================================================

--- a/backend/tests/test_sdk_utils.py
+++ b/backend/tests/test_sdk_utils.py
@@ -6,15 +6,12 @@ import pytest
 from kestrel_backend.graph.sdk_utils import (
     DEFAULT_MODEL_NAME,
     HAS_SDK,
-    KESTREL_ARGS,
-    KESTREL_COMMAND,
     ResultMessage,
     SystemMessage,
     ToolUseBlock,
     chunk,
     classify_mcp_degradation,
     create_agent_options,
-    get_kestrel_mcp_config,
     query_with_usage,
 )
 from kestrel_backend.graph.state import ModelUsageRecord
@@ -25,28 +22,6 @@ class TestHasSDK:
 
     def test_has_sdk_is_boolean(self):
         assert isinstance(HAS_SDK, bool)
-
-
-class TestKestrelConfig:
-    """Test Kestrel MCP configuration factory."""
-
-    def test_kestrel_constants(self):
-        assert KESTREL_COMMAND == "uvx"
-        assert KESTREL_ARGS == ["mcp-client-kestrel"]
-
-    def test_get_kestrel_mcp_config_returns_config_or_none(self):
-        config = get_kestrel_mcp_config()
-        if HAS_SDK:
-            assert config is not None
-            # McpStdioServerConfig may be a dict or object depending on SDK version
-            if isinstance(config, dict):
-                assert config["command"] == "uvx"
-                assert config["args"] == ["mcp-client-kestrel"]
-            else:
-                assert config.command == "uvx"
-                assert config.args == ["mcp-client-kestrel"]
-        else:
-            assert config is None
 
 
 class TestCreateAgentOptions:
@@ -81,15 +56,19 @@ class TestCreateAgentOptions:
             assert options is None
 
     def test_create_with_mcp_servers(self):
-        config = get_kestrel_mcp_config()
-        if config is not None:
-            options = create_agent_options(
-                system_prompt="With MCP",
-                allowed_tools=["hybrid_search"],
-                mcp_servers=[config],
-            )
+        # create_agent_options still supports an mcp_servers passthrough (used by
+        # future non-stdio servers); the Kestrel stdio config itself was retired (#61).
+        config = {"type": "stdio", "command": "x", "args": []}
+        options = create_agent_options(
+            system_prompt="With MCP",
+            allowed_tools=["hybrid_search"],
+            mcp_servers=[config],
+        )
+        if HAS_SDK:
             assert options is not None
             assert options.mcp_servers == [config]
+        else:
+            assert options is None
 
 
 class TestChunk:

--- a/docs/plans/2026-06-02-001-fix-five-nodes-off-stdio-mcp-plan.md
+++ b/docs/plans/2026-06-02-001-fix-five-nodes-off-stdio-mcp-plan.md
@@ -1,0 +1,311 @@
+---
+title: "fix: Migrate the five remaining SDK nodes off the broken stdio MCP (#61)"
+type: fix
+status: active
+date: 2026-06-02
+deepened: 2026-06-02
+---
+
+# fix: Migrate the five remaining SDK nodes off the broken stdio MCP (#61)
+
+## Overview
+
+PR #60 fixed `pathway_enrichment` — one of six discovery-pipeline nodes that configure the Kestrel **stdio MCP** server via `uvx mcp-client-kestrel`, a package that does not exist on PyPI (`graph/sdk_utils.py:35-36`; root-cause record in `graph/nodes/cold_start.py:1-18`; note `cold_start` is *not* one of the six — it was migrated earlier and already runs HTTP-only with `allowed_tools=[]`). The stdio subprocess can never launch, so on every SDK call these nodes pay a doomed-spawn cost, and when their SDK tier fires it produces output not grounded in the knowledge graph. (The *degree* of fabrication varies — e.g. triage's prompt funnels a failed query to `edge_count: 0`, so it degrades toward a default rather than a confident wrong number — but in no case is the SDK tier doing real KG work.)
+
+This migrates the **five remaining** nodes — `entity_resolution`, `direct_kg`, `triage`, `integration`, `temporal` — off the broken path, **right-sized per node** (not a blanket copy of the pathway_enrichment template), and retires the dead `get_kestrel_mcp_config` stdio path. Verified (issue #61): all five are low-medium severity — their authoritative outputs come from HTTP Tier 1; the broken SDK degrades only fallback/supplementary tiers. The goal is a correctness guarantee: **no SDK tier can silently surface a fabricated CURIE, association, or edge-count as a KG fact.** (Temporal *direction* and integration *gap* judgments are intentionally retained model reasoning over already-grounded findings — they annotate/relabel real CURIE-bearing findings, and gap CURIEs are **nulled/membership-checked at the data boundary (R1b)** so a gap can never surface a model-authored CURIE. The guarantee is about fabricated KG *facts*, not about eliminating all model inference.)
+
+## Problem Frame
+
+Each node requests `mcp__kestrel__*` tools in `allowed_tools` and passes `mcp_servers={"kestrel": get_kestrel_mcp_config()}`. The tools never register. Two distinct shapes exist:
+
+- **Tier-2 fallbacks** (`entity_resolution`, `direct_kg`, `triage`): the SDK tier fires *only when HTTP Tier 1 already failed* for an entity. It uses MCP tools to re-query the KG and reason. A naive "HTTP prefetch" must therefore use a *different/broader* query than the one that just failed, or it adds nothing.
+- **Reason-over-context** (`temporal`, `integration` gap analysis): the SDK already receives the data it needs in the prompt (findings summaries / study context) and uses MCP tools only to *validate/expand*. These don't need a prefetch — they need the tools removed.
+
+`integration` is the subtlest: its **bridges already come from HTTP** (`api_bridges` = `detect_bridges_via_api` (`integration.py:617`) + `detect_subgraphs_via_api` (`integration.py:624`), concatenated at `:628`; both call `call_kestrel_tool`); only the speculative **gap analysis** (tier-3 "expected but absent") uses the broken SDK (`integration.py:680-699`, which parses *gaps only* and discards the LLM bridges with `_`).
+
+## Requirements Trace
+
+- R1. No SDK tier may present hallucinated training-data as KG facts — each either uses real HTTP data, reasons only over already-provided context, or honestly fails/degrades.
+- R1a. **(closes R1 for the non-empty `entity_resolution` case)** Any CURIE returned by the select-from-candidates SDK call MUST be validated as a member of the prefetched candidate set; a CURIE the model emits that was not in the candidates is treated as `method="failed"`, never surfaced as a resolved fact. (The empty-candidate guard alone does not close this — see Key Decisions.)
+  - **Membership semantics (required, or R1a doesn't actually close the path):** compare on **exact CURIE strings after a single canonical normalization applied identically to both sides** (e.g. uppercase the prefix, trim) — **fuzzy/equivalent-namespace matching is prohibited**, since a lenient match could admit a *different* node that merely normalizes alike. On a match, **surface the matched candidate's own `curie`/`name`/`category`, never the model's emitted strings** (the model selects; it does not author the fact). Key the candidate set by the canonical form so lookup is O(1) and the surfaced object is always the prefetched one.
+- R1b. **(closes R1 for the `integration` gap path)** Integration gap entities MUST NOT surface a model-authored CURIE as a KG fact. **Construct each `GapEntity` with `curie` nulled** (or kept only if it's a member of the already-grounded in-prompt finding CURIEs — same discipline as R1a). Since gaps are by definition "expected but *absent* from these findings," unconditional nulling is acceptable and simplest. **`GapEntity` is `frozen=True` (`state.py:183`), so apply this at construction inside `parse_integration_result` (pass `curie=None`/the gated value into the constructor) — NOT by post-parse mutation like `gap.curie = None`, which raises `ValidationError`** (alternatively rebuild via `model_copy(update={"curie": None})`). A model can otherwise emit a plausible training-data CURIE that `parse_integration_result` preserves (`integration.py:518`, `curie=g.get("curie")`) into the unvalidated `GapEntity.curie` (`state.py:187`), which `synthesis.py:496` renders as a backtick CURIE indistinguishable from a real one — the same fabrication class as R1a. (Consumer audit confirmed: `synthesis.py:496/506` is the only renderer of a gap CURIE; `literature_grounding` reads `resolution.curie`, not gap CURIEs; `node_detail_extractors` builds gap items without curie — so nulling at construction covers every consumer.)
+- R2. Stop configuring the nonexistent stdio MCP server on every SDK call (remove `mcp_servers` + the `mcp__*` allowlist), eliminating the failed-spawn overhead.
+- R3. Reuse PR #60's shared pieces — `query_with_usage` diagnostics, `classify_mcp_degradation`, and the `cold_start`/`pathway_enrichment` HTTP-prefetch + `allowed_tools=[]` data-in-prompt pattern. No new abstractions.
+- R4. Preserve each node's authoritative HTTP Tier-1 output and its findings `source` tags unchanged.
+- R5. Retire `get_kestrel_mcp_config` + `KESTREL_COMMAND`/`KESTREL_ARGS` from `graph/sdk_utils.py` once no graph node references them.
+
+## Scope Boundaries
+
+- Not changing any node's **Tier-1 HTTP** logic, output schema, or finding `source` strings.
+- Not changing `pathway_enrichment` (done in #60) or `cold_start` (already HTTP, `allowed_tools=[]`).
+- Not touching classic-mode `agent.py` — it has its *own* `_get_kestrel_mcp_config` (`agent.py:86`) and stdio config; separate surface.
+- Not changing the LangGraph topology, state schema, or reducers.
+- **Single PR** (user decision) covering all five nodes + the `sdk_utils` cleanup.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **Template (prefetch + data-in-prompt):** `graph/nodes/pathway_enrichment.py` (`prefetch_one_hop_neighbors`, `_build_inference_user_prompt`, the emptiness guard, `allowed_tools=[]`, `SDK_SEMAPHORE`) and `graph/nodes/cold_start.py:148-225` (`get_entity_connections`).
+- **Shared guard/diagnostics:** `graph/sdk_utils.py` — `classify_mcp_degradation`, the `query_with_usage` `mcp_tool_calls`/`available_tools` instrumentation (from #60).
+- **Per-node SDK tiers to migrate:**
+  - `entity_resolution.py:259-320` (`resolve_single_entity`, prompt `f"Resolve: {entity}"`, tools hybrid_search/text_search/get_nodes/get_node_info/get_neighbors); Tier-1 HTTP is `resolve_via_api` (`:96`, `call_kestrel_tool("hybrid_search", ...)`).
+  - `direct_kg.py:536-600` (`analyze_single_entity`, Tier-2 `llm_fallback`); Tier-1 HTTP is `analyze_via_api` (`:292`, 6 `call_kestrel_tool("one_hop_query")` calls).
+  - `triage.py:167-235` (`count_edges_single`); Tier-1 HTTP is `count_edges_via_api` (`:64`, `call_kestrel_tool("one_hop_query", mode="preview")`).
+  - `integration.py:680-699` (gap-analysis SDK call); bridges via `detect_subgraphs_via_api` (`:414`).
+  - `temporal.py:290-310` (SDK classify, `allowed_tools=["mcp__kestrel__one_hop_query"]  # Minimal - just for validation`), reasons over `build_study_context_for_temporal` (`:138`).
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/sdk-stdio-mcp-unavailable-migrate-to-http-data-in-prompt-2026-06-02.md` — the migration + degradation-guard pattern from #60.
+- `docs/solutions/best-practices/discovery-pipeline-one-graph-methods-within-nodes-2026-05-28.md` — two-tier (HTTP + SDK) node design context.
+- `docs/plans/2026-06-01-001-fix-pathway-enrichment-mcp-degradation-plan.md` — the #60 plan this follows.
+
+## Key Technical Decisions
+
+- **Three outcomes, assigned by what the SDK tier actually needs** (not one template):
+  1. **Drop the tools** where the data is already in-context — `temporal` (validation-only tool) and `integration` gap analysis (reasons over the provided findings summaries). *The load-bearing safety argument is that the stdio MCP was **always broken**, so these tools never registered — gap analysis has therefore only ever reasoned over the in-prompt context, and dropping the (already-dead) tool config is behaviorally inert. We do not rely on the weaker, runtime-unverifiable claim "the model chose not to call the tools."*
+  2. **Drop the fallback to the honest existing default** where a prefetch would re-fail — `direct_kg` and `triage`. **The "same endpoint, same args → re-fails" premise is asymmetric across these two nodes and must not be bundled:** `analyze_via_api` (direct_kg) returns `None` *only* from its top-level `except` — a total failure, so a fresh prefetch genuinely re-fails. `count_edges_via_api` (triage), by contrast, returns `None` on per-call `isError`/empty/parse-fail for a *single* CURIE against an otherwise-healthy endpoint — a transient condition a retry could clear. So: direct_kg → remove the SDK tier, yield no findings (honest). triage → remove the SDK tier, **and add a single in-place retry of `count_edges_via_api` on per-call `None` before falling to the default** (cheap, directly addresses the flaky mode). A transient-failure *prefetch* is **out of scope** for this PR — a post-deploy follow-on if logs later justify it (see Open Questions). This PR ships drop (direct_kg) / drop-plus-retry (triage).
+  3. **Prefetch + select** where the fallback genuinely adds reach — `entity_resolution` only.
+- **`entity_resolution` is the one true prefetch — and it must preserve Tier-2's variant-search behavior.** Tier-2 fires when Tier-1 `hybrid_search` scored the *raw name* too low; its value is iterative reformulation (synonyms, de-hyphenation, prefix/gene-symbol heuristics across `max_turns=5`). A single raw-name prefetch would drop exactly those variant-spelled entities to cold_start — a recall regression, not just an "honest fail." So the prefetch must issue **multiple HTTP queries** (raw + de-hyphenated + prefix-stripped + gene-symbol variants, via `text_search` *and* `hybrid_search`, `limit>1`) to build a candidate set comparable to the live loop; the SDK then selects from candidates with `allowed_tools=[]`. This **requires rewriting `RESOLUTION_PROMPT`/`RETRY_PROMPT`** from "search the KG" to "select the best CURIE from these candidates." Empty candidate set → `method="failed"` (no fabrication).
+- **The static variant list is an *approximation* of the live loop, not an equivalent — so gate it against ground truth.** The live Tier-2 is open-ended: across `max_turns=5` the LLM generates *new* reformulations conditioned on prior results, and it could (in principle) traverse via `get_nodes`/`get_node_info`/`get_neighbors` — none of which a fixed 4-variant search prefetch reproduces. The fixed list is therefore a strict subset and *can* lose recall. **The gate must use an absolute, hand-labeled target — not "% of the pre-change baseline":** by this plan's own premise the broken Tier-2 SDK loop produces ungrounded output, so a relative gate compares against a non-functional or HTTP-only baseline and passes tautologically. Instead: a **repo-committed fixture of ≥20 hard-variant entities, each with a hand-labeled expected CURIE** (mined from #60 `FALLBACK_EVENT` entities that reached Tier-2), and the prefetch+select path must resolve **≥95% of those to the correct labeled CURIE**. On a miss, **reclassify `entity_resolution` to honest-fail** (drop Tier-2 → cold_start; the variant-string SDK loop is a deferred follow-on, not built here — user decision) — do not silently ship a regression.
+- **The empty-candidate guard does NOT close the hallucination path on its own (R1a).** With a non-empty candidate set, `parse_resolution_result` returns whatever CURIE the model emits — including a plausible training-data CURIE never in the candidates. The load-bearing protection is the **membership check (R1a)**: reject any returned CURIE not present in the prefetched candidate set → `method="failed"`. The prompt rewrite alone is *not* sufficient.
+- **The correctness guarantee is "no real data → honest failure," not the MCP classifier.** With `allowed_tools=[]` the `classify_mcp_degradation` guard is inert by design; the active protection is per-node honest-default behavior on empty/failed data **plus the data-boundary CURIE validation: entity_resolution membership check (R1a) and integration gap-CURIE nulling (R1b)**.
+- **`integration` gap analysis drops tools AND nulls model-authored gap CURIEs (R1b).** Two distinct changes: (1) drop the broken tool config — behaviorally inert, since the stdio MCP never functioned and gap analysis already reasons only over the in-prompt study context (gaps are tier-3 speculative, "expected but absent from these findings"); (2) **the tool drop alone does NOT close the fabrication path** — the model can still emit a CURIE in its gap output that flows to synthesis, so R1b nulls/membership-checks `GapEntity.curie` at construction. Bridges (HTTP) are untouched.
+- **`temporal` simply drops its validation-only tool.** Classification already reasons over `build_study_context_for_temporal`; `allowed_tools=[]` removes the doomed spawn with no behavioral loss.
+- **Reuse, don't abstract.** Each node's prefetch is small and uses node-specific tools; mirror `cold_start.get_entity_connections` per node rather than forcing a shared helper.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Severity / blocking? Verified low-medium, fallback-only, non-blocking (issue #61).
+- One PR vs many? Single PR (user decision).
+- Per-node approach? Three outcomes (review-refined): **drop-tools** (temporal, integration-gap), **drop-fallback to honest default** (direct_kg = drop only; triage = drop **+ single in-place retry** for its transient per-call `None` mode), **prefetch+select** (entity_resolution only — the one with genuine variant-search value-add).
+- `entity_resolution` prompt? **Rewrite** `RESOLUTION_PROMPT`/`RETRY_PROMPT` from "search" to "select from candidates" (required, not optional) — with multi-variant prefetch to avoid a recall regression.
+- `entity_resolution` hallucination closure? **Membership check (R1a)** is mandatory: a returned CURIE not in the prefetched candidate set → `method="failed"`. The empty-candidate guard alone is insufficient.
+- `entity_resolution` recall safety? **Pre-committed go/no-go gate against a repo-committed, hand-labeled fixture** (≥20 hard-variant entities, ≥95% resolved to the correct labeled CURIE — absolute, *not* relative to the non-functional Tier-2 baseline). Build/freeze the fixture before coding.
+- **Gate-miss behavior? (user decision)** **Reclassify `entity_resolution` to honest-fail** — drop Tier-2 entirely (consistent with `direct_kg`); gate-failing variants route to cold_start. Honest failure is always in scope and satisfies the correctness goal; a recall hit is accepted rather than introducing a third resolution strategy in this fix-PR. The variant-string SDK loop is **not** built here — if production later shows the recall hit matters, it is a separate follow-on issue.
+
+### Deferred to Implementation
+
+- **`text_search`'s response envelope (request param already resolved).** The request param is `search_text` (confirmed in `kestrel_tools.py`, matching `hybrid_search`) — reuse it. **Still verify the response envelope before reusing `resolve_via_api`'s parse path:** if `text_search` returns a different shape than the `{search_text: [results]}` envelope `resolve_via_api` parses (`entity_resolution.py:143-150`), the parse silently yields zero candidates for *all* `text_search` results — partially defeating the variant search with no error signal. Treat as a **Unit 3 precondition**, not an optional deferral.
+- **Optional `direct_kg`/`triage` prefetch — out of scope for this PR.** This PR commits to **drop** (`direct_kg`) and **drop + single retry** (`triage`); both fully satisfy R1–R5 without a prefetch. A transient-failure prefetch is a **post-deploy follow-on**, not an in-PR log-gated decision: after merge, check the #60 `FALLBACK_EVENT`/`mcp_tool_calls=0` lines (`sudo journalctl -u kraken-backend-dev | grep FALLBACK_EVENT`); only if they show a meaningful per-call/transient rate that the triage retry doesn't already clear, open a separate issue to add a thin `one_hop_query` prefetch. Do not build it speculatively here.
+- **`triage_failed` marker (optional).** Whether to add a distinct marker so Synthesis can flag reduced confidence for entities rerouted to cold-start by a failed count, vs. leaving the pre-existing `cold_start` default (Unit 5).
+
+## High-Level Technical Design
+
+> *This illustrates the intended per-node approach and is directional guidance for review, not implementation specification.*
+
+| Node | Broken SDK tier does | Migration pattern | Empty/failure behavior |
+|---|---|---|---|
+| `temporal` | classify longitudinal; tool "just for validation" | **drop tools** (`allowed_tools=[]`, no `mcp_servers`); reason over study context | unchanged (classification still runs) |
+| `integration` (gap) | speculative gap analysis | **drop tools** + **null model-authored gap CURIEs at construction (R1b)**; reason over provided findings context | gap CURIEs nulled (R1b); empty gaps possible; bridges unaffected, already HTTP |
+| `entity_resolution` | Tier-2 name→CURIE *variant search* | **prefetch + select**: multi-variant HTTP `text_search`+`hybrid_search` (`limit>1`) → SDK selects CURIE (`allowed_tools=[]`); **rewrite prompt** to "select from candidates"; **validate returned CURIE ∈ candidates (R1a)** | no candidates → `method="failed"`; transport failure → `method="failed"`; CURIE not in candidates → `method="failed"` |
+| `direct_kg` | Tier-2 association lookup (fires on *total* Tier-1 failure) | **drop fallback** → honest no-findings (prefetch only if logs show per-call failures) | no findings |
+| `triage` | Tier-2 edge counting (fires on *per-call/transient* Tier-1 failure) | **drop fallback + single in-place retry** on per-call `None` → existing default (prefetch only if logs justify) | default classification = `cold_start` (reroutes entity — see Unit 5) |
+| `sdk_utils` | — | **retire** `get_kestrel_mcp_config` + `KESTREL_*` | n/a |
+
+## Implementation Units
+
+- [ ] **Unit 1: `temporal` — drop the validation-only MCP tool**
+
+**Goal:** Stop configuring the broken stdio server in temporal; reason over the already-provided study context.
+
+**Requirements:** R1, R2, R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `backend/src/kestrel_backend/graph/nodes/temporal.py` (SDK options; **edit the `from ..sdk_utils import ...` line to remove only the dead symbols** — `get_kestrel_mcp_config`, `McpStdioServerConfig`, `KESTREL_COMMAND`, `KESTREL_ARGS` — while **keeping** the still-used `HAS_SDK`, `query_with_usage`, `ClaudeAgentOptions` (note: `chunk` is **not** imported/used in this file); Unit 6 deletes the symbols from `sdk_utils`)
+- Test: `backend/tests/test_langgraph_prototype.py` (`TestTemporalNode`)
+
+**Approach:**
+- Set `allowed_tools=[]`, remove `mcp_servers` and the `get_kestrel_mcp_config()` call. The classification prompt already includes `build_study_context_for_temporal` output — no prefetch needed. With `allowed_tools=[]` the MCP classifier is inert (no false degradation).
+- **Prune the now-dead `..sdk_utils` import names** (see Files) so Unit 6's symbol deletion can't leave a dangling import that breaks graph build.
+- If `TEMPORAL_PROMPT` still instructs tool use (e.g. "use one_hop_query…"), prune that reference so the model doesn't waste a turn or emit "tools not available" phrasing under `allowed_tools=[]`.
+- **`system_prompt` structure:** the current temporal call embeds the full prompt in the user turn and passes no `system_prompt` (unlike the `cold_start` pattern, which splits a `system_prompt`). Keeping the existing user-turn structure is fine for parity — but make it a *deliberate* choice: do not silently diverge from the cited `cold_start` pattern. If aligning with `cold_start`, split `TEMPORAL_PROMPT` into `system_prompt` + user turn explicitly; otherwise note that the user-turn structure is retained intentionally.
+
+**Execution note:** Characterization-first — capture current temporal classification output on a longitudinal fixture before the change to assert parity.
+
+**Patterns to follow:** `cold_start` SDK call (`allowed_tools=[]`, reason over provided data).
+
+**Test scenarios:**
+- Happy path: longitudinal study fixture → temporal classifications produced (parity with pre-change shape).
+- Edge case: non-longitudinal → still skips (routing unchanged).
+- Error path: `HAS_SDK is False` → existing graceful return unchanged.
+
+**Verification:** temporal produces classifications with `allowed_tools=[]` and no `mcp_servers`; no reference to `get_kestrel_mcp_config` remains in the file.
+
+- [ ] **Unit 2: `integration` gap analysis — drop tools, reason over context**
+
+**Goal:** Migrate the gap-analysis SDK call off MCP, **and close the gap-CURIE fabrication path (R1b)**; leave the HTTP bridges untouched.
+
+**Requirements:** R1, R1b, R2, R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `backend/src/kestrel_backend/graph/nodes/integration.py` (gap-analysis SDK options; **null/membership-check `GapEntity.curie` after parse (R1b)**; **edit the `..sdk_utils` import line to remove only the dead symbols**, keeping the still-used `HAS_SDK`/`query_with_usage`/`ClaudeAgentOptions` (note: `chunk` is **not** imported/used in this file))
+- Test: `backend/tests/test_langgraph_prototype.py` (`TestIntegrationNode`)
+
+**Approach:**
+- Set `allowed_tools=[]`, remove `mcp_servers`/`get_kestrel_mcp_config`. **The tool-drop safety argument is structural, not behavioral:** the stdio MCP was always broken, so the gap-analysis tools never registered — gap analysis has only ever reasoned over the in-prompt study context (findings summaries). Dropping the (already-dead) tool config is therefore **behaviorally inert**. (We do not rely on the runtime-unverifiable claim "the model chose not to call the tools.") `bridges = api_bridges` (HTTP) path stays exactly as-is.
+- **Close the gap-CURIE hole (R1b — the tool drop alone does NOT close it):** `parse_integration_result` currently keeps `curie=g.get("curie")` (`integration.py:518`) → unvalidated `GapEntity.curie` (`state.py:187`) → rendered by `synthesis.py:496`. **`GapEntity` is `frozen=True` (`state.py:183`)**, so do this **at construction** — pass `curie=None` (or the membership-gated value) into the `GapEntity(...)` call at `integration.py:515-525`; do **not** write `gap.curie = None` post-parse (raises `ValidationError`). Gaps are "expected but *absent*," so the CURIE is not needed to convey the gap. Consumer audit (already done): `synthesis.py:496/506` is the sole renderer; `literature_grounding` reads `resolution.curie` not gap CURIEs; `node_detail_extractors` omits the gap curie — nulling at construction covers all. (Membership variant: source the allowlist from the in-prompt finding CURIEs actually placed in the prompt, not raw model output.)
+- Prune the dead `..sdk_utils` import names (see Files) and any tool-usage instruction left in the gap prompt / `INTEGRATION_PROMPT`.
+
+**Execution note:** Characterization-first — assert bridges (HTTP) are unchanged and gaps still parse; capture a model-emitted non-null gap CURIE pre-change and assert it is nulled post-change.
+
+**Patterns to follow:** the existing `bridges = api_bridges` / `parse_integration_result` flow (`integration.py:698-702`); R1a's membership discipline for the optional keep-if-grounded variant.
+
+**Test scenarios:**
+- Happy path: study context with an obvious absent marker → a gap is produced; bridges from `api_bridges` unchanged.
+- Edge case: no informative gaps → `gaps == []`; bridges still emitted.
+- **R1b path: model emits a non-null gap `curie` → it is nulled (or rejected) and does NOT appear in the synthesis report.**
+- Integration: output dict still carries `bridges`, `gap_entities`, `direct_findings` with the same `source` tags.
+
+**Verification:** gaps are produced with `allowed_tools=[]`; bridges and their source/HTTP path are byte-unchanged; **a model-emitted gap CURIE never reaches the synthesis report (R1b)**; no `get_kestrel_mcp_config` reference remains.
+
+- [ ] **Unit 3: `entity_resolution` Tier-2 — HTTP search-candidate prefetch + SDK select**
+
+**Goal:** Replace the MCP-tool search fallback with an HTTP `text_search`+`hybrid_search` prefetch; the SDK selects the best CURIE; no candidates → honest `failed`.
+
+**Requirements:** R1, R1a, R2, R3, R4
+
+**Dependencies:** None (uses existing `call_kestrel_tool`)
+
+**Files:**
+- Modify: `backend/src/kestrel_backend/graph/nodes/entity_resolution.py` (`resolve_single_entity`; add a multi-variant prefetch helper; **rewrite `RESOLUTION_PROMPT`/`RETRY_PROMPT`** to "select from candidates"; **add post-parse candidate-membership validation (R1a)**; remove only the dead `..sdk_utils` import names)
+- Test: `backend/tests/test_langgraph_prototype.py` (`TestEntityResolution*`) or a new `backend/tests/test_entity_resolution.py`
+
+**Approach:**
+- **Scope (mirrors Units 4/5):** this PR builds a **fixed-variant HTTP prefetch + membership-gated selection**. The open-ended `max_turns=5` reformulation loop is **not** reproduced or re-implemented here; if the recall gate is missed, **reclassify to honest-fail (drop Tier-2 → cold_start)** — the variant-string SDK loop is a deferred follow-on. Do not attempt the iterative loop as an in-PR secondary fallback.
+- **Preserve Tier-2's variant-search behavior, server-side.** Tier-2 fires when Tier-1 `hybrid_search` scored the *raw name* too low — **but note `resolve_via_api` returns `None` on `is_error`/empty/parse-fail too, not only on score `< 0.6`.** So a low score (prefetch helps) and a transport/endpoint failure (prefetch re-fails — same trap as direct_kg/triage) both route here. The prefetch is the right fix for the *score* case; on a *transport* failure it must fail honestly (`method="failed"`), not imply recovery. Issue **multiple prefetch queries** (raw + de-hyphenated + prefix-stripped + gene-symbol forms) across `text_search` *and* `hybrid_search`, with `limit > 1` (e.g. 5-10) and iterate the full results list — do **not** copy `resolve_via_api`'s `limit:1`/`results[0]`. Dedup into a candidate set of `{curie, name, category, score}`.
+- **Rewrite the SDK call to select, not search:** new prompt = "select the single best CURIE for `<entity>` from these candidates, or null if none fit"; `allowed_tools=[]`; parse via `parse_resolution_result`. **No candidates → `method="failed"`** without invoking the SDK.
+- **Validate the selection (R1a — this, not the prompt, closes the hallucination path):** after parsing, **check the returned CURIE is a member of the prefetched candidate set** via exact match on a single canonical normalization applied to both sides (uppercase prefix + trim); **no fuzzy matching**. On a hit, surface the **candidate's** `curie`/`name`/`category`, not the model's emitted fields. A model can emit a plausible training-data CURIE that was never in the candidates; reject it → `method="failed"`. The prompt rewrite reduces but does not eliminate this. (Beware: `resolve_via_api` reads `top.get("id") or top.get("curie")` while `parse_resolution_result` reads `data.get("curie")` — two independently-formatted strings, which is exactly why the normalization must be applied to both.)
+- **The static variant list is an approximation, not an equivalent of `max_turns=5`.** It cannot reproduce the live loop's turn-by-turn reformulation or its `get_nodes`/`get_neighbors` traversal, so recall *can* drop. **Gate on the pre-committed ground-truth fixture (see Execution note); on a miss, reclassify `entity_resolution` to honest-fail (drop Tier-2, route to cold_start) — the variant-string SDK loop is a follow-on, not built here** (user decision). Do not silently ship the static-list prefetch if it underperforms.
+- `text_search`'s request param is `search_text` (confirmed, matches `hybrid_search`); **verify its response envelope** matches the `{search_text: [results]}` shape `resolve_via_api` parses before reusing that parse path, and add a branch if it differs — see Deferred.
+- **Parse robustness (harden proactively — do NOT defer to the gate):** `parse_resolution_result`'s `\{[^{}]+\}` regex cannot match *nested* JSON. Keep the new "select from candidates" prompt's output a **flat** object (`{"curie": ..., "confidence": ...}`) **and** ensure the parser either handles any plausible nested shape or rejects it → `method="failed"` (honest). The recall gate validates *recall on the fixture entities*, not *parser correctness on corner cases*, so a silent parse failure on an out-of-fixture shape would slip through — fix it at the parser, not by hoping the fixture exercises it.
+
+**Execution note:** Characterization-first against a **pre-committed, repo-committed fixture** of ≥20 hard-variant entities (hyphenation/gene-symbol/prefix cases that motivated `max_turns=5`, mined from #60 `FALLBACK_EVENT` entities), **each carrying a hand-labeled expected CURIE**. **Go/no-go gate: the prefetch+select path must resolve ≥95% of the fixture to its labeled CURIE** (absolute target — not relative to the non-functional Tier-2 baseline). Build and freeze the fixture *before* implementing so the gate is reviewable and not self-graded. On a miss, **reclassify to honest-fail (drop Tier-2 → cold_start)**, not a shipped regression; do not assume recall can only improve.
+
+**Patterns to follow:** `resolve_via_api` (`:96-200`) for the HTTP call/parse; `pathway_enrichment.prefetch_one_hop_neighbors` for the gather/errored handling.
+
+**Test scenarios:**
+- Happy path: mocked multi-query prefetch returns candidates → SDK selects the best → resolved CURIE.
+- Edge case (the point of the node): a variant form (de-hyphenated / gene-symbol) surfaces a candidate the raw name missed → resolves; assert recall ≥ a curated set of hard entities.
+- Error path: no candidate across all variants → `method="failed"`, SDK not called (no fabricated CURIE).
+- Error path: **SDK returns a CURIE not in the candidate set → `method="failed"` (R1a membership check), no fabricated CURIE surfaced.**
+- Error path: prefetch hits a transport failure (all variant queries error) → `method="failed"`, not a false resolution.
+- Error path: `HAS_SDK is False` → existing failed-resolution shape unchanged.
+
+**Verification:** Tier-2 resolves from HTTP candidates with `allowed_tools=[]`; the committed hard-variant fixture resolves at **≥95% to its hand-labeled CURIEs** (else reclassify to honest-fail: drop Tier-2 → cold_start); empty candidates **and out-of-set selections** yield `failed`, never a hallucinated CURIE.
+
+- [ ] **Unit 4: `direct_kg` Tier-2 — drop the broken SDK fallback (default) → honest no-findings**
+
+**Goal:** Remove the `llm_fallback` SDK tier that fires only on total Tier-1 failure and can only fabricate; entities whose Tier-1 failed contribute no `direct_kg` findings (honest), not hallucinated associations.
+
+**Requirements:** R1, R2, R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `backend/src/kestrel_backend/graph/nodes/direct_kg.py` (`analyze_single_entity` + its call site; remove **only** the dead `..sdk_utils` import names — and if dropping the Tier-2 batching loop removes the file's last `chunk(...)` call, drop `chunk` too; otherwise keep it)
+- Test: `backend/tests/test_langgraph_prototype.py` (`TestDirectKG*`) or new `backend/tests/test_direct_kg.py`
+
+**Approach:**
+- **Default: drop the SDK Tier-2.** `analyze_via_api` returns `None` only from its top-level `except` (a total failure; per-call errors are swallowed with `continue`), so a fresh `one_hop_query` prefetch would call the *same* failing endpoint with the *same* CURIE and re-fail. Remove the `mcp_servers`/`allowed_tools` SDK call; an entity whose Tier-1 failed simply yields no `direct_kg` findings.
+- **Prefetch is out of scope (post-deploy follow-on).** `direct_kg`'s `None` is total-failure-only, so a prefetch would re-fail the same endpoint; drop is the complete fix. If post-deploy logs ever show per-call/transient failures, a thin HTTP `one_hop_query` prefetch + `allowed_tools=[]` extraction (parse via `parse_direct_kg_result`, `source="direct_kg:llm_fallback"`, empty → no findings) is a *separate* issue — not built here (see Open Questions).
+
+**Execution note:** Characterization-first — capture current fallback output, then assert the dropped path yields no fabricated associations.
+
+**Patterns to follow:** the existing Tier-1 `analyze_via_api` result handling (Tier-2 reached only when it returns `None`).
+
+**Test scenarios:**
+- Happy path: Tier-1 succeeds → Tier-2 never invoked (unchanged); associations come from HTTP.
+- Error path: Tier-1 returns `None` for an entity → no `direct_kg` findings for it (no fabricated associations), pipeline continues.
+- Error path: `HAS_SDK is False` → unchanged.
+
+**Verification:** no `mcp_servers`/`mcp__*` config remains in `direct_kg.py`; a failed-Tier-1 entity yields zero fabricated associations.
+
+- [ ] **Unit 5: `triage` Tier-2 — drop the broken SDK fallback (default); name the reroute honestly**
+
+**Goal:** Remove the edge-counting SDK fallback that fires only on total Tier-1 failure; a failed count falls to triage's existing default classification — and the plan states the routing consequence plainly.
+
+**Requirements:** R1, R2, R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `backend/src/kestrel_backend/graph/nodes/triage.py` (`count_edges_single` + call site; remove **only** the dead `..sdk_utils` import names — and if dropping the Tier-2 batching loop removes the file's last `chunk(...)` call, drop `chunk` too; otherwise keep it)
+- Test: `backend/tests/test_langgraph_prototype.py` (`TestTriageNode`) or new `backend/tests/test_triage.py`
+
+**Approach:**
+- **Default: drop the SDK Tier-2.** `count_edges_via_api` already funnels failures toward `edge_count=0`, and the SDK fallback (with broken tools) can't do better. Remove the SDK call.
+- **Add a single in-place retry of `count_edges_via_api` on per-call `None` before defaulting** (this node, unlike `direct_kg`). `count_edges_via_api` returns `None` on per-call `isError`/empty/parse-fail for a *single* CURIE against an otherwise-healthy endpoint. **Scope the retry to the genuinely time-varying causes (exception/timeout/`isError`)** — those a retry can clear. A *stable* empty/malformed envelope for a specific CURIE is **deterministic**: an identical-args retry re-fails, so it correctly falls to the documented `cold_start` reroute (that is expected, not a failure of the retry). A small backoff/jitter is optional; do not claim the retry "handles transient failures" for the deterministic class. A genuinely well-characterized entity should not be downgraded because one preview query *flaked* — that is the case this targets. (Do **not** add this to `direct_kg`, whose `None` is total-failure-only.)
+- **Name the consequence honestly (this is NOT a neutral "unknown"):** `classify_by_edge_count` has no `unknown` bucket — a count that fails *even after the retry* → `edge_count=0` → `cold_start`, which `route_after_triage` sends to the cold-start analogue branch instead of `direct_kg`. So a *genuinely well-characterized* entity whose triage still failed is downgraded to cold-start analysis. This is **pre-existing** behavior (the current default is already `cold_start`), so the migration doesn't worsen it — but decide whether to leave it or add a distinct `triage_failed` marker so Synthesis can flag reduced confidence. Record the decision.
+- **Prefetch is out of scope (post-deploy follow-on).** Beyond the retry, a thin `one_hop_query` prefetch could occasionally succeed, but it is **not built here** — a separate issue only if post-deploy logs show transient failures the single retry didn't clear (see Open Questions).
+
+**Execution note:** Characterization-first on the classification output + routing.
+
+**Patterns to follow:** `count_edges_via_api` (`:64`) + `classify_by_edge_count`.
+
+**Test scenarios:**
+- Happy path: Tier-1 counts an edge → correct `classify_by_edge_count` bucket (unchanged).
+- Error path: Tier-1 returns `None` once then succeeds on retry → correct bucket (assert the retry recovers the transient case, no reroute).
+- Error path: Tier-1 returns `None` on both attempts → entity defaults to `cold_start` (assert the reroute, no SDK-guessed count).
+- Error path: `HAS_SDK is False` → unchanged.
+
+**Verification:** no `mcp_servers`/`mcp__*` config remains in `triage.py`; a transient per-call `None` is recovered by one retry; counts failing after retry default to `cold_start` (documented reroute), never an SDK-guessed number.
+
+- [ ] **Unit 6: Retire the dead stdio config in `sdk_utils.py`**
+
+**Goal:** Remove `get_kestrel_mcp_config` + `KESTREL_COMMAND`/`KESTREL_ARGS` once no graph node references them.
+
+**Requirements:** R5
+
+**Dependencies:** Units 1-5 (all graph callers removed)
+
+**Files:**
+- Modify: `backend/src/kestrel_backend/graph/sdk_utils.py` (remove `get_kestrel_mcp_config`, `KESTREL_COMMAND`, `KESTREL_ARGS`, and the `McpStdioServerConfig` re-export — review confirmed `agent.py` imports it directly from `claude_agent_sdk.types`, not from `sdk_utils`, so nothing imports it from here once the five nodes are pruned)
+- Test: `backend/tests/test_sdk_utils.py` (delete `TestKestrelConfig` **and** remove `KESTREL_COMMAND`/`KESTREL_ARGS`/`get_kestrel_mcp_config` from the module-level import — otherwise the test module fails at collection)
+
+**Approach:**
+- After Units 1-5 prune their import lines, remove the symbols. Classic `agent.py` keeps its own `_get_kestrel_mcp_config` — leave it.
+
+**Test expectation:** none beyond removing `TestKestrelConfig` + its imports; import-cleanliness covered by the suite.
+
+**Verification:** `grep -rn "get_kestrel_mcp_config\|KESTREL_COMMAND\|KESTREL_ARGS\|McpStdioServerConfig" backend/src/kestrel_backend/graph/` returns nothing; **also confirm nothing outside `graph/` imports the removed re-export** with `grep -rn "from .*sdk_utils import.*McpStdioServerConfig" backend/src/` (expected: none — `agent.py` imports `McpStdioServerConfig` directly from `claude_agent_sdk.types`, not from `sdk_utils`); **`uv run python -c "import kestrel_backend.graph.builder"` succeeds** (proves no node left a dangling import — `builder.py` eagerly imports all node modules); suite collects and imports clean.
+
+## System-Wide Impact
+
+- **Interaction graph:** all five nodes feed Integration/Synthesis; outputs (CURIEs, associations, edge-count classifications, gaps, temporal classifications) keep their schemas and `source` tags, so downstream consumers are unaffected.
+- **Error propagation:** the change *strengthens* honesty — failure modes that previously hallucinated now return `failed`/`unknown`/empty, via two mechanisms: **tool-drop** (temporal, integration bridges) and **data-boundary CURIE validation** (entity_resolution membership check R1a; integration gap-CURIE nulling R1b). No new exceptions introduced.
+- **State lifecycle:** no state-schema or reducer changes; no new fields.
+- **API surface parity:** this completes the parity started by #60 — after it, all six SDK nodes are off the broken stdio path and `cold_start`-style.
+- **Unchanged invariants:** every node's HTTP Tier-1 logic, output schema, and finding `source` strings; classic-mode `agent.py`; LangGraph topology.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| **Stale `..sdk_utils` import after Unit 6 deletes symbols → ImportError breaks the whole graph** (`builder.py` eagerly imports all node modules) | Each of Units 1-5 edits its `..sdk_utils` import to remove **only** the dead symbols (keeping each file's still-used subset of `HAS_SDK`/`query_with_usage`/`ClaudeAgentOptions`/`chunk` — `chunk` only in the batching nodes, not temporal/integration); Unit 6 greps **all** dead symbols (not just `get_kestrel_mcp_config`) and runs `import kestrel_backend.graph.builder` as a smoke gate. |
+| **`entity_resolution` recall regression**: a fixed-variant prefetch is a strict *subset* of the live `max_turns=5` loop (no turn-by-turn reformulation, no `get_neighbors` traversal) and can drop variant-spelled entities to cold_start | Multi-variant prefetch (de-hyphenated / prefix / gene-symbol forms) to rebuild a comparable candidate set; **pre-committed go/no-go gate against a repo-committed, hand-labeled fixture (≥95% to correct CURIE — absolute, not relative to the non-functional Tier-2 baseline)**; on a miss, **reclassify to honest-fail (drop Tier-2 → cold_start)** — do not assume "can only improve." |
+| **`entity_resolution` hallucinated CURIE survives the empty-candidate guard**: with non-empty candidates the model can emit a training-data CURIE never in the set | **R1a membership check**: reject any returned CURIE not present in the prefetched candidate set → `method="failed"`. The prompt rewrite alone does not close this. |
+| `direct_kg`/`triage` prefetch would re-fail (same endpoint Tier-1 just failed on) | `direct_kg`: `None` is total-failure-only → **drop**, no retry. `triage`: `None` is transient per-call → **drop + single in-place retry** before defaulting. Build a *prefetch* only if logs show transient failures the retry didn't clear (committed default if logs unavailable: no prefetch). |
+| `triage` failed count silently reroutes a well-characterized entity to cold-start | Single retry recovers the transient case; residual reroute is pre-existing behavior (current default is already `cold_start`); plan names it explicitly and offers an optional `triage_failed` marker decision (Unit 5). |
+| **`entity_resolution` Tier-1 `None` conflates score-too-low with transport failure** — prefetch helps the former, re-fails the latter | Prefetch is correct for the score case; on transport failure (all variant queries error) it returns `method="failed"`, never a false resolution. |
+| Larger single-PR diff across five node files | Units 1+2 (drop-tools) are independently safe; the `direct_kg`/`triage` simplification (drop, not prefetch) shrinks the contested surface; characterization-first per node; the builder import smoke test gates the whole PR. |
+
+## Documentation / Operational Notes
+
+- Run tests with `cd backend && uv run python -m pytest tests/ -v -m "not integration"` (venv-path-spaces learning).
+- After merge, close #61 and note in the #60 compound doc that all six SDK nodes are migrated.
+- Production logs: the #60 `mcp_tool_calls=0` diagnostics for these nodes should disappear once migrated — a quick post-deploy confirmation.
+
+## Sources & References
+
+- Issue: #61 (this work); PR #60 (pathway_enrichment precedent), PR #24 (cold_start precedent).
+- Plan: `docs/plans/2026-06-01-001-fix-pathway-enrichment-mcp-degradation-plan.md`.
+- Learning: `docs/solutions/best-practices/sdk-stdio-mcp-unavailable-migrate-to-http-data-in-prompt-2026-06-02.md`.
+- Code: `graph/nodes/{entity_resolution,direct_kg,triage,integration,temporal}.py`, `graph/sdk_utils.py`, `graph/nodes/cold_start.py:148-225`.

--- a/docs/solutions/best-practices/sdk-stdio-mcp-unavailable-migrate-to-http-data-in-prompt-2026-06-02.md
+++ b/docs/solutions/best-practices/sdk-stdio-mcp-unavailable-migrate-to-http-data-in-prompt-2026-06-02.md
@@ -1,0 +1,118 @@
+---
+title: "When a Claude Agent SDK node's stdio MCP server can't launch, it silently hallucinates — detect it and migrate to HTTP data-in-prompt"
+date: 2026-06-02
+category: docs/solutions/best-practices
+module: kestrel_backend.graph
+problem_type: best_practice
+component: assistant
+severity: high
+applies_when:
+  - "A discovery-pipeline node uses the Claude Agent SDK with a stdio MCP server (uvx/npx-launched) and allowed_tools requesting mcp__* tools"
+  - "An SDK phase's output looks plausible but may be fabricated from training data rather than the knowledge graph"
+  - "A node depends on an external MCP package that may not exist / fail to launch in the deploy environment"
+tags:
+  - claude-agent-sdk
+  - mcp
+  - stdio
+  - hallucination
+  - degradation-guard
+  - data-in-prompt
+  - kestrel
+  - pathway-enrichment
+---
+
+# When a Claude Agent SDK node's stdio MCP server can't launch, it silently hallucinates — detect it and migrate to HTTP data-in-prompt
+
+## Context
+
+Issue #44 reported that `pathway_enrichment` Phase B intermittently announced *"The Kestrel MCP tools are not available in my current tool set"* and then produced one-hop analysis fabricated from the model's training knowledge. Investigation found the root cause is **not** a race: the stdio MCP server is configured to launch `uvx mcp-client-kestrel` (`graph/sdk_utils.py:35-36`), but **`mcp-client-kestrel` does not exist on PyPI** — already discovered and documented in `graph/nodes/cold_start.py:1-18` (PR #24 migrated cold_start off it for exactly this reason). The stdio subprocess can never start, so the tools never register; under `permission_mode="bypassPermissions"` the model fills the gap by hallucinating.
+
+The same broken stdio path is used by **all six SDK nodes** (`pathway_enrichment`, `entity_resolution`, `direct_kg`, `integration`, `temporal`, `triage`) — each passes `mcp_servers={"kestrel": get_kestrel_mcp_config()}` and requests `mcp__kestrel__*` tools. The failure is masked to varying degrees because most nodes also have an HTTP tier (see [[discovery-pipeline-one-graph-methods-within-nodes-2026-05-28]]). `pathway_enrichment` was the most visible because its Phase B one-hop analysis was SDK-primary.
+
+## Guidance
+
+Three reusable practices came out of this fix (PR #60):
+
+**1. Prefer HTTP data-in-prompt over stdio MCP for KG access.** Fetch the data deterministically via the HTTP client (`call_kestrel_tool`), then have the SDK *reason over the provided data* with `allowed_tools=[]` and no `mcp_servers`. This is the proven `cold_start` pattern — the model can't hallucinate KG facts it was handed, and you don't depend on a subprocess launching.
+
+**2. Add a structural degradation guard at the shared SDK layer.** Don't trust SDK output that *claims* to use tools. Instrument the SDK event stream to count `mcp__*` tool-use blocks and capture the init tool list, then classify:
+- **Definitive:** init tool list known and missing an expected tool.
+- **Structural:** expected tools non-empty AND zero `mcp__*` calls (only safe for prompts that *mandate* tool use).
+- **Corroborator only:** the fallback phrase (`"not available in my current tool set"`) — never the sole trigger; model wording is brittle.
+- **Never degrade** when `expected_tools == []` (data-in-prompt nodes), or when the init list confirms all tools present and there's no phrase.
+
+On degradation, **drop the unreliable findings and set a `degraded` flag** so synthesis/UI can disclose the gap — silent fabricated findings are worse than a visible gap.
+
+**3. Stage independent (HTTP) findings outside the SDK `try`.** Anything not produced by the fragile SDK call (e.g. a parallel HTTP analysis) must be computed *before* the `try` and emitted on **every** exit path — happy, degraded-drop, timeout, and exception — or an SDK failure silently discards real results too.
+
+## Why This Matters
+
+- **The failure lies about its cause.** A `ModuleNotFoundError`-style "tools unavailable" reads like a transient MCP hiccup; the real cause is a nonexistent package that fails 100% of the time. Teams chase the wrong thing.
+- **Silent hallucination is the real harm.** In a research-grade pipeline, output that *looks* KG-grounded but isn't flows into synthesis and erodes trust far more than an honest error. The guard converts a silent correctness risk into a visible, contained one.
+- **Instrument at the shared layer.** Putting the tool-call/availability diagnostics in the shared `query_with_usage` makes the *same* latent failure observable across all SDK nodes for free — the logs tell you which other nodes are silently degraded before you migrate them.
+
+## When to Apply
+
+- Any Claude Agent SDK call that sets `mcp_servers=...` and lists `mcp__*` entries in `allowed_tools` — verify the MCP server actually launches in the deploy environment (run `uvx --from <pkg> ... --help` / check it exists).
+- Any node whose authoritative output comes from the SDK tier rather than an HTTP/deterministic tier.
+- When reusing the structural guard on a node whose prompt does **not** mandate tool use, require the init-list signal or the phrase — never the bare zero-calls count (it false-positives on legitimate no-tool runs).
+
+## Examples
+
+**Before — broken stdio MCP (model hallucinates when the server can't launch):**
+```python
+options = ClaudeAgentOptions(
+    system_prompt=PATHWAY_ENRICHMENT_PROMPT,
+    allowed_tools=["mcp__kestrel__one_hop_query", "mcp__kestrel__get_nodes"],
+    mcp_servers={"kestrel": get_kestrel_mcp_config()},  # uvx mcp-client-kestrel — doesn't exist
+    max_turns=25,
+)
+result_text, _ = await query_with_usage(prompt=user_prompt, options=options, node_name="pathway_enrichment")
+```
+
+**After — HTTP data-in-prompt (mirrors `cold_start.get_entity_connections`):**
+```python
+per_entity, no_data = await prefetch_one_hop_neighbors(selected_entities)  # HTTP call_kestrel_tool
+if no_data:                                                                 # <2 entities returned real data
+    return _degraded_phase_b_result(two_hop_findings, errors, None, "prefetch_no_data")
+
+options = ClaudeAgentOptions(
+    system_prompt=PATHWAY_INFERENCE_PROMPT,
+    allowed_tools=[],                # no MCP tools — reason over the embedded data
+    max_turns=2,
+)
+async with SDK_SEMAPHORE:
+    result_text, usage = await query_with_usage(prompt=_build_inference_user_prompt(selected_entities, per_entity),
+                                                options=options, node_name="pathway_enrichment")
+```
+
+**The structural guard (shared, in `sdk_utils.py`):**
+```python
+def classify_mcp_degradation(expected_tools, mcp_tool_calls, result_text="", available_tools=None):
+    if not expected_tools:
+        return McpDegradationVerdict(False, "no_tools_expected", "none")
+    phrase_hit = bool(result_text) and any(p in result_text.lower() for p in _MCP_FALLBACK_PHRASES)
+    if available_tools is not None:
+        missing = [t for t in expected_tools if t not in available_tools]
+        if missing:
+            return McpDegradationVerdict(True, f"tools_missing_from_init:{','.join(missing)}", "definitive")
+        if mcp_tool_calls == 0 and not phrase_hit:        # tools registered, model just didn't call → not degraded
+            return McpDegradationVerdict(False, "tools_registered_zero_calls", "none")
+    if mcp_tool_calls == 0:
+        return McpDegradationVerdict(True, "zero_mcp_tool_calls" + ("+phrase" if phrase_hit else ""),
+                                     "high" if phrase_hit else "structural")
+    return McpDegradationVerdict(False, "tools_used", "none")
+```
+
+**Prevention tests** worth pinning (from `test_sdk_utils.py` / `test_pathway_enrichment.py`):
+- zero calls + phrase → degraded `high`; zero calls + no phrase → `structural`; tools used → not degraded.
+- `expected_tools == []` never degrades; init-list confirms-all + zero calls + no phrase → not degraded.
+- a Phase B exception/timeout still preserves the HTTP findings AND sets `degraded=True`.
+
+## Related
+
+- Issues: #44 (root issue), #61 (follow-up: migrate the other five SDK nodes); PR #60 (this fix), PR #24 (cold_start precedent).
+- `backend/src/kestrel_backend/graph/nodes/cold_start.py:1-18` — the original "package doesn't exist" record + the HTTP-not-MCP rationale.
+- `docs/plans/2026-06-01-001-fix-pathway-enrichment-mcp-degradation-plan.md` — full plan + 3-round review.
+- [[discovery-pipeline-one-graph-methods-within-nodes-2026-05-28]] — related pipeline-architecture learning.
+- [[pytest-venv-path-spaces-module-invocation-2026-06-01]] — run these tests with `uv run python -m pytest`.


### PR DESCRIPTION
## Summary

Completes the parity started by #60: migrates the **five remaining** discovery-pipeline nodes — `entity_resolution`, `direct_kg`, `triage`, `integration`, `temporal` — off the broken Kestrel **stdio MCP** (`uvx mcp-client-kestrel`, a package not on PyPI, so the subprocess could never launch). After this, all six SDK nodes are off the broken stdio path, and the dead `get_kestrel_mcp_config` config is retired.

**Correctness guarantee:** no SDK tier can silently surface a fabricated CURIE, association, or edge-count as a KG fact. Right-sized per node (not a blanket template).

Plan: `docs/plans/2026-06-02-001-fix-five-nodes-off-stdio-mcp-plan.md` (reviewed via 4-pass `/ce:document-review`).

## Per-node approach (3 outcomes)

| Node | Change |
|---|---|
| `temporal` | **Drop tools** — `allowed_tools=[]`, reason over the in-prompt study context (the "validation-only" tool was a doomed spawn). |
| `integration` (gap) | **Drop tools** + **R1b**: null model-authored gap CURIEs at construction (`parse_integration_result`), so synthesis can't render an ungrounded CURIE. HTTP bridges untouched. |
| `entity_resolution` | **Prefetch + select + R1a**: multi-variant HTTP `hybrid_search`/`text_search` prefetch → SDK selects from candidates (`allowed_tools=[]`) → returned CURIE validated against the candidate set (exact canonical match, no fuzzy); out-of-set/empty/transport-failure → `method="failed"`. Surfaces the candidate's own fields, never the model's. |
| `direct_kg` | **Drop fallback** → honest no-findings. Tier-1 `None` is total-failure-only, so a prefetch would re-fail. |
| `triage` | **Drop fallback + single retry** scoped to transient (`isError`/exception) failures; deterministic per-CURIE failures fall to the documented `cold_start` reroute. |
| `sdk_utils` | **Retire** `get_kestrel_mcp_config` + `KESTREL_*` + the `McpStdioServerConfig` re-export. |

## New correctness requirements
- **R1a** (entity_resolution): selected CURIE must be a member of the prefetched candidate set, else `failed`.
- **R1b** (integration): gap CURIEs are nulled/membership-checked at the data boundary.

## Testing
- New/updated unit tests per node: prefetch dedup, select happy-path, R1a out-of-set rejection, transport-failure→failed, R1b gap-CURIE nulling, triage retry-recovery + persistent-failure→cold_start, temporal `allowed_tools=[]`, direct_kg Tier-1-failure→no-findings.
- `test_langgraph_prototype.py`: **zero net-new failures** vs. the pre-change baseline (same env), **one fixed**. The ~35 remaining failures are pre-existing state-contract/constructor drift unrelated to this PR.
- Builder import smoke gate passes (no dangling `..sdk_utils` imports across all six node modules); `test_sdk_utils.py` green (28).

## ⚠️ Pre-merge follow-up (needs live Kestrel)
The `entity_resolution` recall **go/no-go gate** could not be run in an offline session: it requires a live Kestrel KG to build/commit a hand-labeled hard-variant fixture (≥20 entities) and measure ≥95% resolution to the correct CURIE. **Run this against dev before merging to `main`.** On a miss, reclassify `entity_resolution` to honest-fail (drop Tier-2 → cold_start) per the plan decision; the variant-string SDK loop is a deferred follow-on, not built here.

## Post-deploy
- Confirm the #60 `mcp_tool_calls=0` diagnostics disappear for these nodes.
- Close #61; note in the #60 compound doc that all six SDK nodes are migrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)