### PR TITLE
fix(kestrel): parse_kestrel_response helper — fix silent-fallback bridge parse (Unit 2A)

### DIFF
--- a/backend/src/kestrel_backend/graph/nodes/integration.py
+++ b/backend/src/kestrel_backend/graph/nodes/integration.py
@@ -308,9 +308,8 @@ def parse_multi_hop_result(
     for path in parsed["paths"][:10]:  # Limit to top 10 paths
         curies = path["curies"]
         names = path["names"]
+        # parse_kestrel_response guarantees len(curies) >= 2, so hop_count >= 1 here.
         hop_count = len(curies) - 1
-        if hop_count < 1:
-            continue
         path_description = f"{cat1_short} → {cat2_short} ({hop_count} hops)"
         tier = 2 if hop_count <= 2 else 3
         significance = f"Path connects {names[0]} to {names[-1]}"

--- a/backend/src/kestrel_backend/graph/nodes/integration.py
+++ b/backend/src/kestrel_backend/graph/nodes/integration.py
@@ -26,7 +26,7 @@ from ..state import (
     DiseaseAssociation, PathwayMembership, InferredAssociation, BiologicalTheme,
     EntityResolution
 )
-from ...kestrel_client import multi_hop_query, call_kestrel_tool
+from ...kestrel_client import multi_hop_query, call_kestrel_tool, parse_kestrel_response
 from ..sdk_utils import HAS_SDK, ClaudeAgentOptions, query_with_usage
 from ..state_contracts import validate_state, IntegrationInput, IntegrationOutput
 from ..pipeline_config import get_pipeline_config
@@ -297,73 +297,32 @@ def parse_multi_hop_result(
     """
     bridges: list[Bridge] = []
 
-    try:
-        # Extract JSON content from MCP response
-        content = result.get("content", [])
-        if not content:
-            return bridges
+    # Parse via the shared helper — the real response is {"results":[{"paths":[[curie,...]]}],
+    # "nodes":{...}}, NOT {"paths":[...]}. The helper fails loudly to [] on a bad shape and
+    # never falls back to the raw dict (the silent-fallback bug that emitted zero bridges).
+    parsed = parse_kestrel_response(result)
 
-        # The first content item should be JSON text
-        json_text = content[0].get("text", "")
-        if not json_text:
-            return bridges
+    cat1_short = cat1.replace("biolink:", "")
+    cat2_short = cat2.replace("biolink:", "")
 
-        # Parse JSON response
-        data = json.loads(json_text)
-
-        # Handle different response formats
-        # Expected format: {"paths": [...]} or direct list of paths
-        paths = data.get("paths", data) if isinstance(data, dict) else data
-
-        if not isinstance(paths, list):
-            logger.warning("parse_multi_hop_result: unexpected format, expected list of paths")
-            return bridges
-
-        # Convert each path to a Bridge
-        for path_data in paths[:10]:  # Limit to top 10 paths
-            try:
-                # Extract path components
-                # Expected: {"nodes": [...], "edges": [...], "predicates": [...]}
-                nodes = path_data.get("nodes", [])
-                predicates = path_data.get("predicates", [])
-                node_names = path_data.get("node_names", [])
-
-                if len(nodes) < 2:
-                    continue
-
-                # Build path description
-                cat1_short = cat1.replace("biolink:", "")
-                cat2_short = cat2.replace("biolink:", "")
-                hop_count = len(nodes) - 1  # Number of hops = nodes - 1
-                path_description = f"{cat1_short} → {cat2_short} ({hop_count} hops)"
-
-                # Determine tier: 2 if path is short (1-2 hops), else 3
-                tier = 2 if hop_count <= 2 else 3
-
-                # Generate significance from path structure
-                if node_names and len(node_names) == len(nodes):
-                    significance = f"Path connects {node_names[0]} to {node_names[-1]}"
-                else:
-                    significance = f"Path connects {nodes[0]} to {nodes[-1]}"
-
-                bridges.append(Bridge(
-                    path_description=path_description,
-                    entities=nodes,
-                    entity_names=node_names if node_names else [],
-                    predicates=predicates if predicates else [],
-                    tier=tier,
-                    novelty="known",  # From KG, not inferred
-                    significance=significance,
-                ))
-
-            except Exception as e:
-                logger.warning("Error parsing path: %s", str(e))
-                continue
-
-    except json.JSONDecodeError as e:
-        logger.error("Failed to parse multi_hop_query JSON: %s", str(e))
-    except Exception as e:
-        logger.error("Unexpected error parsing multi_hop_result: %s", str(e))
+    for path in parsed["paths"][:10]:  # Limit to top 10 paths
+        curies = path["curies"]
+        names = path["names"]
+        hop_count = len(curies) - 1
+        if hop_count < 1:
+            continue
+        path_description = f"{cat1_short} → {cat2_short} ({hop_count} hops)"
+        tier = 2 if hop_count <= 2 else 3
+        significance = f"Path connects {names[0]} to {names[-1]}"
+        bridges.append(Bridge(
+            path_description=path_description,
+            entities=curies,
+            entity_names=names,
+            predicates=[],  # predicate-per-hop derivation deferred (edges/edge_schema mapping)
+            tier=tier,
+            novelty="known",  # From KG, not inferred
+            significance=significance,
+        ))
 
     return bridges
 

--- a/backend/src/kestrel_backend/graph/nodes/pathway_enrichment.py
+++ b/backend/src/kestrel_backend/graph/nodes/pathway_enrichment.py
@@ -23,7 +23,7 @@ from typing import Any
 from ..state import (
     DiscoveryState, SharedNeighbor, BiologicalTheme, Finding
 )
-from ...kestrel_client import multi_hop_query
+from ...kestrel_client import multi_hop_query, parse_kestrel_response
 from .cold_start import get_entity_connections
 from ..sdk_utils import HAS_SDK, ClaudeAgentOptions, query_with_usage
 from ..pipeline_config import get_pipeline_config
@@ -243,45 +243,22 @@ async def find_two_hop_shared_neighbors(
                 errors.append(f"multi_hop_query error for {curie}: {error_text}")
                 continue
 
-            # Extract reachable nodes from result
-            content = result.get("content", [])
-            if not content:
-                continue
-
-            json_text = content[0].get("text", "")
-            if not json_text:
-                continue
-
-            data = json.loads(json_text)
-            # Kestrel's multi-hop response is {"results": [...], "nodes": {...},
-            # "edges": {...}} — there is NO top-level "paths" key. Each result item
-            # carries its own node sequences under result["paths"] (lists of CURIE
-            # strings) plus a terminal result["end_node_id"]. Collect every node this
-            # entity can reach (deduped per input), drop the start node, then count it
-            # as ONE input connection so the >=2 filter below means "reachable from 2+
-            # distinct input entities" (not "appeared on 2+ paths").
-            results = data.get("results", []) if isinstance(data, dict) else []
-            if not isinstance(results, list):
-                continue
-
-            reached: set[str] = set()
-            for res in results:
-                if not isinstance(res, dict):
-                    continue
-                end_id = res.get("end_node_id")
-                if isinstance(end_id, str) and end_id:
-                    reached.add(end_id)
-                for path in res.get("paths", []):
-                    if isinstance(path, list):
-                        reached.update(n for n in path if isinstance(n, str))
+            # Parse via the shared helper. Kestrel's multi-hop response is
+            # {"results": [...], "nodes": {...}, "edges": {...}} — there is NO top-level
+            # "paths" key; the helper reads result["end_node_id"] + result["paths"] (CURIE
+            # lists) and fails loudly to empty on a bad shape. Collect every node this entity
+            # can reach (end-nodes + intermediates, deduped per input), drop the start node,
+            # then count it as ONE input connection so the >=2 filter below means "reachable
+            # from 2+ distinct input entities" (not "appeared on 2+ paths").
+            parsed = parse_kestrel_response(result)
+            reached: set[str] = set(parsed["end_node_ids"])
+            for path in parsed["paths"]:
+                reached.update(path["curies"])
 
             reached.discard(curie)  # exclude the start node itself
             for node in reached:
                 neighbor_counts[node] = neighbor_counts.get(node, 0) + 1
 
-        except json.JSONDecodeError as e:
-            logger.error("Failed to parse multi_hop_query result for %s: %s", curie, str(e))
-            errors.append(f"JSON parse error for {curie}")
         except Exception as e:
             logger.error("Error in two-hop search for %s: %s", curie, str(e))
             errors.append(f"Exception for {curie}: {str(e)}")

--- a/backend/src/kestrel_backend/graph/nodes/synthesis.py
+++ b/backend/src/kestrel_backend/graph/nodes/synthesis.py
@@ -14,7 +14,6 @@ systematic review data showing that approximately 18% of computational predictio
 progress to clinical investigation.
 """
 
-import json
 import logging
 import time
 from typing import Any
@@ -25,7 +24,7 @@ from ..state import (
     Hypothesis
 )
 from ...literature_utils import format_pmid_link
-from ...kestrel_client import multi_hop_query
+from ...kestrel_client import multi_hop_query, parse_kestrel_response
 from ..sdk_utils import HAS_SDK, ClaudeAgentOptions, query_with_usage
 from ..state_contracts import validate_state, SynthesisInput, SynthesisOutput
 
@@ -887,21 +886,13 @@ async def validate_bridge_hypotheses(bridges: list[Bridge]) -> list[Bridge]:
                 validated_bridges.append(bridge)
                 continue
 
-            # Check if we got any paths back
-            content = result.get("content", [])
-            if not content:
-                validated_bridges.append(bridge)
-                continue
+            # Check if we got any paths back. Use the shared helper — the real response is
+            # {"results":[{"paths":[[curie,...]]}], ...} with NO top-level "paths" key. The old
+            # data.get("paths", data) fell back to the whole dict (always truthy) and upgraded
+            # EVERY bridge to Tier 2 on garbage; the helper returns n_paths=0 on a no-path result.
+            parsed = parse_kestrel_response(result)
 
-            json_text = content[0].get("text", "")
-            if not json_text:
-                validated_bridges.append(bridge)
-                continue
-
-            data = json.loads(json_text)
-            paths = data.get("paths", data) if isinstance(data, dict) else data
-
-            if paths and len(paths) > 0:
+            if parsed["n_paths"] > 0:
                 # Path verified! Upgrade to Tier 2
                 logger.info(
                     "validate_bridge_hypotheses: VALIDATED %s -> %s, upgrading to Tier 2",

--- a/backend/src/kestrel_backend/kestrel_client.py
+++ b/backend/src/kestrel_backend/kestrel_client.py
@@ -411,3 +411,85 @@ async def multi_hop_query(
         arguments["mode"] = mode
 
     return await call_kestrel_tool("multi_hop_query", arguments)
+
+
+def parse_kestrel_response(envelope: dict[str, Any]) -> dict[str, Any]:
+    """Parse a multi_hop_query / subgraph_query MCP envelope into normalized paths.
+
+    Replaces the drift-prone ``data.get("paths", data)`` parse that shipped to prod in
+    three nodes for ~3.5 months. The real response (see .claude/skills/kestrel-api) has NO
+    top-level ``"paths"`` key — it is ``{"results": [...], "nodes": {...}, "edges": {...}}``
+    where each ``result["paths"]`` is a list of **CURIE-string lists** (not dicts).
+
+    FAILS LOUDLY: on a missing/mis-shaped ``results`` (or a bad envelope) it returns an
+    EMPTY path set and logs — it NEVER falls back to the raw dict (the silent-fallback bug).
+
+    Args:
+        envelope: the MCP tool result ``{"content": [{"text": "<json>"}], "isError": ...}``.
+
+    Returns:
+        ``{"paths": [{"curies": [...], "names": [...], "end_node_id": str,
+        "degree": int, "score": float}], "nodes": {curie: {...}},
+        "end_node_ids": [str, ...], "n_paths": int}`` — ``end_node_ids`` lists every result's
+        ``end_node_id`` (order-preserving, deduped), for callers that need reachable end-nodes
+        rather than full paths (e.g. pathway_enrichment's shared-neighbor counting).
+    """
+    empty = {"paths": [], "nodes": {}, "end_node_ids": [], "n_paths": 0}
+    try:
+        content = envelope.get("content", []) if isinstance(envelope, dict) else []
+        if not content:
+            return empty
+        json_text = content[0].get("text", "")
+        if not json_text:
+            return empty
+        data = json.loads(json_text)
+    except (json.JSONDecodeError, AttributeError, IndexError, TypeError) as e:
+        logger.warning("parse_kestrel_response: bad envelope (%s)", e)
+        return empty
+
+    if not isinstance(data, dict):
+        logger.warning("parse_kestrel_response: inner data not a dict: %s", type(data).__name__)
+        return empty
+
+    results = data.get("results", [])
+    if not isinstance(results, list):
+        logger.warning("parse_kestrel_response: 'results' not a list (keys=%s)", list(data)[:5])
+        return empty
+
+    nodes = data.get("nodes", {})
+    if not isinstance(nodes, dict):
+        nodes = {}
+
+    def _name(curie: str) -> str:
+        info = nodes.get(curie)
+        if isinstance(info, dict) and info.get("name"):
+            return str(info["name"])
+        return curie
+
+    parsed_paths: list[dict[str, Any]] = []
+    end_node_ids: list[str] = []
+    seen_ends: set[str] = set()
+    for res in results:
+        if not isinstance(res, dict):
+            continue
+        end_id = res.get("end_node_id")
+        if isinstance(end_id, str) and end_id and end_id not in seen_ends:
+            seen_ends.add(end_id)
+            end_node_ids.append(end_id)
+        for path in res.get("paths", []) or []:
+            # A path is a list of CURIE strings. Reject the old dict shape loudly.
+            if not isinstance(path, list) or len(path) < 2:
+                continue
+            curies = [c for c in path if isinstance(c, str)]
+            if len(curies) < 2:
+                continue
+            parsed_paths.append({
+                "curies": curies,
+                "names": [_name(c) for c in curies],
+                "end_node_id": res.get("end_node_id", curies[-1]),
+                "degree": res.get("degree", 0),
+                "score": res.get("score", 0.0),
+            })
+
+    return {"paths": parsed_paths, "nodes": nodes,
+            "end_node_ids": end_node_ids, "n_paths": len(parsed_paths)}

--- a/backend/tests/test_kestrel_parse.py
+++ b/backend/tests/test_kestrel_parse.py
@@ -1,0 +1,106 @@
+"""Tests for kestrel_client.parse_kestrel_response.
+
+The helper replaces the ``data.get("paths", data)`` silent-fallback parse that shipped to prod
+in three nodes for ~3.5 months. It MUST fail loudly to an empty result on a missing/mis-shaped
+``results`` and NEVER fall back to the raw dict (the bug that over-validated bridges in synthesis
+and silently dropped them in integration).
+
+Run with: uv run python -m pytest tests/test_kestrel_parse.py -v
+"""
+
+import json
+
+from src.kestrel_backend.kestrel_client import parse_kestrel_response
+
+
+def _envelope(inner: dict | list) -> dict:
+    """Wrap an inner Kestrel response in the MCP tool-result envelope."""
+    return {"content": [{"type": "text", "text": json.dumps(inner)}], "isError": False}
+
+
+# The real multi_hop_query response shape (see .claude/skills/kestrel-api): results -> per-result
+# paths (lists of CURIE strings) + end_node_id; names come from the top-level nodes dict.
+REAL = _envelope({
+    "results": [
+        {"end_node_id": "MONDO:0005148", "paths": [["CHEBI:4167", "MONDO:0005148"]],
+         "degree": 11051, "score": 0.81},
+    ],
+    "nodes": {"CHEBI:4167": {"name": "glucose"}, "MONDO:0005148": {"name": "type 2 diabetes"}},
+    "edges": {},
+})
+
+
+def test_real_shape_parses_paths_and_names():
+    r = parse_kestrel_response(REAL)
+    assert r["n_paths"] == 1
+    assert r["paths"][0]["curies"] == ["CHEBI:4167", "MONDO:0005148"]
+    assert r["paths"][0]["names"] == ["glucose", "type 2 diabetes"]
+    assert r["end_node_ids"] == ["MONDO:0005148"]
+
+
+def test_empty_results_no_fallback_to_dict():
+    r = parse_kestrel_response(_envelope({"results": [], "nodes": {}, "edges": {}}))
+    assert r["n_paths"] == 0
+    assert r["paths"] == []
+    assert r["end_node_ids"] == []
+
+
+def test_missing_results_key_fails_loud_not_dict():
+    # No "results" key — must NOT return the raw dict (the silent-fallback bug).
+    r = parse_kestrel_response(_envelope({"nodes": {"X": {"name": "x"}}}))
+    assert r["n_paths"] == 0 and r["paths"] == []
+
+
+def test_old_bug_shape_yields_nothing():
+    # The shape Kestrel never returns ({"paths": [{"nodes": [...]}]}) must produce 0 paths,
+    # not be mistaken for a real path set (regression guard for the historic bug).
+    r = parse_kestrel_response(_envelope({"paths": [{"nodes": ["A", "B"], "predicates": ["x"]}]}))
+    assert r["n_paths"] == 0
+
+
+def test_malformed_inputs_never_raise():
+    for bad in [
+        _envelope({"results": "nope"}),          # results not a list
+        _envelope(["x"]),                          # inner not a dict
+        {"content": [{"text": "{not json"}]},      # bad JSON
+        {"content": []},                           # empty content
+        {},                                        # no content key
+        {"content": [{}]},                         # content item missing text
+    ]:
+        r = parse_kestrel_response(bad)
+        assert r["n_paths"] == 0 and r["paths"] == [] and r["end_node_ids"] == []
+
+
+def test_short_path_excluded_but_end_node_kept():
+    # A result with a terminal end_node_id but a too-short path: the path is dropped (len<2),
+    # yet the end_node_id is still surfaced for reachable-node callers (pathway_enrichment).
+    env = _envelope({
+        "results": [{"end_node_id": "CHEBI:9", "paths": [["CHEBI:9"]]}],
+        "nodes": {"CHEBI:9": {"name": "lonely"}},
+    })
+    r = parse_kestrel_response(env)
+    assert r["n_paths"] == 0
+    assert r["end_node_ids"] == ["CHEBI:9"]
+
+
+def test_end_node_ids_deduped_order_preserving():
+    env = _envelope({
+        "results": [
+            {"end_node_id": "B", "paths": [["A", "B"]]},
+            {"end_node_id": "C", "paths": [["A", "C"]]},
+            {"end_node_id": "B", "paths": [["A", "X", "B"]]},  # duplicate end-node
+        ],
+        "nodes": {"A": {"name": "a"}, "B": {"name": "b"}, "C": {"name": "c"}, "X": {"name": "x"}},
+    })
+    r = parse_kestrel_response(env)
+    assert r["end_node_ids"] == ["B", "C"]
+    assert r["n_paths"] == 3
+
+
+def test_missing_node_name_falls_back_to_curie():
+    env = _envelope({
+        "results": [{"end_node_id": "GO:1", "paths": [["CHEBI:1", "GO:1"]]}],
+        "nodes": {"CHEBI:1": {"name": "named"}},  # GO:1 absent from nodes
+    })
+    r = parse_kestrel_response(env)
+    assert r["paths"][0]["names"] == ["named", "GO:1"]

--- a/backend/tests/test_multi_hop_integration.py
+++ b/backend/tests/test_multi_hop_integration.py
@@ -33,7 +33,7 @@ class TestMultiHopQueryWrapper:
         """Test singly-pinned mode (start nodes only)."""
         with patch('src.kestrel_backend.kestrel_client.call_kestrel_tool', new_callable=AsyncMock) as mock_call:
             mock_call.return_value = {
-                "content": [{"type": "text", "text": '{"paths": []}'}],
+                "content": [{"type": "text", "text": '{"results": []}'}],
                 "isError": False,
             }
 
@@ -43,12 +43,12 @@ class TestMultiHopQueryWrapper:
                 limit=10,
             )
 
-            # Verify the call was made correctly
+            # Verify the call was made correctly. The wrapper maps max_hops -> max_path_length.
             mock_call.assert_called_once()
             call_args = mock_call.call_args[0]
             assert call_args[0] == "multi_hop_query"
             assert call_args[1]["start_node_ids"] == ["CHEBI:17234"]
-            assert call_args[1]["max_hops"] == 2
+            assert call_args[1]["max_path_length"] == 2
             assert call_args[1]["limit"] == 10
             assert "end_node_ids" not in call_args[1]
 
@@ -59,7 +59,7 @@ class TestMultiHopQueryWrapper:
         """Test doubly-pinned mode (start and end nodes)."""
         with patch('src.kestrel_backend.kestrel_client.call_kestrel_tool', new_callable=AsyncMock) as mock_call:
             mock_call.return_value = {
-                "content": [{"type": "text", "text": '{"paths": []}'}],
+                "content": [{"type": "text", "text": '{"results": []}'}],
                 "isError": False,
             }
 
@@ -72,7 +72,7 @@ class TestMultiHopQueryWrapper:
             call_args = mock_call.call_args[0]
             assert call_args[1]["start_node_ids"] == ["CHEBI:17234"]
             assert call_args[1]["end_node_ids"] == ["MONDO:0005148"]
-            assert call_args[1]["max_hops"] == 3
+            assert call_args[1]["max_path_length"] == 3
 
     @pytest.mark.asyncio
     async def test_validation_max_hops(self):
@@ -160,15 +160,16 @@ class TestDetectBridgesViaAPI:
 
         with patch('src.kestrel_backend.graph.nodes.integration.multi_hop_query', new_callable=AsyncMock) as mock_mhq:
             # Mock a successful path response
+            # Real Kestrel shape: results -> per-result paths (CURIE-string lists) + end_node_id;
+            # names from the top-level nodes dict (NOT a per-path {nodes,predicates} dict).
             mock_mhq.return_value = {
                 "content": [{
                     "type": "text",
                     "text": json.dumps({
-                        "paths": [{
-                            "nodes": ["CHEBI:17234", "HGNC:6081"],
-                            "predicates": ["biolink:affects"],
-                            "node_names": ["glucose", "INS"],
-                        }]
+                        "results": [{"end_node_id": "HGNC:6081",
+                                     "paths": [["CHEBI:17234", "HGNC:6081"]]}],
+                        "nodes": {"CHEBI:17234": {"name": "glucose"},
+                                  "HGNC:6081": {"name": "INS"}},
                     })
                 }],
                 "isError": False,
@@ -177,7 +178,7 @@ class TestDetectBridgesViaAPI:
             bridges, errors = await detect_bridges_via_api(entities, max_hops=2)
 
             assert len(bridges) == 1
-            assert bridges[0].tier == 2  # 2-hop path
+            assert bridges[0].tier == 2  # 1-hop path (<=2 hops) -> tier 2
             assert "CHEBI:17234" in bridges[0].entities
             assert "HGNC:6081" in bridges[0].entities
 
@@ -191,11 +192,15 @@ class TestParseMultiHopResult:
             "content": [{
                 "type": "text",
                 "text": json.dumps({
-                    "paths": [{
-                        "nodes": ["CHEBI:17234", "HGNC:6081", "MONDO:0005148"],
-                        "predicates": ["biolink:affects", "biolink:associated_with"],
-                        "node_names": ["glucose", "INS", "type 2 diabetes"],
-                    }]
+                    "results": [{
+                        "end_node_id": "MONDO:0005148",
+                        "paths": [["CHEBI:17234", "HGNC:6081", "MONDO:0005148"]],
+                    }],
+                    "nodes": {
+                        "CHEBI:17234": {"name": "glucose"},
+                        "HGNC:6081": {"name": "INS"},
+                        "MONDO:0005148": {"name": "type 2 diabetes"},
+                    },
                 })
             }]
         }
@@ -289,15 +294,15 @@ class TestValidateBridgeHypotheses:
         )
 
         with patch('src.kestrel_backend.graph.nodes.synthesis.multi_hop_query', new_callable=AsyncMock) as mock_mhq:
-            # Mock successful validation
+            # Mock successful validation — real shape with a reachable path.
             mock_mhq.return_value = {
                 "content": [{
                     "type": "text",
                     "text": json.dumps({
-                        "paths": [{
-                            "nodes": ["CHEBI:17234", "HGNC:6081"],
-                            "predicates": ["biolink:affects"],
-                        }]
+                        "results": [{"end_node_id": "HGNC:6081",
+                                     "paths": [["CHEBI:17234", "HGNC:6081"]]}],
+                        "nodes": {"CHEBI:17234": {"name": "glucose"},
+                                  "HGNC:6081": {"name": "INS"}},
                     })
                 }],
                 "isError": False,
@@ -324,11 +329,11 @@ class TestValidateBridgeHypotheses:
         )
 
         with patch('src.kestrel_backend.graph.nodes.synthesis.multi_hop_query', new_callable=AsyncMock) as mock_mhq:
-            # Mock no paths found
+            # Mock no paths found (real empty shape).
             mock_mhq.return_value = {
                 "content": [{
                     "type": "text",
-                    "text": json.dumps({"paths": []})
+                    "text": json.dumps({"results": []})
                 }],
                 "isError": False,
             }
@@ -366,27 +371,27 @@ class TestFindTwoHopSharedNeighbors:
             # Mock responses for two entities sharing a neighbor
             def mock_response(start_node_ids, **kwargs):
                 if start_node_ids == ["CHEBI:17234"]:
-                    # Glucose connects to HGNC:6081 (INS) in 2 hops
+                    # Glucose reaches GO:0005737 and HGNC:6081 (real shape: CURIE-list path).
                     return {
                         "content": [{
                             "type": "text",
                             "text": json.dumps({
-                                "paths": [{
-                                    "nodes": ["CHEBI:17234", "GO:0005737", "HGNC:6081"],
-                                }]
+                                "results": [{"end_node_id": "HGNC:6081",
+                                             "paths": [["CHEBI:17234", "GO:0005737", "HGNC:6081"]]}],
+                                "nodes": {},
                             })
                         }],
                         "isError": False,
                     }
                 elif start_node_ids == ["CHEBI:28757"]:
-                    # Fructose also connects to HGNC:6081 (INS) in 2 hops
+                    # Fructose also reaches GO:0005737 and HGNC:6081.
                     return {
                         "content": [{
                             "type": "text",
                             "text": json.dumps({
-                                "paths": [{
-                                    "nodes": ["CHEBI:28757", "GO:0005737", "HGNC:6081"],
-                                }]
+                                "results": [{"end_node_id": "HGNC:6081",
+                                             "paths": [["CHEBI:28757", "GO:0005737", "HGNC:6081"]]}],
+                                "nodes": {},
                             })
                         }],
                         "isError": False,
@@ -416,9 +421,9 @@ class TestFindTwoHopSharedNeighbors:
                         "content": [{
                             "type": "text",
                             "text": json.dumps({
-                                "paths": [{
-                                    "nodes": ["CHEBI:17234", "UNIQUE:001"],
-                                }]
+                                "results": [{"end_node_id": "UNIQUE:001",
+                                             "paths": [["CHEBI:17234", "UNIQUE:001"]]}],
+                                "nodes": {},
                             })
                         }],
                         "isError": False,
@@ -428,9 +433,9 @@ class TestFindTwoHopSharedNeighbors:
                         "content": [{
                             "type": "text",
                             "text": json.dumps({
-                                "paths": [{
-                                    "nodes": ["CHEBI:28757", "UNIQUE:002"],
-                                }]
+                                "results": [{"end_node_id": "UNIQUE:002",
+                                             "paths": [["CHEBI:28757", "UNIQUE:002"]]}],
+                                "nodes": {},
                             })
                         }],
                         "isError": False,


### PR DESCRIPTION
## Summary

Adds a single tested `parse_kestrel_response()` helper and routes the three drift-prone Kestrel `multi_hop_query` parse sites through it, fixing a **silent-fallback bug** that shipped to prod for ~3.5 months.

This is **Unit 2A** of the [ground-before-synthesis plan](docs/plans/2026-06-11-002-feat-ground-before-synthesis-plan.md), landed first as its own PR so the reorder (PR 1) moves an already-correct function. Validated by a throwaway value spike (Spike 0) that needed real bridge hypotheses to test against.

## The bug

The response has **no top-level `"paths"` key** — it is `{"results": [...], "nodes": {...}, "edges": {...}}` where each `result["paths"]` is a list of **CURIE-string lists**. Three nodes parsed it as `data.get("paths", data)`, which falls back to the **whole dict** when `"paths"` is absent:

- **`integration.parse_multi_hop_result`** — the dict isn't a list of path-dicts → **zero bridges emitted**. On `dev` today, well-characterized multi-entity discovery queries silently produce **0 hypotheses** (their only hypothesis source is bridges).
- **`synthesis.validate_bridge_hypotheses`** — `len(dict) > 0` is truthy → **every** bridge upgraded to Tier 2 on garbage (always-upgrade no-op).

It survived ~3.5 months because the tests mocked the fake `{"paths": [{"nodes": [...]}]}` shape Kestrel never returns, **certifying the bug as passing**.

## Changes

- **`kestrel_client.parse_kestrel_response()`** — reads the real shape, maps CURIEs → names via the top-level `nodes` dict, and **fails loudly to an empty result (+log)** on a missing/mis-shaped response; never falls back to the raw dict. Exposes `paths` (CURIE-list bridges), `end_node_ids` (reachable end-nodes), and `n_paths`.
- Route **integration**, **synthesis**, and **pathway_enrichment** through the helper (single source of truth). `pathway_enrichment` was already correct post-#70 — this dedups it via `end_node_ids`, preserving its exact reachable-set semantics.
- `integration` rebuilds `Bridge`s from CURIE-string paths (`entities` + names from `nodes`) instead of the non-existent per-path `{nodes,predicates,node_names}` dicts.
- Rewrite the wrong-shape mocks in `test_multi_hop_integration.py` to the real shape; fix two pre-existing wrapper assertions (`max_hops` → `max_path_length`).
- Add `tests/test_kestrel_parse.py` (real / empty / malformed / old-bug-shape / `end_node_ids` / short-path / missing-name cases).

## Behavior change (intentional, per-caller)

- **synthesis:** upgrades **fewer** bridges to Tier 2 — only genuinely path-verified ones.
- **integration:** **newly emits bridges** it currently drops silently (highest blast radius).
- Verified live: a well-characterized panel (urolithin A, spermidine, SIRT1, PINK1, NFE2L2) went **0 → 20 bridges → 102 hypotheses**.

## Testing

- `python -m pytest tests/test_kestrel_parse.py tests/test_multi_hop_integration.py tests/test_pathway_enrichment.py` → **38 passed**.
- `test_langgraph_prototype.py`: 37 failures, but **identical with and without this change** (pre-existing, known-broken suite — verified by stash/compare). No new failures introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)