### PR TITLE
feat(literature): fetch + cache abstract bodies in literature_grounding

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "psycopg2-binary>=2.9.0",
     "PyJWT[crypto]>=2.8.0",
     "ftfy>=6.3.1",
+    "defusedxml>=0.7.1",  # safe parsing of PubMed EFetch XML (XXE / billion-laughs)
 ]
 
 [dependency-groups]

--- a/backend/src/kestrel_backend/graph/nodes/literature_grounding.py
+++ b/backend/src/kestrel_backend/graph/nodes/literature_grounding.py
@@ -33,7 +33,8 @@ from ...exa_client import (
     extract_doi_from_url, extract_year_from_date
 )
 from ...pubmed_client import (
-    search_papers as pubmed_search_papers, PubMedSearchError
+    search_papers as pubmed_search_papers, PubMedSearchError,
+    fetch_abstracts as pubmed_fetch_abstracts, normalize_pmid,
 )
 
 from ..pipeline_config import get_pipeline_config
@@ -442,6 +443,7 @@ async def create_literature_from_s2(paper: dict, hypothesis_claim: str) -> Liter
             else classify_relationship(paper, hypothesis_claim)
         ),
         key_passage=extract_key_passage(paper, hypothesis_claim),
+        abstract=paper.get("abstract") or None,  # already fetched by S2; previously discarded
         citation_count=paper.get("citationCount") or 0,
         source="s2",
     )
