### PR TITLE
fix(#61): address Greptile review on release PR #64

### DIFF
--- a/backend/src/kestrel_backend/graph/nodes/entity_resolution.py
+++ b/backend/src/kestrel_backend/graph/nodes/entity_resolution.py
@@ -276,7 +276,11 @@ def _resolution_variants(entity: str) -> list[str]:
     add(entity)
     add(entity.replace("-", " "))   # de-hyphenated
     add(entity.replace("-", ""))    # hyphen-removed
-    add(re.sub(r"^[0-9A-Za-z]{1,3}-", "", entity))  # strip a leading "N-"/"16-"/"3-" prefix
+    # strip a leading "N-"/"16-"/"3-" prefix, but skip degenerate stubs (e.g. "IL-6" -> "6")
+    # that would just burn a result slot with noise — the raw name is always searched anyway.
+    stripped = re.sub(r"^[0-9A-Za-z]{1,3}-", "", entity)
+    if len(stripped) > 3:
+        add(stripped)
     if 2 <= len(entity) <= 6 and entity.isalnum():
         add(entity.upper())         # gene-symbol form
     return variants

--- a/backend/src/kestrel_backend/graph/nodes/pathway_enrichment.py
+++ b/backend/src/kestrel_backend/graph/nodes/pathway_enrichment.py
@@ -25,7 +25,7 @@ from ..state import (
 )
 from ...kestrel_client import multi_hop_query
 from .cold_start import get_entity_connections
-from ..sdk_utils import HAS_SDK, ClaudeAgentOptions, query_with_usage, classify_mcp_degradation
+from ..sdk_utils import HAS_SDK, ClaudeAgentOptions, query_with_usage
 from ..pipeline_config import get_pipeline_config
 from ..state_contracts import validate_state, PathwayEnrichmentInput, PathwayEnrichmentOutput
 
@@ -535,27 +535,14 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
         if parse_errors:
             logger.warning("pathway_enrichment parse errors: %s", parse_errors)
 
-        # Issue #44 (Stage 2): Phase B now uses data-in-prompt inference (allowed_tools=[]),
-        # so the MCP classifier is inert here (expected_tools=[] -> never degraded) and kept
-        # only as a safety net should MCP tools ever be reintroduced. The active protection
-        # against sparse-prompt re-hallucination is the prefetch no_data guard above.
-        verdict = classify_mcp_degradation(
-            expected_tools=[],
-            mcp_tool_calls=usage_record.mcp_tool_calls if usage_record else 0,
-            result_text=result_text,
-            available_tools=usage_record.available_tools if usage_record else None,
-        )
+        # Issue #44 (Stage 2): Phase B uses data-in-prompt inference (allowed_tools=[]),
+        # so there is no MCP tier left to degrade — the MCP-degradation classifier was
+        # removed here rather than left as inert/unreachable code. The active protection
+        # against sparse-prompt re-hallucination is the prefetch no_data guard above
+        # (see the _degraded_phase_b_result call at the prefetch stage). If MCP tools are
+        # ever reintroduced into Phase B, re-add classify_mcp_degradation(expected_tools=[...])
+        # plus the drop_findings_on_degraded branch here.
         phase_b_degraded = False
-        if verdict.degraded:
-            if _config.drop_findings_on_degraded:
-                return _degraded_phase_b_result(
-                    two_hop_findings, two_hop_errors, usage_record, f"mcp_{verdict.reason}"
-                )
-            phase_b_degraded = True  # flag for disclosure even though output is kept
-            logger.warning(
-                "pathway_enrichment degraded (reason=%s) but drop_findings_on_degraded=False — keeping output",
-                verdict.reason,
-            )
 
         # Create findings from top themes (SDK-derived — dropped on degradation)
         sdk_findings: list[Finding] = []

--- a/backend/src/kestrel_backend/graph/nodes/triage.py
+++ b/backend/src/kestrel_backend/graph/nodes/triage.py
@@ -262,7 +262,8 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
 
     duration = time.time() - start
     logger.info(
-        "Completed triage in %.1fs — well_char=%d, moderate=%d, sparse=%d, cold_start=%d (tier1=%d, tier2=%d)",
+        "Completed triage in %.1fs — well_char=%d, moderate=%d, sparse=%d, cold_start=%d "
+        "(tier1_ok=%d, tier1_failed=%d)",
         duration, len(well_characterized), len(moderate), len(sparse), len(cold_start),
         tier1_success, len(valid_entities) - tier1_success
     )


### PR DESCRIPTION
## Summary

Three P2 follow-ups Greptile raised on the `dev` → `main` release PR (#64). All minor, no behavioral change to the production data path.

- **triage** — rename the stale `tier2=%d` completion-log label (Tier-2 was removed in #61) to `tier1_ok=%d, tier1_failed=%d`, so prod monitoring/alerting doesn't misread it as a second LLM tier.
- **entity_resolution** — skip degenerate prefix-strip variants: `^[0-9A-Za-z]{1,3}-` turned `IL-6` into `6` (a noisy query that burned a `limit=10` result slot). Now only add the stripped variant when `len > 3`. Verified: `IL-6 → ['IL-6', 'IL 6', 'IL6']`; `16-hydroxypalmitate` still yields `hydroxypalmitate`.
- **pathway_enrichment** — remove the inert/unreachable `classify_mcp_degradation` block (`expected_tools=[]` → never degraded) instead of leaving dead code; document where the active guard is (prefetch `no_data`) and how to re-enable if MCP tools return. Drop the now-unused import.

## Validation
- `IL-6` variant fix confirmed; builder import smoke gate passes.
- `TestTriageNode`, `TestEntityResolutionNode`, `test_pathway_enrichment.py` — 28 passed.

## Note
Once merged to `dev`, the release PR #64 (head = `dev`) picks these up automatically and Greptile re-reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)