### PR TITLE
fix: kestrel parsing + no-auth client path + dev README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist
 server/public
 vite.config.ts.*
 *.tar.gz
+.idea
 
 # Python backend
 backend/.venv/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# KRAKEN Chatbot
+
+AI-powered interface for exploring the KRAKEN knowledge graph (via Kestrel). React frontend + FastAPI backend over WebSocket.
+
+## Run locally
+
+Prerequisites: [`uv`](https://docs.astral.sh/uv/), Node.js, a Kestrel API key, and the Claude CLI (`claude`).
+
+### Backend (terminal 1)
+
+```bash
+cd backend
+cp .env.example .env
+# In .env set:
+#   KESTREL_API_KEY=<your key>
+#   CLERK_AUTH_ENABLED=false     # no login for local dev
+#   LANGFUSE_ENABLED=false       # silence tracing locally
+
+claude login        # one-time; the agent's LLM calls use this (or set ANTHROPIC_API_KEY in .env)
+uv sync
+uv run uvicorn src.kestrel_backend.main:app --reload --host 127.0.0.1 --port 8000
+```
+
+Wait for `Application startup complete` before loading the UI.
+
+### Frontend (terminal 2)
+
+```bash
+npm install
+VITE_WS_URL=ws://127.0.0.1:8000/ws/chat npm run dev
+```
+
+Open the URL Vite prints (http://localhost:5173).
+
+## Gotchas
+
+- **Use `127.0.0.1`, not `localhost`, in `VITE_WS_URL`.** `localhost` can resolve to IPv6 (`::1`) while the backend binds IPv4 (`127.0.0.1`), so the WebSocket silently fails to connect.
+- **Start the backend first.** If the UI loads before the backend is accepting connections, the app falls into offline **demo mode** (shows canned data, badge in the upper-left reads `demo`). Hard-refresh once the backend is up.
+- Postgres (`DATABASE_URL`) and Langfuse are optional — only needed for conversation persistence and tracing.
+
+## More
+
+See `CLAUDE.md` for architecture, deployment, and the discovery-pipeline details.

--- a/backend/src/kestrel_backend/graph/nodes/pathway_enrichment.py
+++ b/backend/src/kestrel_backend/graph/nodes/pathway_enrichment.py
@@ -253,19 +253,31 @@ async def find_two_hop_shared_neighbors(
                 continue
 
             data = json.loads(json_text)
-            paths = data.get("paths", data) if isinstance(data, dict) else data
-
-            if not isinstance(paths, list):
+            # Kestrel's multi-hop response is {"results": [...], "nodes": {...},
+            # "edges": {...}} — there is NO top-level "paths" key. Each result item
+            # carries its own node sequences under result["paths"] (lists of CURIE
+            # strings) plus a terminal result["end_node_id"]. Collect every node this
+            # entity can reach (deduped per input), drop the start node, then count it
+            # as ONE input connection so the >=2 filter below means "reachable from 2+
+            # distinct input entities" (not "appeared on 2+ paths").
+            results = data.get("results", []) if isinstance(data, dict) else []
+            if not isinstance(results, list):
                 continue
 
-            # Count unique neighbors reached in these paths
-            for path_data in paths:
-                nodes = path_data.get("nodes", [])
-                # Count all intermediate and terminal nodes (exclude the start node)
-                for node in nodes[1:]:
-                    if node not in neighbor_counts:
-                        neighbor_counts[node] = 0
-                    neighbor_counts[node] += 1
+            reached: set[str] = set()
+            for res in results:
+                if not isinstance(res, dict):
+                    continue
+                end_id = res.get("end_node_id")
+                if isinstance(end_id, str) and end_id:
+                    reached.add(end_id)
+                for path in res.get("paths", []):
+                    if isinstance(path, list):
+                        reached.update(n for n in path if isinstance(n, str))
+
+            reached.discard(curie)  # exclude the start node itself
+            for node in reached:
+                neighbor_counts[node] = neighbor_counts.get(node, 0) + 1
 
         except json.JSONDecodeError as e:
             logger.error("Failed to parse multi_hop_query result for %s: %s", curie, str(e))

--- a/backend/src/kestrel_backend/graph/nodes/triage.py
+++ b/backend/src/kestrel_backend/graph/nodes/triage.py
@@ -73,7 +73,6 @@ async def count_edges_via_api(entity: EntityResolution) -> NoveltyScore | None:
             result = await call_kestrel_tool("one_hop_query", {
                 "start_node_ids": curie,
                 "mode": "preview",
-                "direction": "both",
                 "limit": 10000,  # High limit to get accurate count
             })
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -54,7 +54,7 @@ const ALLOWED_UX_DOMAINS = rawFrontendDomains.split(",").map((d: string) => d.tr
 const rawFrontendEmails = (import.meta.env.VITE_ALLOWED_EMAILS as string | undefined) || "";
 const ALLOWED_UX_EMAILS = new Set(rawFrontendEmails.split(",").map((e: string) => e.trim().toLowerCase()).filter(Boolean));
 
-function ProtectedRoute({ component: Component }: { component: React.ComponentType }) {
+function ClerkProtectedRoute({ component: Component }: { component: React.ComponentType }) {
   const { user, isLoaded, isSignedIn } = useUser();
 
   if (!isLoaded) return null;
@@ -74,6 +74,16 @@ function ProtectedRoute({ component: Component }: { component: React.ComponentTy
   }
 
   return <Component />;
+}
+
+// When Clerk isn't configured (local dev / no publishable key), no ClerkProvider
+// is mounted, so calling useUser() would throw. In that case bypass auth and
+// render the route directly. `clerkPubKey` is a build-time constant, so this
+// branch is stable across renders (no conditional-hooks violation), and prod —
+// which always sets the key — is unaffected.
+function ProtectedRoute({ component: Component }: { component: React.ComponentType }) {
+  if (!clerkPubKey) return <Component />;
+  return <ClerkProtectedRoute component={Component} />;
 }
 
 function Router() {

--- a/client/src/hooks/useWebSocket.ts
+++ b/client/src/hooks/useWebSocket.ts
@@ -13,6 +13,12 @@ import type {
 
 const WS_URL = import.meta.env.VITE_WS_URL || "";
 
+// Stable no-op token getter used when Clerk auth is disabled (local dev). Defined
+// at module scope so its identity is constant across renders — the connect effect
+// lists getToken in its deps, so an inline stub recreated each render would thrash
+// the socket (reconnect storm → "Insufficient resources").
+const NOOP_GET_TOKEN = async (): Promise<string | null> => null;
+
 const RECONNECT_DELAYS = [1000, 2000, 4000, 8000, 16000, 30000];
 const MAX_CONNECT_ATTEMPTS_BEFORE_DEMO = 3;
 
@@ -220,8 +226,16 @@ export function useWebSocket() {
   const [agentMode, setAgentMode] = useState<AgentMode>("classic");
   const [pipelineProgress, setPipelineProgress] = useState<PipelineProgress | null>(null);
 
-  // Clerk auth: get fresh session token for WebSocket connections
-  const { getToken, isSignedIn } = useAuth();
+  // Clerk auth: get fresh session token for WebSocket connections.
+  // When Clerk isn't configured (local dev / no publishable key) there's no
+  // ClerkProvider mounted, so useAuth() would throw. Fall back to an
+  // unauthenticated stub. VITE_CLERK_PUBLISHABLE_KEY is a build-time constant,
+  // so this branch is stable across renders (no conditional-hooks violation).
+  const clerkConfigured = !!import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const { getToken, isSignedIn } = clerkConfigured
+    ? useAuth()
+    : { getToken: NOOP_GET_TOKEN, isSignedIn: false };
 
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectAttemptRef = useRef(0);


### PR DESCRIPTION
## Summary

Lands amykglen's three commits onto `dev` (fast-forwardable — `amy` is `dev + 3` with no divergence).

- **fix: kestrel requests/parsing** — `pathway_enrichment.py`'s `multi_hop_query` parser now reads the real response shape `{"results": [...], "nodes": {...}, "edges": {...}}` instead of a non-existent top-level `"paths"` key, and dedups reachable nodes per input entity so the `>=2` shared-neighbor filter counts distinct entities. Also drops the unsupported `direction` param from `one_hop_query` in `triage.py`.
- **fix(client): support running without Clerk** — local/no-auth path so the client runs without Clerk configured.
- **docs: add README with local dev setup**

## Notes

- No divergence from `dev`; merges as a fast-forward.
- Merging to `dev` triggers the dev deploy (`deploy-dev.yml`).
- Greptile: one P2 style note on a build-time-constant conditional hook in `useWebSocket.ts` (works correctly); confidence 4/5, safe to merge.

### Related
This fix exposes the same `data.get("paths", data)` parsing bug in `validate_bridge_hypotheses` (`synthesis.py`), which this PR does **not** touch. That occurrence is handled separately in the `feat/ground-before-synthesis` work (Unit 2 applies the same `paths`->`results` fix while relocating the function).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