@@ -1037,6 +1039,74 @@ def ground_hypothesis_kg(
     return hypothesis, False
 
 
+def _pmid_for_lit(lit: LiteratureSupport) -> str | None:
+    """
+    Best-effort bare PMID for a literature entry, or None.
+
+    Sources: a 'PMID:'-prefixed paper_id (kg/pubmed), or a PubMed URL. S2/OpenAlex/Exa
+    entries usually have no PMID and are skipped (S2 already carries its abstract inline).
+    """
+    if lit.paper_id.startswith("PMID:"):
+        pmid = normalize_pmid(lit.paper_id)
+        return pmid if pmid.isdigit() else None
+    if lit.url and "pubmed.ncbi.nlm.nih.gov" in lit.url:
+        m = re.search(r"pubmed\.ncbi\.nlm\.nih\.gov/(\d+)", lit.url)
+        if m:
+            return m.group(1)
+    return None
+
+
+async def backfill_abstracts(hypotheses: list[Hypothesis]) -> tuple[list[Hypothesis], int]:
+    """
+    Fill in `abstract` bodies for grounded papers that have a PMID but no abstract.
+
+    Idempotent: entries that already carry an `abstract` (e.g. from S2) are skipped, so
+    re-running fetches nothing new. PMIDs are deduplicated across all hypotheses, so each
+    is fetched from EFetch at most once per run. Best-effort: a PMID with no abstract (or a
+    fetch failure) leaves the entry unchanged.
+
+    Returns:
+        (updated hypotheses, number of literature entries filled)
+    """
+    # Collect the distinct PMIDs that still need a body.
+    needed: set[str] = set()
+    for h in hypotheses:
+        for lit in h.literature_support:
+            if lit.abstract:
+                continue
+            pmid = _pmid_for_lit(lit)
+            if pmid:
+                needed.add(pmid)
+
+    if not needed:
+        return hypotheses, 0
+
+    abstracts = await pubmed_fetch_abstracts(sorted(needed))
+    if not abstracts:
+        return hypotheses, 0
+
+    # Rewrite frozen entries with the fetched body where one was found.
+    filled = 0
+    updated_hypotheses: list[Hypothesis] = []
+    for h in hypotheses:
+        new_support: list[LiteratureSupport] = []
+        changed = False
+        for lit in h.literature_support:
+            pmid = None if lit.abstract else _pmid_for_lit(lit)
+            body = abstracts.get(pmid) if pmid else None
+            if body:
+                new_support.append(lit.model_copy(update={"abstract": body}))
+                filled += 1
+                changed = True
+            else:
+                new_support.append(lit)
+        updated_hypotheses.append(
+            h.model_copy(update={"literature_support": new_support}) if changed else h
+        )
+
+    return updated_hypotheses, filled
+
+
 @validate_state(LiteratureGroundingInput, LiteratureGroundingOutput)
 async def run(state: DiscoveryState) -> dict[str, Any]:
     """
@@ -1129,6 +1199,13 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
 
     # Add ungrounded hypotheses
     grounded.extend(remaining)
+
+    # Backfill abstract bodies for PMID-bearing papers that lack one (S2 already
+    # carries its abstract inline; this fills kg/pubmed entries via EFetch). Idempotent
+    # and best-effort — failures leave entries unchanged.
+    grounded, abstracts_filled = await backfill_abstracts(grounded)
+    if abstracts_filled:
+        logger.info("Abstract backfill: filled %d literature entries via EFetch", abstracts_filled)
 
     # Count papers found by source (after deduplication)
     papers_found = sum(len(h.literature_support) for h in grounded)

--- a/backend/src/kestrel_backend/graph/nodes/literature_grounding.py
+++ b/backend/src/kestrel_backend/graph/nodes/literature_grounding.py
@@ -530,6 +530,11 @@ def merge_literature(
         merged_citation_count = best.citation_count
         merged_key_passage = best.key_passage
         merged_doi = best.doi
+        # Abstract bodies are only set on S2 entries at this point, and S2 is the
+        # lowest-priority source — so the body usually lives on a lower-priority
+        # duplicate. Carry it onto `best` (same pattern as key_passage) so it
+        # survives dedup; otherwise the S2 "free win" is silently dropped here.
+        merged_abstract = best.abstract
 
         for other in papers[1:]:
             if other.citation_count > merged_citation_count:
@@ -538,11 +543,14 @@ def merge_literature(
                 merged_key_passage = other.key_passage
             if not merged_doi and other.doi:
                 merged_doi = other.doi
+            if not merged_abstract and other.abstract:
+                merged_abstract = other.abstract
 
         # Create merged result if any fields changed
         if (merged_citation_count != best.citation_count or
             merged_key_passage != best.key_passage or
-            merged_doi != best.doi):
+            merged_doi != best.doi or
+            merged_abstract != best.abstract):
             best = LiteratureSupport(
                 paper_id=best.paper_id,
                 title=best.title,
@@ -553,6 +561,7 @@ def merge_literature(
                 relevance_score=best.relevance_score,
                 relationship=best.relationship,
                 key_passage=merged_key_passage,
+                abstract=merged_abstract,
                 citation_count=merged_citation_count,
                 source=best.source,
             )

--- a/backend/src/kestrel_backend/graph/state.py
+++ b/backend/src/kestrel_backend/graph/state.py
@@ -234,6 +234,11 @@ class LiteratureSupport(BaseModel):
         "supporting", description="How paper relates to hypothesis"
     )
     key_passage: str = Field(default="", description="Most relevant passage from abstract")
+    abstract: str | None = Field(
+        default=None,
+        description="Full abstract body, when fetched (S2 inline or PubMed EFetch). "
+        "None when unavailable. Consumed by downstream literature-scoring mechanisms.",
+    )
     citation_count: int = Field(default=0, ge=0, description="Citation count for credibility weighting")
     source: Literal["kg", "openalex", "s2", "exa", "pubmed"] = Field(
         default="s2", description="Source of this literature reference"

--- a/backend/src/kestrel_backend/pubmed_client.py
+++ b/backend/src/kestrel_backend/pubmed_client.py
@@ -17,6 +17,11 @@ import re
 from typing import Any
 
 import httpx
+# defusedxml hardens against XXE / billion-laughs / quadratic-blowup in the
+# EFetch XML, which arrives over the network. Same API as xml.etree.ElementTree.
+import defusedxml.ElementTree as ET
+from defusedxml.common import DefusedXmlException
+from xml.etree.ElementTree import Element, ParseError
 
 logger = logging.getLogger(__name__)
 
@@ -232,3 +237,119 @@ def format_authors_from_summary(paper: dict) -> str:
     if len(authors) > 1:
         return f"{first_author} et al."
     return first_author
+
+
+def normalize_pmid(pmid: str) -> str:
+    """Strip a 'PMID:' prefix and surrounding whitespace, returning the bare digits."""
+    return pmid.replace("PMID:", "").strip()
+
+
+def _parse_efetch_abstracts(xml_text: str) -> dict[str, str]:
+    """
+    Parse an EFetch PubMed XML payload into {pmid: abstract_text}.
+
+    Structured abstracts split the body across multiple <AbstractText> elements,
+    each optionally carrying a Label (e.g. BACKGROUND, METHODS). We join the
+    segments in document order, prefixing labels when present. PMIDs with no
+    abstract are omitted from the result.
+
+    Args:
+        xml_text: Raw EFetch XML response body.
+
+    Returns:
+        Dict mapping bare PMID string to concatenated abstract text.
+    """
+    abstracts: dict[str, str] = {}
+    try:
+        root = ET.fromstring(xml_text)
+    except (ParseError, DefusedXmlException) as e:
+        logger.error("PubMed EFetch XML parse/safety error: %s", e)
+        return abstracts
+
+    for article in root.iter("PubmedArticle"):
+        pmid_el: Element | None = article.find("./MedlineCitation/PMID")
+        pmid = (pmid_el.text or "").strip() if pmid_el is not None else ""
+        if not pmid:
+            continue
+
+        segments: list[str] = []
+        for at in article.iter("AbstractText"):
+            text = "".join(at.itertext()).strip()  # flatten inline markup (e.g. <i>, <sup>)
+            if not text:
+                continue
+            label = (at.get("Label") or "").strip()
+            segments.append(f"{label}: {text}" if label else text)
+
+        if segments:
+            abstracts[pmid] = "\n".join(segments)
+
+    return abstracts
+
+
+async def _efetch_batch(pmids: list[str]) -> dict[str, str]:
+    """Fetch one batch of abstracts via EFetch (XML). Returns {} on failure."""
+    params: dict[str, Any] = {
+        "db": "pubmed",
+        "id": ",".join(pmids),
+        "retmode": "xml",
+        "rettype": "abstract",
+    }
+    if NCBI_API_KEY:
+        params["api_key"] = NCBI_API_KEY
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        try:
+            await asyncio.sleep(PUBMED_DELAY)  # Rate limit (same policy as ESearch/ESummary)
+            response = await client.get(f"{EUTILS_BASE}/efetch.fcgi", params=params)
+            response.raise_for_status()
+            return _parse_efetch_abstracts(response.text)
+        except httpx.HTTPStatusError as e:
+            logger.error("PubMed EFetch HTTP error: %s", e)
+            return {}
+        except Exception as e:
+            logger.error("PubMed EFetch failed: %s", e)
+            return {}
+
+
+async def fetch_abstracts(pmids: list[str], batch_size: int = 200) -> dict[str, str]:
+    """
+    Fetch abstract bodies for a list of PMIDs via EFetch.
+
+    ESummary (used by ``search_papers``) returns metadata only; abstract bodies
+    require EFetch. PMIDs may be passed with or without a 'PMID:' prefix; the
+    returned dict is keyed by the bare numeric PMID. PMIDs without an abstract
+    (or that fail to fetch) are simply absent from the result — callers treat a
+    missing key as "no abstract available".
+
+    Reuses the module's NCBI rate-limit policy (PUBMED_SEMAPHORE / PUBMED_DELAY /
+    NCBI_API_KEY). Input is deduplicated so each PMID is fetched at most once.
+
+    Args:
+        pmids: PMID strings (bare or 'PMID:'-prefixed).
+        batch_size: Max PMIDs per EFetch request (NCBI tolerates a few hundred).
+
+    Returns:
+        Dict mapping bare PMID string to abstract text.
+    """
+    # Normalize, validate (numeric only), and dedupe while preserving order.
+    seen: set[str] = set()
+    clean: list[str] = []
+    for raw in pmids:
+        pmid = normalize_pmid(str(raw))
+        if pmid.isdigit() and pmid not in seen:
+            seen.add(pmid)
+            clean.append(pmid)
+
+    if not clean:
+        return {}
+
+    results: dict[str, str] = {}
+    async with PUBMED_SEMAPHORE:
+        for i in range(0, len(clean), batch_size):
+            batch = clean[i:i + batch_size]
+            results.update(await _efetch_batch(batch))
+
+    logger.info(
+        "PubMed EFetch: %d abstracts retrieved for %d PMIDs", len(results), len(clean)
+    )
+    return results

--- a/backend/src/kestrel_backend/pubmed_client.py
+++ b/backend/src/kestrel_backend/pubmed_client.py
@@ -343,10 +343,14 @@ async def fetch_abstracts(pmids: list[str], batch_size: int = 200) -> dict[str, 
     if not clean:
         return {}
 
+    # Acquire the semaphore per batch (one EFetch request = one logical unit, as
+    # search_papers does) rather than holding it across the whole loop — otherwise
+    # a large PMID set starves concurrent pipeline invocations sharing this
+    # module-level semaphore for the full duration.
     results: dict[str, str] = {}
-    async with PUBMED_SEMAPHORE:
-        for i in range(0, len(clean), batch_size):
-            batch = clean[i:i + batch_size]
+    for i in range(0, len(clean), batch_size):
+        batch = clean[i:i + batch_size]
+        async with PUBMED_SEMAPHORE:
             results.update(await _efetch_batch(batch))
 
     logger.info(

--- a/backend/tests/test_literature_grounding.py
+++ b/backend/tests/test_literature_grounding.py
@@ -669,6 +669,42 @@ class TestMergeLiterature:
         # PubMed has higher priority than OpenAlex
         assert result[0].source == "pubmed"
 
+    def test_merge_preserves_s2_abstract_from_lower_priority_duplicate(self):
+        """Abstract on a lower-priority S2 duplicate must survive onto the best entry.
+
+        S2 is the lowest-priority source and the only one carrying an abstract at
+        merge time, so the body typically lives on the lower-priority duplicate.
+        Regression for the silent-drop bug (PR #69 review).
+        """
+        pubmed = LiteratureSupport(
+            paper_id="PMID:777", title="Shared", authors="A", year=2024,
+            doi="10.1/shared", relevance_score=0.9, source="pubmed",
+        )
+        s2 = LiteratureSupport(
+            paper_id="S2:abc", title="Shared", authors="A", year=2024,
+            doi="10.1/shared", relevance_score=0.85, source="s2",
+            abstract="full S2 abstract body",
+        )
+        result = lit_grounding_module.merge_literature([pubmed, s2])
+        assert len(result) == 1
+        assert result[0].source == "pubmed"          # higher priority wins
+        assert result[0].abstract == "full S2 abstract body"  # but abstract survives
+
+    def test_merge_keeps_best_abstract_when_present(self):
+        """A best-source abstract is not clobbered by an abstract-less duplicate."""
+        s2_best = LiteratureSupport(
+            paper_id="PMID:888", title="Shared2", authors="A", year=2024,
+            relevance_score=0.9, source="pubmed", abstract="best body",
+        )
+        other = LiteratureSupport(
+            paper_id="PMID:888", title="Shared2", authors="A", year=2024,
+            relevance_score=0.85, source="openalex", citation_count=99,
+        )
+        result = lit_grounding_module.merge_literature([s2_best, other])
+        assert len(result) == 1
+        assert result[0].abstract == "best body"
+        assert result[0].citation_count == 99  # complementary merge still works
+
     def test_merge_deduplicates_by_title_year(self):
         """Test that papers with same title+year are deduplicated."""
         lit1 = LiteratureSupport(

--- a/backend/tests/test_literature_grounding.py
+++ b/backend/tests/test_literature_grounding.py
@@ -78,6 +78,13 @@ sys.modules["kestrel_backend.exa_client"] = mock_exa_client
 mock_pubmed_client = types.ModuleType("kestrel_backend.pubmed_client")
 mock_pubmed_client.search_papers = None
 mock_pubmed_client.PubMedSearchError = Exception
+# Backfill (issue: abstract-body fetch) imports these into the node namespace.
+# Provide a real normalize_pmid (pure) and a default async fetch stub that returns
+# nothing; backfill tests monkeypatch lit_grounding_module.pubmed_fetch_abstracts.
+mock_pubmed_client.normalize_pmid = lambda pmid: str(pmid).replace("PMID:", "").strip()
+async def _stub_fetch_abstracts(pmids, batch_size=200):
+    return {}
+mock_pubmed_client.fetch_abstracts = _stub_fetch_abstracts
 sys.modules["kestrel_backend.pubmed_client"] = mock_pubmed_client
 
 # Now import build_references_table from the real module
@@ -1299,3 +1306,262 @@ class TestGetPaperKey:
         )
         key = _get_paper_key(lit)
         assert key == f"title:{'a' * 100}:2024"
+
+
+# =============================================================================
+# Abstract-body fetch + cache (spike: feat/literature-abstract-fetch)
+# =============================================================================
+
+import src.kestrel_backend.pubmed_client as pmc
+
+backfill_abstracts = lit_grounding_module.backfill_abstracts
+_pmid_for_lit = lit_grounding_module._pmid_for_lit
+
+
+def _make_hypothesis(title, literature):
+    """Minimal valid Hypothesis with the given literature_support."""
+    return Hypothesis(
+        title=title, tier=2, claim=f"{title} claim",
+        supporting_entities=["CURIE:1"], structural_logic="logic",
+        validation_steps=["step"], literature_support=literature,
+    )
+
+
+# Realistic EFetch XML: one simple abstract, one structured (labelled) abstract,
+# one article with no abstract at all.
+_EFETCH_XML = """<?xml version="1.0"?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation>
+      <PMID Version="1">111</PMID>
+      <Article>
+        <Abstract>
+          <AbstractText>Metformin activates AMPK in hepatocytes.</AbstractText>
+        </Abstract>
+      </Article>
+    </MedlineCitation>
+  </PubmedArticle>
+  <PubmedArticle>
+    <MedlineCitation>
+      <PMID Version="1">222</PMID>
+      <Article>
+        <Abstract>
+          <AbstractText Label="BACKGROUND">Type 2 diabetes is common.</AbstractText>
+          <AbstractText Label="RESULTS">BCAAs rose <sup>2</sup>-fold in cases.</AbstractText>
+        </Abstract>
+      </Article>
+    </MedlineCitation>
+  </PubmedArticle>
+  <PubmedArticle>
+    <MedlineCitation>
+      <PMID Version="1">333</PMID>
+      <Article><ArticleTitle>No abstract here</ArticleTitle></Article>
+    </MedlineCitation>
+  </PubmedArticle>
+</PubmedArticleSet>"""
+
+
+class TestEFetchAbstractParsing:
+    """pubmed_client._parse_efetch_abstracts XML handling."""
+
+    def test_simple_abstract(self):
+        result = pmc._parse_efetch_abstracts(_EFETCH_XML)
+        assert result["111"] == "Metformin activates AMPK in hepatocytes."
+
+    def test_structured_abstract_joins_labelled_segments(self):
+        result = pmc._parse_efetch_abstracts(_EFETCH_XML)
+        # Labels are prefixed; inline markup (<sup>) is flattened into text.
+        assert result["222"] == (
+            "BACKGROUND: Type 2 diabetes is common.\n"
+            "RESULTS: BCAAs rose 2-fold in cases."
+        )
+
+    def test_pmid_without_abstract_is_omitted(self):
+        result = pmc._parse_efetch_abstracts(_EFETCH_XML)
+        assert "333" not in result
+
+    def test_malformed_xml_returns_empty(self):
+        assert pmc._parse_efetch_abstracts("<not valid xml") == {}
+
+
+class TestNormalizePmid:
+    def test_strips_prefix_and_whitespace(self):
+        assert pmc.normalize_pmid(" PMID:12345 ") == "12345"
+
+    def test_bare_pmid_unchanged(self):
+        assert pmc.normalize_pmid("12345") == "12345"
+
+
+class TestFetchAbstracts:
+    """pubmed_client.fetch_abstracts: dedup, normalize, batch — no network."""
+
+    @pytest.mark.asyncio
+    async def test_dedupes_and_normalizes_pmids(self, monkeypatch):
+        seen_batches = []
+
+        async def fake_efetch_batch(batch):
+            seen_batches.append(list(batch))
+            return {p: f"abstract-{p}" for p in batch}
+
+        monkeypatch.setattr(pmc, "_efetch_batch", fake_efetch_batch)
+
+        # Duplicates (bare + prefixed), one non-numeric junk PMID.
+        result = await pmc.fetch_abstracts(["PMID:111", "111", "222", "abc"])
+
+        assert result == {"111": "abstract-111", "222": "abstract-222"}
+        # 111 fetched once; "abc" dropped.
+        flat = [p for b in seen_batches for p in b]
+        assert sorted(flat) == ["111", "222"]
+
+    @pytest.mark.asyncio
+    async def test_empty_input_skips_fetch(self, monkeypatch):
+        called = False
+
+        async def fake_efetch_batch(batch):
+            nonlocal called
+            called = True
+            return {}
+
+        monkeypatch.setattr(pmc, "_efetch_batch", fake_efetch_batch)
+        assert await pmc.fetch_abstracts(["xyz", "PMID:"]) == {}
+        assert called is False
+
+    @pytest.mark.asyncio
+    async def test_batches_respect_batch_size(self, monkeypatch):
+        seen_batches = []
+
+        async def fake_efetch_batch(batch):
+            seen_batches.append(list(batch))
+            return {p: "a" for p in batch}
+
+        monkeypatch.setattr(pmc, "_efetch_batch", fake_efetch_batch)
+        await pmc.fetch_abstracts([str(i) for i in range(5)], batch_size=2)
+        assert [len(b) for b in seen_batches] == [2, 2, 1]
+
+
+class TestLiteratureSupportAbstractField:
+    def test_default_none(self):
+        lit = LiteratureSupport(paper_id="PMID:1", title="t", authors="a", year=2024)
+        assert lit.abstract is None
+
+    def test_accepts_body(self):
+        lit = LiteratureSupport(
+            paper_id="PMID:1", title="t", authors="a", year=2024,
+            abstract="full body",
+        )
+        assert lit.abstract == "full body"
+
+
+class TestPmidForLit:
+    def test_from_prefixed_paper_id(self):
+        lit = LiteratureSupport(paper_id="PMID:42", title="t", authors="a", year=2024)
+        assert _pmid_for_lit(lit) == "42"
+
+    def test_from_pubmed_url(self):
+        lit = LiteratureSupport(
+            paper_id="S2:abc", title="t", authors="a", year=2024,
+            url="https://pubmed.ncbi.nlm.nih.gov/99/",
+        )
+        assert _pmid_for_lit(lit) == "99"
+
+    def test_none_when_no_pmid(self):
+        lit = LiteratureSupport(
+            paper_id="openalex:W1", title="t", authors="a", year=2024,
+            doi="10.1/x", url="https://doi.org/10.1/x",
+        )
+        assert _pmid_for_lit(lit) is None
+
+
+class TestBackfillAbstracts:
+    """backfill_abstracts: idempotency, cross-hypothesis dedup, best-effort."""
+
+    @pytest.mark.asyncio
+    async def test_fills_missing_and_skips_present(self, monkeypatch):
+        calls = []
+
+        async def fake_fetch(pmids, batch_size=200):
+            calls.append(sorted(pmids))
+            return {"111": "body-111", "222": "body-222"}
+
+        monkeypatch.setattr(lit_grounding_module, "pubmed_fetch_abstracts", fake_fetch)
+
+        already = LiteratureSupport(
+            paper_id="S2:x", title="t", authors="a", year=2024,
+            abstract="s2 inline body", source="s2",
+        )
+        need1 = LiteratureSupport(paper_id="PMID:111", title="t", authors="a", year=2024, source="kg")
+        need2 = LiteratureSupport(paper_id="PMID:222", title="t", authors="a", year=2024, source="pubmed")
+
+        hyps = [
+            _make_hypothesis("H1", [already, need1]),
+            _make_hypothesis("H2", [need2]),
+        ]
+
+        updated, filled = await backfill_abstracts(hyps)
+
+        assert filled == 2
+        # S2 entry already had abstract → not re-fetched.
+        assert calls == [["111", "222"]]
+        # Bodies attached; S2 entry untouched.
+        h1_lits = {l.paper_id: l for l in updated[0].literature_support}
+        assert h1_lits["S2:x"].abstract == "s2 inline body"
+        assert h1_lits["PMID:111"].abstract == "body-111"
+        assert updated[1].literature_support[0].abstract == "body-222"
+
+    @pytest.mark.asyncio
+    async def test_idempotent_second_pass_fetches_nothing(self, monkeypatch):
+        call_count = 0
+
+        async def fake_fetch(pmids, batch_size=200):
+            nonlocal call_count
+            call_count += 1
+            return {"111": "body-111"}
+
+        monkeypatch.setattr(lit_grounding_module, "pubmed_fetch_abstracts", fake_fetch)
+
+        need = LiteratureSupport(paper_id="PMID:111", title="t", authors="a", year=2024, source="kg")
+        hyps = [_make_hypothesis("H1", [need])]
+
+        updated, filled = await backfill_abstracts(hyps)
+        assert filled == 1 and call_count == 1
+
+        # Re-running over the now-filled output collects no PMIDs → no fetch.
+        updated2, filled2 = await backfill_abstracts(updated)
+        assert filled2 == 0 and call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_dedups_pmid_across_hypotheses(self, monkeypatch):
+        async def fake_fetch(pmids, batch_size=200):
+            # Same PMID cited by two hypotheses must appear once.
+            assert sorted(pmids) == ["111"]
+            return {"111": "body-111"}
+
+        monkeypatch.setattr(lit_grounding_module, "pubmed_fetch_abstracts", fake_fetch)
+
+        lit_a = LiteratureSupport(paper_id="PMID:111", title="t", authors="a", year=2024, source="kg")
+        lit_b = LiteratureSupport(paper_id="PMID:111", title="t", authors="a", year=2024, source="kg")
+        hyps = [_make_hypothesis("H1", [lit_a]), _make_hypothesis("H2", [lit_b])]
+
+        updated, filled = await backfill_abstracts(hyps)
+        assert filled == 2  # both entries filled from the single fetched body
+
+    @pytest.mark.asyncio
+    async def test_best_effort_when_no_pmids(self, monkeypatch):
+        called = False
+
+        async def fake_fetch(pmids, batch_size=200):
+            nonlocal called
+            called = True
+            return {}
+
+        monkeypatch.setattr(lit_grounding_module, "pubmed_fetch_abstracts", fake_fetch)
+
+        no_pmid = LiteratureSupport(
+            paper_id="openalex:W1", title="t", authors="a", year=2024,
+            doi="10.1/x", url="https://doi.org/10.1/x", source="openalex",
+        )
+        hyps = [_make_hypothesis("H1", [no_pmid])]
+
+        updated, filled = await backfill_abstracts(hyps)
+        assert filled == 0 and called is False
+        assert updated[0].literature_support[0].abstract is None

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -379,6 +379,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604 },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -857,6 +866,7 @@ dependencies = [
     { name = "anthropic" },
     { name = "asyncpg" },
     { name = "claude-agent-sdk" },
+    { name = "defusedxml" },
     { name = "fastapi" },
     { name = "ftfy" },
     { name = "httpx" },
@@ -891,6 +901,7 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.42.0" },
     { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "claude-agent-sdk", specifier = ">=0.1.0" },
+    { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "ftfy", specifier = ">=6.3.1" },
     { name = "httpx", specifier = ">=0.27.0" },

--- a/docs/plans/2026-06-08-001-feat-literature-abstract-fetch-plan.md
+++ b/docs/plans/2026-06-08-001-feat-literature-abstract-fetch-plan.md
@@ -1,0 +1,86 @@
+# Spike: Abstract-body fetch + cache in `literature_grounding`
+
+**Date:** 2026-06-08
+**Branch:** `feat/literature-abstract-fetch` (off `dev`)
+**Type:** Spike (narrow, single-gap)
+**Status:** in progress
+
+## Problem
+
+Every KM-GPT-DCH-style mechanism we plan to port — the A-B-C mediated-chain grounding
+scorer and the Beta-Binomial resampling credible interval (see
+`docs/references/km-gpt-dch-competing-hypotheses.md`, code-level mining section) — reads
+**abstract text**. The `literature_grounding` node currently attaches only paper
+**metadata** to each hypothesis (`LiteratureSupport` carries a ≤300-char `key_passage`
+snippet, never the full body). That data gap, not the scoring math, is the real porting
+blocker, and it is step 0 of the planned synthesis-literature swap.
+
+This spike closes **only** that gap: make abstract bodies fetchable and attached
+("cached" in-state) for the papers a hypothesis already surfaces.
+
+## Current state (verified)
+
+- Sources in `graph/nodes/literature_grounding.py`: KG PMIDs, OpenAlex, Exa, PubMed, S2.
+  None persist an abstract body.
+- `pubmed_client.py` uses ESearch → **ESummary** → metadata only (no abstract).
+- `semantic_scholar.py:40-62` already requests the `abstract` field and uses it for
+  relevance scoring + `key_passage`, then **discards** it.
+- `LiteratureSupport` (`graph/state.py:221-240`, `frozen=True`) has no abstract field.
+- **No persistent literature cache exists.** DB models (`models.py`) are
+  conversation/turn/tool-call observability only. The de-facto cache is the in-memory
+  `hypothesis.literature_support` list on LangGraph state.
+
+## Minimal change
+
+1. **`LiteratureSupport.abstract: str | None = None`** — new optional frozen field.
+   Backward-compatible: existing constructors omit it (default `None`); the references
+   table and frontend ignore it (additive serialization).
+
+2. **S2 (free win):** in `create_literature_from_s2`, set `abstract=paper.get("abstract")`.
+   No new API calls — the body is already fetched and currently dropped.
+
+3. **PubMed EFetch path:** add `fetch_abstracts(pmids) -> dict[str, str]` to
+   `pubmed_client.py` using `efetch.fcgi` (`retmode=xml`, `rettype=abstract`), parsed with
+   stdlib `xml.etree.ElementTree` (no Biopython dep). Reuse the existing
+   `PUBMED_SEMAPHORE`, `PUBMED_DELAY`, and `NCBI_API_KEY`. Batch PMIDs (≤200/request).
+   Concatenate multiple `<AbstractText>` segments (structured abstracts) with their
+   `Label`s.
+
+4. **Backfill step in the node:** after grounding, collect every grounded
+   `LiteratureSupport` that has a resolvable PMID but no `abstract`, dedupe PMIDs across
+   all hypotheses, EFetch once, and rewrite those entries with the body filled in.
+
+## Idempotency & rate limits
+
+- Skip any paper that already has `abstract` (S2 papers are never re-fetched).
+- Dedupe PMIDs across the whole run → each PMID hits EFetch at most once per run.
+- Batch requests; reuse the repo's existing semaphore + inter-request delay + API key.
+- Network failure is non-fatal: on EFetch error the paper keeps `abstract=None` and the
+  pipeline proceeds (grounding is best-effort today and stays best-effort).
+
+## Out of scope (non-goals)
+
+- No grounding-confidence scorer, A-B-C chain scorer, or credible interval.
+- No persistent (disk/DB) cross-run cache, no Alembic migration. In-state + in-run dedup
+  only. (Cross-run cache noted as a follow-up below.)
+- No change to the temporal-eval workstream (`AGENT-TASK-temporal-eval-port.md` stays
+  blocked on one/multi/subgraph reasoning).
+- No change to the reasoning model or harness.
+
+## Verification
+
+- Unit: XML parsing (single + structured multi-segment abstract; empty/no-abstract PMID),
+  S2 abstract passthrough, idempotent skip when `abstract` already set, cross-hypothesis
+  PMID dedup.
+- End-to-end (one real hypothesis): run the backfill against live NCBI EFetch for a known
+  PMID set and show a cached abstract body on a `LiteratureSupport`.
+
+## What this unblocks
+
+With abstract bodies attached to each hypothesis's papers, the **A-B-C mediated-chain
+grounding scorer** can be built next: it reads `LiteratureSupport.abstract` for the
+papers on a bridge hypothesis, splits them into AB/BC pools, and runs the
+composition-scoring prompt mined from skimgpt — no further data plumbing required. The
+Beta-Binomial resampling CI likewise becomes feasible because it can now sample over real
+abstract sets. A cross-run persistent abstract cache (keyed by PMID) is the natural
+follow-up optimization once the scorer's fetch volume is known.


### PR DESCRIPTION
## Summary

Spike that closes **one gap**: the discovery pipeline's `literature_grounding` node attached paper **metadata** only (a ≤300-char `key_passage` snippet), never the **abstract body**. Every KM-GPT-DCH-style mechanism we plan to port — the A-B-C mediated-chain grounding scorer and the Beta-Binomial resampling credible interval (see `docs/references/km-gpt-dch-competing-hypotheses.md`, code-level mining section) — reads abstract **text**. That data gap, not the scoring math, is the real porting blocker, and it's step 0 of the planned synthesis-literature swap.

Spike plan: `docs/plans/2026-06-08-001-feat-literature-abstract-fetch-plan.md`.

## What changed

- **`LiteratureSupport.abstract: str | None`** — new optional field on the (frozen) model. Backward-compatible: existing constructors omit it (default `None`); references table and frontend are additive-safe.
- **Semantic Scholar = free win** — S2 already fetched the `abstract` field and used it for scoring/`key_passage`, then **discarded** it. Now stored. Zero new API calls.
- **`pubmed_client.fetch_abstracts()`** — new EFetch path (`efetch.fcgi`, `retmode=xml`, `rettype=abstract`) since ESummary returns no abstract. Parsed with **`defusedxml`** (XXE / billion-laughs hardening on network XML). Reuses the existing `PUBMED_SEMAPHORE` / `PUBMED_DELAY` / `NCBI_API_KEY`. Structured (labelled) abstracts are joined with their labels; inline markup is flattened.
- **Backfill step in the node** — for grounded papers that have a resolvable PMID but no abstract, fetch bodies and attach them.

## Idempotency & rate limits

- Skips any paper that already has an `abstract` (S2 papers are never re-fetched).
- Dedupes PMIDs across all hypotheses → each PMID hits EFetch at most once per run.
- Batches requests; best-effort — an EFetch failure or abstract-less PMID leaves the entry unchanged and the pipeline proceeds.

## Verification

- **End-to-end against live NCBI EFetch**: a hypothesis grounded on two real PMIDs went from `abstract=None` → real bodies attached (1390 & 1495 chars, correctly parsed); a second pass filled **0** (idempotent).
- **18 new unit tests** (XML parsing incl. structured/empty/malformed, fetch dedup+normalize+batching, model field, `_pmid_for_lit`, backfill idempotency/cross-hypothesis dedup/best-effort). Full literature suite: **115 passed, 1 deselected**.

## Scope / non-goals

- No grounding-confidence scorer, A-B-C chain scorer, or credible interval (next steps).
- No persistent (disk/DB) cross-run cache, **no Alembic migration** — in-state abstract field + in-run dedup only. Cross-run cache noted as a follow-up.
- No change to the temporal-eval workstream (`AGENT-TASK-temporal-eval-port.md` stays blocked) and no change to the reasoning model/harness.

## What this unblocks

Abstract bodies are now attached to each hypothesis's papers, so the **A-B-C mediated-chain grounding scorer** can be built next directly against `LiteratureSupport.abstract` — no further data plumbing. The resampling CI likewise becomes feasible (it can sample over real abstract sets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)