### PR TITLE
Feat/biomapper entity resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ docs/references/biomedical-link-prediction-methods-and-evidence.pdf
 
 # code-on-graph spike: ignore transient per-item checkpoints (final result JSONs are tracked)
 backend/tests/code_on_graph_spike/runs/*.partial.json
+
+# Biomapper eval run artifacts (timestamped; persisted by default)
+backend/src/kestrel_backend/evals/**/runs/

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,6 +12,15 @@ RATE_LIMIT_PER_MINUTE=10
 KESTREL_API_KEY=your-kestrel-api-key-here
 # KESTREL_MCP_URL=https://kestrel.nathanpricelab.com/mcp  # Optional, defaults to production
 
+# Biomapper2 entity resolution (only needed when the biomapper pre-resolver flag is enabled).
+# Provides namespace/species-correct CURIE resolution before Kestrel ranking. The flag itself
+# lives in pipeline_config (default off); these are just the credentials.
+# BIOMAPPER_API_KEY=your-biomapper2-api-key-here
+# BIOMAPPER_BASE_URL=https://biomapper.expertintheloop.io  # Optional; unset = client default (prod).
+#                                                            # MUST be https:// when a key is set.
+# BIOMAPPER_DEV_BASE_URL=https://dev-biomapper.expertintheloop.io/api/v1  # Backs the prod/dev API
+#                              # toggle (biomapper_env="dev"). HTTPS only when a key is set.
+
 # Database (optional, for conversation persistence)
 # DATABASE_URL=postgresql://user:password@localhost:5432/kraken_db
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "PyJWT[crypto]>=2.8.0",
     "ftfy>=6.3.1",
     "defusedxml>=0.7.1",  # safe parsing of PubMed EFetch XML (XXE / billion-laughs)
+    "biomapper>=1.2.1",  # namespace/species-correct entity resolution (>=1.2.1 for entity_type support)
 ]
 
 [dependency-groups]

--- a/backend/src/kestrel_backend/biomapper_client.py
+++ b/backend/src/kestrel_backend/biomapper_client.py
@@ -1,0 +1,126 @@
+"""Async Biomapper pre-resolver wrapper for the entity_resolution node.
+
+Maps a single ``(name, entity_type_hint)`` to a normalized resolution dict using the
+``biomapper`` PyPI client over the BioMapper2 HTTP API. The module is import-safe with no
+side effects; ``biomapper`` itself is **lazy-imported inside the call** so flag-off runs and
+environments without the dependency/credentials are unaffected.
+
+Responsibilities (kept here so the node stays thin):
+  - map the intake ``entity_type_hint`` -> a Biolink class (the namespace/species lever);
+  - gate on the confidence tier, read **via attribute** (``confidence_tier`` is a computed
+    @property — ``model_dump()`` drops it);
+  - apply the error taxonomy (``BioMapperAuthError`` is fatal → re-raise; everything else →
+    ``None`` so the caller falls back to Kestrel);
+  - validate the returned CURIE shape (BioMapper2 is a third-party service in the resolution
+    trust boundary);
+  - never log or echo the API key.
+
+See docs/plans/2026-06-11-001-feat-biomapper-entity-resolution-plan.md (Unit 2).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+from .config import get_settings
+
+logger = logging.getLogger(__name__)
+
+# intake ``entity_type_hint`` -> Biolink class passed to Biomapper as the namespace/species
+# lever. Standard Biolink model classes; validate against ``client.list_entity_types()`` if they
+# ever drift. A hint outside this map (or None) means "no class signal" → skip Biomapper.
+_CLASS_TO_BIOLINK: dict[str, str] = {
+    "gene": "biolink:Gene",
+    "protein": "biolink:Protein",
+    "metabolite": "biolink:SmallMolecule",
+}
+
+# Minimum confidence tier to accept a Biomapper map; below this the caller falls back to Kestrel.
+# Tiers are derived by the SDK from an (unbounded) relevance score: >=2.0 high, >=1.0 medium,
+# else low; None score -> "unknown".
+_MIN_CONFIDENCE_TIER = "medium"
+_TIER_RANK = {"unknown": -1, "low": 0, "medium": 1, "high": 2}
+
+# CURIE shape guard: a malformed/crafted CURIE must not flow into a Kestrel query or the report.
+_CURIE_RE = re.compile(r"^[A-Za-z0-9_.]+:[A-Za-z0-9._\-]+$")
+
+
+def biolink_class_for(entity_type_hint: str | None) -> str | None:
+    """Return the Biolink class for an intake hint, or None if there is no usable signal."""
+    if not entity_type_hint:
+        return None
+    return _CLASS_TO_BIOLINK.get(entity_type_hint.strip().lower())
+
+
+async def resolve_entity(
+    name: str, entity_type_hint: str | None, base_url: str | None = None
+) -> dict | None:
+    """Resolve a single entity name via Biomapper, or return None to fall back to Kestrel.
+
+    Returns a normalized dict on a confident, well-formed map:
+        {"curie", "tier", "confidence", "resolved_name", "category", "xrefs"}
+    Returns None when: no/unknown hint, Biomapper did not resolve, the tier is below the gate,
+    the CURIE is malformed, or any non-auth Biomapper/transport error occurred.
+    Raises BioMapperAuthError (fatal misconfig — never silently degrade a bad key).
+
+    ``base_url`` overrides the configured biomapper2 endpoint per call (the prod/dev toggle);
+    None falls back to Settings, then to the client default.
+    """
+    biolink = biolink_class_for(entity_type_hint)
+    if biolink is None:
+        return None  # no class signal → don't guess; caller uses Kestrel
+
+    # Lazy import: keeps module import side-effect-free and flag-off/dep-absent paths unaffected.
+    from biomapper import (  # noqa: PLC0415 — intentional lazy import
+        BioMapperAuthError,
+        BioMapperClient,
+        BioMapperError,
+    )
+
+    settings = get_settings()
+    client_kwargs: dict[str, object] = {}
+    if settings.biomapper_api_key:
+        client_kwargs["api_key"] = settings.biomapper_api_key
+    effective_base_url = base_url or settings.biomapper_base_url
+    if effective_base_url:
+        client_kwargs["base_url"] = effective_base_url
+
+    try:
+        async with BioMapperClient(**client_kwargs) as client:
+            result = await client.map_entity(name=name, entity_type=biolink)
+    except BioMapperAuthError:
+        # Bad/absent key is a deployment misconfig — fail loud, do not fall through silently.
+        raise
+    except BioMapperError:
+        # Rate-limit / config / server / timeout (all subclass BioMapperError) → fall back.
+        logger.info("FALLBACK_EVENT reason=biomapper_error name=%r class=%s", name, biolink)
+        return None
+    except Exception:  # noqa: BLE001 — transport/unknown: never break resolution, fall back
+        logger.info("FALLBACK_EVENT reason=biomapper_transport name=%r class=%s", name, biolink)
+        return None
+
+    if not getattr(result, "resolved", False):
+        return None
+
+    # confidence_tier is a computed @property — read via attribute, NEVER via model_dump().
+    tier = getattr(result, "confidence_tier", "unknown")
+    if _TIER_RANK.get(tier, -1) < _TIER_RANK[_MIN_CONFIDENCE_TIER]:
+        return None
+
+    curie = getattr(result, "primary_curie", None)
+    if not curie or not _CURIE_RE.match(curie):
+        # Missing or malformed CURIE from a third-party service → treat as unmapped.
+        return None
+
+    xrefs = getattr(result, "kg_equivalent_ids", None) or {}
+    return {
+        "curie": curie,
+        "tier": tier,
+        "confidence": getattr(result, "confidence_score", None),
+        # Biomapper has no canonical display-name field (only query_name echo + chosen_kg_id);
+        # Unit 3/4 prefer the confirmed Kestrel node's name. Echo the query name as a fallback.
+        "resolved_name": getattr(result, "query_name", name),
+        "category": biolink,  # provisional; Unit 4 overrides with the Kestrel-native category
+        "xrefs": dict(xrefs),  # dict[str, list[str]] keyed by namespace prefix
+    }

--- a/backend/src/kestrel_backend/config.py
+++ b/backend/src/kestrel_backend/config.py
@@ -2,7 +2,7 @@
 
 import os
 from functools import lru_cache
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 from dotenv import load_dotenv
 
 
@@ -37,10 +37,36 @@ class Settings(BaseModel):
     langfuse_secret_key: str | None = None
     langfuse_base_url: str = "https://us.cloud.langfuse.com"
 
+    # Biomapper2 entity resolution (R7: secrets via env; flag/policy live in pipeline_config).
+    # biomapper_base_url=None means "use the biomapper client default" (prod HTTPS instance).
+    # biomapper_dev_base_url backs the prod/dev API toggle (mirrors biomapper-ui env routing).
+    biomapper_api_key: str | None = None
+    biomapper_base_url: str | None = None
+    biomapper_dev_base_url: str | None = None
+
     # Logging configuration
     log_level: str = "INFO"
     log_format: str = "text"  # "json" or "text"
     log_module_levels: dict[str, str] = {}  # Module-specific log levels
+
+    @model_validator(mode="after")
+    def _enforce_biomapper_https(self) -> "Settings":
+        """Never transmit the Biomapper API key over plaintext HTTP.
+
+        Reject an http:// base URL when a key is set so the credential is never sent in the
+        clear. A None base URL (client default) and HTTPS URLs are both fine.
+        """
+        if self.biomapper_api_key:
+            for field, url in (
+                ("BIOMAPPER_BASE_URL", self.biomapper_base_url),
+                ("BIOMAPPER_DEV_BASE_URL", self.biomapper_dev_base_url),
+            ):
+                if url and url.lower().startswith("http://"):
+                    raise ValueError(
+                        f"{field} must use HTTPS when BIOMAPPER_API_KEY is set "
+                        "(refusing to send the API key over plaintext HTTP)."
+                    )
+        return self
 
 
 @lru_cache
@@ -103,7 +129,50 @@ def get_settings() -> Settings:
         langfuse_public_key=os.getenv("LANGFUSE_PUBLIC_KEY"),
         langfuse_secret_key=os.getenv("LANGFUSE_SECRET_KEY"),
         langfuse_base_url=os.getenv("LANGFUSE_BASE_URL", "https://us.cloud.langfuse.com"),
+        biomapper_api_key=os.getenv("BIOMAPPER_API_KEY"),
+        biomapper_base_url=os.getenv("BIOMAPPER_BASE_URL"),
+        biomapper_dev_base_url=os.getenv("BIOMAPPER_DEV_BASE_URL"),
         log_level=os.getenv("LOG_LEVEL", "INFO"),
         log_format=os.getenv("LOG_FORMAT", "text"),
         log_module_levels=module_levels,
     )
+
+
+_VALID_BIOMAPPER_ENVS = {"production", "dev"}
+
+
+def resolve_biomapper_base_url(env: str | None, settings: "Settings") -> str | None:
+    """Resolve the biomapper2 base URL for a requested environment (the prod/dev toggle).
+
+    Mirrors biomapper-ui's env routing. Returns the base URL, where None means "use the biomapper
+    client default" (the prod instance). ``env`` is the per-request toggle value (``"production"``
+    default, or ``"dev"``).
+
+    Raises ValueError on an unknown env name, or when ``dev`` is requested but
+    ``BIOMAPPER_DEV_BASE_URL`` is not configured — the caller maps this to a user-facing error.
+    """
+    name = (env or "production").strip().lower()
+    if name not in _VALID_BIOMAPPER_ENVS:
+        raise ValueError(f"Invalid biomapper env '{env}'. Valid values: production, dev")
+    if name == "dev":
+        if not settings.biomapper_dev_base_url:
+            raise ValueError("Dev biomapper API is not configured (BIOMAPPER_DEV_BASE_URL not set)")
+        return settings.biomapper_dev_base_url
+    return settings.biomapper_base_url  # None = client default (prod)
+
+
+def biomapper_misconfig_reason(enabled: bool, api_key: str | None) -> str | None:
+    """Return a CRITICAL-log reason if the Biomapper pre-resolver is misconfigured, else None.
+
+    The enable flag lives in pipeline_config (tuning) and the secret in Settings (deployment),
+    so this pure helper cross-checks both without coupling the two modules. Mirrors the Clerk
+    fail-closed guard: enabled-but-unconfigured surfaces loudly at startup instead of as a
+    BioMapperAuthError on every live request. Returns None (no-op) when the flag is off.
+    """
+    if enabled and not api_key:
+        return (
+            "biomapper.enabled=true but BIOMAPPER_API_KEY is unset. Every live Biomapper "
+            "resolution will raise BioMapperAuthError and fall back to Kestrel. "
+            "Set BIOMAPPER_API_KEY or disable the biomapper flag."
+        )
+    return None

--- a/backend/src/kestrel_backend/evals/biomapper_resolution/gold_set.json
+++ b/backend/src/kestrel_backend/evals/biomapper_resolution/gold_set.json
@@ -1,0 +1,13 @@
+{
+  "description": "Human gene/protein resolution gold set for the biomapper pre-resolver merge gate.",
+  "oracle_note": "expected_curie values are canonical HUMAN NCBIGene IDs from an external authority (NCBI Gene), NOT 'which ID has KG edges' — edge-presence and human-correctness are different properties.",
+  "entities": [
+    {"name": "TNFRSF1A", "entity_type_hint": "gene", "expected_curie": "NCBIGene:7132", "verified_live": true, "note": "originating frailty incident; was pig/rat ortholog NCBIGene:397020"},
+    {"name": "TNFRSF1B", "entity_type_hint": "gene", "expected_curie": "NCBIGene:7133", "verified_live": true},
+    {"name": "LDLR", "entity_type_hint": "gene", "expected_curie": "NCBIGene:3949", "verified_live": true, "note": "was ortholog NCBIGene:281276"},
+    {"name": "IL6", "entity_type_hint": "gene", "expected_curie": "NCBIGene:3569", "verified_live": false, "note": "held-out: not from the originating run (measures generalization)"},
+    {"name": "TNF", "entity_type_hint": "gene", "expected_curie": "NCBIGene:7124", "verified_live": false, "note": "held-out"},
+    {"name": "APOE", "entity_type_hint": "gene", "expected_curie": "NCBIGene:348", "verified_live": false, "note": "held-out"},
+    {"name": "GH1", "entity_type_hint": "gene", "expected_curie": "NCBIGene:2688", "verified_live": false, "known_residual": true, "note": "human node absent from Kestrel hybrid-search (recall gap) — expected to fall back to the ortholog; counts against the gate until Kestrel indexes it"}
+  ]
+}

--- a/backend/src/kestrel_backend/evals/biomapper_resolution/run_eval.py
+++ b/backend/src/kestrel_backend/evals/biomapper_resolution/run_eval.py
@@ -1,0 +1,154 @@
+"""False-cold-start gold-set eval for the biomapper pre-resolver (merge gate).
+
+Runs the **production** resolution path (``resolve_entity`` + ``reconcile_to_kestrel``) over a
+gold set of human genes and scores species/namespace correctness. Using the shipped path — not a
+separate batch surface — means the gate measures exactly what production does (no surface-parity gap).
+
+Per the expensive-run SOP, a timestamped artifact is **always written** (``--out`` is an override,
+never the only way to save), with pinned reproduce-inputs (biomapper version, base_url, gold-set
+SHA, timestamp). The API key is never written to the artifact.
+
+Run:  cd backend && uv run python -m kestrel_backend.evals.biomapper_resolution.run_eval --env dev
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+from datetime import datetime, timezone
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+
+from ...biomapper_client import resolve_entity
+from ...config import get_settings, resolve_biomapper_base_url
+from ...graph.nodes.entity_resolution import reconcile_to_kestrel
+
+_GOLD_PATH = Path(__file__).parent / "gold_set.json"
+_RUNS_DIR = Path(__file__).parent / "runs"
+
+# Below this biomapper hit-rate on a gene gold set, assume a throttled/degraded backend
+# (HTTP 200 + empty matches) rather than real no-matches — fail loud, don't record as passes.
+_DEGRADED_HIT_RATE = 0.3
+
+ResolveFn = Callable[..., Awaitable[dict | None]]
+ReconcileFn = Callable[..., Awaitable[tuple[str, str | None] | None]]
+
+
+def load_gold(path: Path = _GOLD_PATH) -> list[dict[str, Any]]:
+    return json.loads(path.read_text())["entities"]
+
+
+async def evaluate(
+    gold_entities: list[dict[str, Any]],
+    base_url: str | None,
+    resolve_fn: ResolveFn = resolve_entity,
+    reconcile_fn: ReconcileFn = reconcile_to_kestrel,
+) -> list[dict[str, Any]]:
+    """Run the production resolve+reconcile path over the gold set; return per-entity rows."""
+    rows: list[dict[str, Any]] = []
+    for ent in gold_entities:
+        name, hint, expected = ent["name"], ent["entity_type_hint"], ent["expected_curie"]
+        resolved: str | None = None
+        method = "unresolved"
+        r = await resolve_fn(name, hint, base_url=base_url)
+        if r:
+            rec = await reconcile_fn(r, hint)
+            if rec:
+                resolved, method = rec[0], "biomapper"
+        rows.append({
+            "name": name,
+            "entity_type_hint": hint,
+            "expected_curie": expected,
+            "resolved_curie": resolved,
+            "method": method,
+            "correct": resolved == expected,
+            "known_residual": ent.get("known_residual", False),
+        })
+    return rows
+
+
+def summarize(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    total = len(rows)
+    correct = sum(1 for r in rows if r["correct"])
+    resolved = sum(1 for r in rows if r["resolved_curie"] is not None)
+    # Wrong-species/namespace: a resolved CURIE that doesn't match the human oracle.
+    mismatched = sum(1 for r in rows if r["resolved_curie"] is not None and not r["correct"])
+    residual = sum(1 for r in rows if r["known_residual"])
+    hit_rate = (resolved / total) if total else 0.0
+    return {
+        "total": total,
+        "correct": correct,
+        "accuracy": round(correct / total, 4) if total else 0.0,
+        "biomapper_hits": resolved,
+        "biomapper_hit_rate": round(hit_rate, 4),
+        "mismatched": mismatched,
+        "known_residuals": residual,
+        # Accuracy excluding the documented Kestrel-recall residuals (e.g. GH1).
+        "accuracy_excl_residual": (
+            round(correct / (total - residual), 4) if (total - residual) else 0.0
+        ),
+        "degraded_backend_suspected": hit_rate < _DEGRADED_HIT_RATE,
+    }
+
+
+def _gold_sha(path: Path = _GOLD_PATH) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
+
+
+def build_artifact(rows: list[dict[str, Any]], base_url: str | None, env: str, ts: str) -> dict[str, Any]:
+    try:
+        bm_version = version("biomapper")
+    except PackageNotFoundError:
+        bm_version = "unknown"
+    return {
+        "eval": "biomapper_resolution_gold_set",
+        "timestamp": ts,
+        "reproduce_inputs": {  # pinned so the result is reproducible
+            "biomapper_version": bm_version,
+            "biomapper_env": env,
+            "biomapper_base_url": base_url,  # NOT the api key
+            "gold_set_sha": _gold_sha(),
+        },
+        "summary": summarize(rows),
+        "rows": rows,
+    }
+
+
+def default_artifact_path(ts: str) -> Path:
+    return _RUNS_DIR / f"biomapper_resolution_{ts}.json"
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description="Biomapper resolution gold-set eval (merge gate)")
+    parser.add_argument("--env", default="dev", choices=["production", "dev"],
+                        help="Which biomapper2 API to evaluate (default: dev — the HGNC fix)")
+    parser.add_argument("--gold", type=str, default=None, help="Path to gold_set.json")
+    parser.add_argument("--out", type=str, default=None,
+                        help="Override artifact path (an artifact is ALWAYS written either way)")
+    args = parser.parse_args()
+
+    settings = get_settings()
+    base_url = resolve_biomapper_base_url(args.env, settings)
+    gold = load_gold(Path(args.gold)) if args.gold else load_gold()
+
+    rows = await evaluate(gold, base_url)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    artifact = build_artifact(rows, base_url, args.env, ts)
+
+    # Persist by default (SOP); --out only overrides the path.
+    out_path = Path(args.out) if args.out else default_artifact_path(ts)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(artifact, indent=2, default=str))
+
+    s = artifact["summary"]
+    print(json.dumps(s, indent=2))
+    if s["degraded_backend_suspected"]:
+        print("WARNING: low hit-rate — biomapper backend may be throttled/degraded; do NOT trust this run.")
+    print(f"Artifact written to {out_path}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/src/kestrel_backend/graph/nodes/entity_resolution.py
+++ b/backend/src/kestrel_backend/graph/nodes/entity_resolution.py
@@ -27,6 +27,8 @@ import time
 from typing import Any
 
 from ...kestrel_client import call_kestrel_tool
+from ...biomapper_client import resolve_entity as biomapper_resolve, biolink_class_for
+from ...config import get_settings, resolve_biomapper_base_url
 from ..state import DiscoveryState, EntityResolution
 from ..sdk_utils import HAS_SDK, query_with_usage, ClaudeAgentOptions, chunk
 from ..pipeline_config import get_pipeline_config
@@ -315,6 +317,117 @@ def _extract_search_results(data: Any, search_text: str) -> list:
     return data or []
 
 
+# ============================ Biomapper pre-resolver helpers (Unit 3) ============================
+# HGNC is human-only by construction; an HGNC equivalent on a gene/protein KG node is the human
+# marker. biomapper2 now prefers the human candidate upstream (PR #69), so this gate is
+# defense-in-depth: it catches any residual wrong-species CURIE before it enters the pipeline.
+_HGNC_MARKER = "HGNC:"
+_HGNC_GATED_CLASSES = {"gene", "protein"}
+
+
+def _tier_to_confidence(tier: str | None) -> float:
+    """Map a Biomapper confidence tier to the EntityResolution 0–1 confidence (provenance-cosmetic)."""
+    return {"high": 0.95, "medium": 0.8}.get(tier or "", 0.7)
+
+
+def _parse_get_nodes(result: Any, curie: str) -> dict | None:
+    """Return the Kestrel node dict for `curie` from a get_nodes MCP envelope, or None.
+
+    Envelope (confirmed live 2026-06-16): present → ``{"<curie>": {node...}}`` (top-level key IS the
+    queried CURIE; value is the node **dict** — some tool versions wrap it as a single-element list,
+    so both are accepted); invalid prefix → ``{"error": true, ...}``; absent → empty value.
+    """
+    if not isinstance(result, dict) or result.get("isError"):
+        return None
+    content = result.get("content", [])
+    if not content:
+        return None
+    text = content[0].get("text", "") if isinstance(content[0], dict) else str(content[0])
+    try:
+        body = json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(body, dict) or body.get("error"):
+        return None
+    payload = body.get(curie)
+    if isinstance(payload, dict):
+        return payload
+    if isinstance(payload, list) and payload and isinstance(payload[0], dict):
+        return payload[0]
+    return None
+
+
+def _node_has_human_marker(node: dict) -> bool:
+    """True if the Kestrel node carries an HGNC equivalent id (human-only marker)."""
+    eq = node.get("equivalent_ids") or []
+    return any(str(x).upper().startswith(_HGNC_MARKER) for x in eq)
+
+
+def _node_category(node: dict) -> str | None:
+    """The node's Kestrel-native category (so the biomapper path emits Kestrel spellings)."""
+    cats = node.get("categories")
+    if isinstance(cats, list) and cats:
+        return cats[0]
+    return node.get("category")
+
+
+def _biomapper_candidate_curies(biomapper_result: dict, hint: str | None) -> list[str]:
+    """Ordered CURIE candidates: primary_curie first, then xrefs by per-class namespace_preference.
+
+    ``xrefs`` is ``dict[prefix -> list[local_id]]`` (verified live: ``{"NCBIGene": ["7132"], ...}``),
+    so a candidate CURIE is built as ``f"{prefix}:{local_id}"``.
+    """
+    prefs = get_pipeline_config().entity_resolution.biomapper.namespace_preference.get(
+        (hint or "").lower(), []
+    )
+    xrefs: dict[str, list] = biomapper_result.get("xrefs") or {}
+    ordered: list[str] = []
+    seen: set[str] = set()
+
+    def _add(curie: str | None) -> None:
+        canon = _canonical_curie(curie)
+        if curie and canon and canon not in seen:
+            seen.add(canon)
+            ordered.append(curie)
+
+    _add(biomapper_result.get("curie"))
+    # xrefs in configured preference order, then any remaining namespaces (lowest priority).
+    pref_upper = [p.upper() for p in prefs]
+    for ns in sorted(xrefs, key=lambda n: pref_upper.index(n.upper()) if n.upper() in pref_upper else 999):
+        for local in (xrefs[ns] if isinstance(xrefs[ns], list) else [xrefs[ns]]):
+            local_s = str(local)
+            _add(local_s if ":" in local_s else f"{ns}:{local_s}")
+    return ordered
+
+
+async def reconcile_to_kestrel(
+    biomapper_result: dict, hint: str | None
+) -> tuple[str, str | None] | None:
+    """Confirm a Biomapper result against the Kestrel KG; return (confirmed_curie, kestrel_category).
+
+    Walks the candidate CURIEs (primary first, then namespace-preferred xrefs), accepting the first
+    that ``get_nodes`` confirms. For gene/protein, the confirmed node must carry the HGNC human
+    marker (defense-in-depth) or the candidate is skipped. Returns the node's canonical id +
+    Kestrel-native category, or None if nothing confirms (caller falls back to Kestrel tiers).
+    """
+    gated = (hint or "").lower() in _HGNC_GATED_CLASSES
+    for candidate in _biomapper_candidate_curies(biomapper_result, hint):
+        try:
+            result = await call_kestrel_tool("get_nodes", {"curies": candidate})
+        except Exception as e:  # noqa: BLE001 — transport failure for this candidate; try next
+            logger.debug("Biomapper reconcile: get_nodes('%s') failed: %s", candidate, e)
+            continue
+        node = _parse_get_nodes(result, candidate)
+        if node is None:
+            continue
+        if gated and not _node_has_human_marker(node):
+            # Confirmed in Kestrel but no HGNC marker → non-human ortholog; reject (defense-in-depth).
+            logger.info("FALLBACK_EVENT node=entity_resolution reason=biomapper_non_human curie=%s", candidate)
+            continue
+        return node.get("id") or candidate, _node_category(node)
+    return None
+
+
 async def prefetch_resolution_candidates(entity: str, limit: int = 10) -> list[dict]:
     """Tier-2 prefetch (#61): issue multiple HTTP variant searches and dedup into a
     candidate set. Replaces the broken MCP variant-search loop.
@@ -484,20 +597,96 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
     all_results: list[EntityResolution | None] = [None] * len(entities)
     errors: list[str] = []
 
-    # ========== TIER 1: API Resolution ==========
+    # ========== BIOMAPPER PRE-RESOLVER (flag-gated; Unit 4) ==========
+    # Read the flag fresh (not the import-time _config) so get_pipeline_config.cache_clear() in
+    # tests takes effect. Flag-off → this whole block is skipped and behavior is byte-identical.
+    biomapper_cfg = get_pipeline_config().entity_resolution.biomapper
+    entity_type_hints: dict[str, str] = state.get("entity_type_hints", {})
+    biomapper_confirmed: set[int] = set()
+    biomapper_resolved = 0
+    if biomapper_cfg.enabled:
+        # Resolve the prod/dev biomapper2 endpoint from the per-run toggle (state["biomapper_env"]).
+        # An invalid/unconfigured env → log and skip biomapper this run (safe fall back to Kestrel),
+        # rather than failing the whole discovery run.
+        try:
+            biomapper_base_url = resolve_biomapper_base_url(state.get("biomapper_env"), get_settings())
+            env_ok = True
+        except ValueError as e:
+            logger.warning("Biomapper env toggle error (%s); skipping biomapper, using Kestrel", e)
+            biomapper_base_url = None
+            env_ok = False
+        # Only attempt entities whose intake hint maps to a Biolink class (else fall back to Kestrel).
+        targets = [
+            (i, e) for i, e in enumerate(entities)
+            if env_ok and biolink_class_for(entity_type_hints.get(e)) is not None
+        ]
+        if targets:
+            sem = asyncio.Semaphore(max(1, biomapper_cfg.http_concurrency))
+            node_timeout = biomapper_cfg.node_timeout_seconds
+
+            async def _biomapper_one(idx: int, name: str) -> tuple[int, EntityResolution | None]:
+                hint = entity_type_hints.get(name)
+                async with sem:
+                    # BioMapperAuthError intentionally propagates out of run() (fail loud, R6).
+                    try:
+                        r = await asyncio.wait_for(
+                            biomapper_resolve(name, hint, base_url=biomapper_base_url),
+                            timeout=node_timeout,
+                        )
+                    except asyncio.TimeoutError:
+                        logger.info(
+                            "FALLBACK_EVENT node=entity_resolution reason=biomapper_timeout entity=%s",
+                            name,
+                        )
+                        return idx, None
+                if r is None:
+                    logger.info(
+                        "FALLBACK_EVENT node=entity_resolution reason=biomapper_miss entity=%s", name
+                    )
+                    return idx, None
+                reconciled = await reconcile_to_kestrel(r, hint)
+                if reconciled is None:
+                    logger.info(
+                        "FALLBACK_EVENT node=entity_resolution reason=biomapper_unconfirmed entity=%s",
+                        name,
+                    )
+                    return idx, None
+                curie, category = reconciled
+                return idx, EntityResolution(
+                    raw_name=name,
+                    curie=curie,
+                    resolved_name=r.get("resolved_name") or name,
+                    category=category,
+                    confidence=_tier_to_confidence(r.get("tier")),
+                    method="biomapper",
+                )
+
+            prepass = await asyncio.gather(*[_biomapper_one(i, e) for (i, e) in targets])
+            for idx, res in prepass:
+                if res is not None:
+                    all_results[idx] = res
+                    biomapper_confirmed.add(idx)
+                    biomapper_resolved += 1
+            logger.info(
+                "Biomapper pre-resolver confirmed %d/%d hinted entities",
+                biomapper_resolved, len(targets),
+            )
+
+    # ========== TIER 1: API Resolution (skips Biomapper-confirmed indices) ==========
     tier1_start = time.time()
-    logger.info("Tier 1 (API): Attempting direct resolution for %d entities", len(entities))
+    tier1_targets = [(i, e) for i, e in enumerate(entities) if i not in biomapper_confirmed]
+    logger.info("Tier 1 (API): Attempting direct resolution for %d entities", len(tier1_targets))
 
     # Run all API calls in parallel (they're fast and independent)
     tier1_results = await asyncio.gather(
-        *[resolve_via_api(e) for e in entities],
+        *[resolve_via_api(e) for (_i, e) in tier1_targets],
         return_exceptions=True,
     )
 
     tier1_resolved = 0
     tier1_failed_indices = []
 
-    for i, (entity, result) in enumerate(zip(entities, tier1_results)):
+    for (i, entity), result in zip(tier1_targets, tier1_results):
         if isinstance(result, Exception):
             logger.debug("Tier 1 '%s': Exception - %s", entity, str(result))
             tier1_failed_indices.append(i)

--- a/backend/src/kestrel_backend/graph/nodes/entity_resolution.py
+++ b/backend/src/kestrel_backend/graph/nodes/entity_resolution.py
@@ -861,9 +861,10 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
     duration = time.time() - start
     rate = 100 * len(resolved) / len(final_results) if final_results else 0
 
-    # Count by tier
+    # Count by tier. Subtract biomapper (pre-pass) too, else the tier2 count is inflated by the
+    # pre-resolver's hits once the flag is on.
     alias_resolved = sum(1 for r in final_results if r.method and r.method.startswith("alias:"))
-    llm_resolved = len(resolved) - tier1_resolved - alias_resolved
+    llm_resolved = len(resolved) - tier1_resolved - alias_resolved - biomapper_resolved
 
     if failed:
         failed_names = [r.raw_name for r in failed[:5]]
@@ -873,8 +874,9 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
         )
 
     logger.info(
-        "Completed entity_resolution in %.1fs — resolved=%d (tier1=%d, alias=%d, tier2=%d), failed=%d (%.0f%%)",
-        duration, len(resolved), tier1_resolved, alias_resolved, llm_resolved, len(failed), rate
+        "Completed entity_resolution in %.1fs — resolved=%d (tier1=%d, biomapper=%d, alias=%d, tier2=%d), failed=%d (%.0f%%)",
+        duration, len(resolved), tier1_resolved, biomapper_resolved, alias_resolved, llm_resolved,
+        len(failed), rate
     )
 
     result = {

--- a/backend/src/kestrel_backend/graph/pipeline_config.py
+++ b/backend/src/kestrel_backend/graph/pipeline_config.py
@@ -80,6 +80,57 @@ class PathwayEnrichmentConfig(BaseModel):
     )
 
 
+class BiomapperConfig(BaseModel):
+    """Configuration for the Biomapper pre-resolver in entity_resolution.
+
+    Default-off feature flag plus the namespace/species policy knobs the pre-resolver
+    needs. Secrets (BIOMAPPER_API_KEY / BIOMAPPER_BASE_URL) live in config.Settings, not
+    here — this model is never sourced from environment variables. See
+    docs/plans/2026-06-11-001-feat-biomapper-entity-resolution-plan.md (Unit 1).
+    """
+
+    enabled: bool = Field(
+        default=False,
+        description="Default-off flag: when True, entity_resolution resolves each hinted "
+        "entity via Biomapper first (namespace/species-correct CURIE), confirms it in Kestrel, "
+        "and falls back to the Kestrel Tier 1/1.5/2 path on any miss. Flag-off behavior is "
+        "byte-identical to today. Mirrors the multi_hop_enabled / subgraph_enabled demo-slice "
+        "flags; a follow-up PR flips it after the gold-set eval confirms improvement.",
+    )
+    namespace_preference: dict[str, list[str]] = Field(
+        default_factory=lambda: {
+            "gene": ["HGNC", "NCBIGene", "UniProtKB"],
+            "protein": ["HGNC", "NCBIGene", "UniProtKB"],
+            "metabolite": ["CHEBI", "HMDB", "RM", "LM"],
+        },
+        description="Per-class ordered namespace preference for reconciling a Biomapper CURIE "
+        "against the Kestrel KG (R5: explicit config, not implicit ranking). Genes/proteins "
+        "anchor on HGNC (human-only by construction; Kestrel normalizes HGNC/UniProt/NCBIGene to "
+        "the same human node and keys edges on NCBIGene — verified 2026-06-15). Metabolite order "
+        "(CHEBI-first) is the starting hypothesis; confirm which namespace Kestrel keys metabolite "
+        "edges on at impl.",
+    )
+    species_default: str = Field(
+        default="human",
+        description="Default species for resolution (R5: explicit). For genes/proteins, "
+        "humanness is enforced at confirmation time by the HGNC-marker gate in Unit 3 (an HGNC "
+        "equivalent id is required), not by an implicit Biomapper default — so this field is "
+        "documentation/metabolite-relevant.",
+    )
+    http_concurrency: int = Field(
+        default=8,
+        description="Max concurrent Biomapper HTTP calls (its own semaphore, independent of the "
+        "entity_resolution SDK semaphore=1) — bounds fan-out without serializing, avoiding the "
+        "throttling-as-no-match gotcha.",
+    )
+    node_timeout_seconds: float = Field(
+        default=30.0,
+        description="Per-entity asyncio.wait_for timeout around each Biomapper map_entity call. "
+        "A stalled call falls back to Kestrel for that entity only; already-resolved entities are "
+        "retained (caps added latency at ~http_concurrency × this).",
+    )
+
+
 class EntityResolutionConfig(BaseModel):
     """Configuration for the entity_resolution node."""
 
@@ -95,6 +146,10 @@ class EntityResolutionConfig(BaseModel):
     tier1_min_score: float = Field(
         default=0.6,
         description="Minimum API resolution score to accept a tier-1 match.",
+    )
+    biomapper: BiomapperConfig = Field(
+        default_factory=BiomapperConfig,
+        description="Biomapper pre-resolver config (default-off flag + namespace/species policy).",
     )
 
 

--- a/backend/src/kestrel_backend/graph/runner.py
+++ b/backend/src/kestrel_backend/graph/runner.py
@@ -47,6 +47,7 @@ async def stream_discovery(
     query: str,
     conversation_history: list[tuple[str, str]] | None = None,
     config: dict[str, Any] | None = None,
+    biomapper_env: str | None = None,
 ) -> AsyncIterator[dict[str, Any]]:
     """
     Stream discovery workflow events for real-time updates.
@@ -72,6 +73,7 @@ async def stream_discovery(
     initial_state: DiscoveryState = {
         "raw_query": query,
         "conversation_history": conversation_history or [],
+        "biomapper_env": biomapper_env,
     }
 
     async for event in graph.astream(initial_state, stream_mode="updates", config=config):

--- a/backend/src/kestrel_backend/graph/runner.py
+++ b/backend/src/kestrel_backend/graph/runner.py
@@ -19,6 +19,7 @@ async def run_discovery(
     query: str,
     conversation_history: list[tuple[str, str]] | None = None,
     config: dict[str, Any] | None = None,
+    biomapper_env: str | None = None,
 ) -> DiscoveryState:
     """
     Run the discovery workflow and return final state.
@@ -28,6 +29,8 @@ async def run_discovery(
         conversation_history: Optional list of (role, content) tuples
         config: Optional LangGraph RunnableConfig (e.g. {"callbacks": [handler]}) passed
             through to the graph. The caller owns it; this module stays observability-agnostic.
+        biomapper_env: Optional prod/dev biomapper2 API toggle ("production"|"dev"); threaded into
+            initial state so this non-streaming path matches stream_discovery.
 
     Returns:
         Final DiscoveryState with synthesis_report populated
@@ -37,6 +40,7 @@ async def run_discovery(
     initial_state: DiscoveryState = {
         "raw_query": query,
         "conversation_history": conversation_history or [],
+        "biomapper_env": biomapper_env,
     }
 
     result = await graph.ainvoke(initial_state, config=config)
@@ -92,10 +96,11 @@ async def stream_discovery(
 def run_discovery_sync(
     query: str,
     conversation_history: list[tuple[str, str]] | None = None,
+    biomapper_env: str | None = None,
 ) -> DiscoveryState:
     """
     Synchronous wrapper for run_discovery.
 
     Useful for testing or non-async contexts.
     """
-    return asyncio.run(run_discovery(query, conversation_history))
+    return asyncio.run(run_discovery(query, conversation_history, biomapper_env=biomapper_env))

--- a/backend/src/kestrel_backend/graph/state.py
+++ b/backend/src/kestrel_backend/graph/state.py
@@ -30,8 +30,13 @@ class EntityResolution(BaseModel):
     resolved_name: str | None = Field(None, description="Canonical name from KG")
     category: str | None = Field(None, description="Biolink category (e.g., biolink:ChemicalEntity)")
     confidence: float = Field(0.0, ge=0.0, le=1.0, description="Resolution confidence score")
-    method: Literal["exact", "fuzzy", "semantic", "failed"] = Field(
-        "failed", description="Resolution method used"
+    # Free string, not a Literal: admits "biomapper" (pre-resolver) and the pre-existing
+    # f"alias:{alias}" value the Tier-1.5 path constructs (which raised ValidationError against
+    # the old Literal — a live crash on its success branch). "failed" remains the sentinel triage
+    # routes to cold_start; readers use == "failed" / startswith("alias:"), both still valid.
+    method: str = Field(
+        "failed",
+        description='Resolution method: "exact"|"fuzzy"|"semantic"|"failed"|"biomapper"|"alias:<name>"',
     )
 
 
@@ -326,6 +331,7 @@ class DiscoveryState(TypedDict, total=False):
     query_type: Literal["retrieval", "discovery", "hybrid"]
     raw_entities: list[str]  # Extracted entity names before resolution
     conversation_history: list[tuple[str, str]]  # (role, content) pairs
+    biomapper_env: str | None  # prod/dev biomapper2 API toggle ("production"|"dev"); None = default
 
     # === Study Context (for longitudinal analysis) ===
     is_longitudinal: bool

--- a/backend/src/kestrel_backend/main.py
+++ b/backend/src/kestrel_backend/main.py
@@ -14,7 +14,7 @@ from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException, Requ
 from fastapi.middleware.cors import CORSMiddleware
 from langfuse import get_client
 
-from .config import get_settings
+from .config import biomapper_misconfig_reason, get_settings
 from .agent import run_agent_turn
 from .logging_config import configure_logging, generate_correlation_id, correlation_id
 from .clerk_auth import get_current_user, validate_ws_clerk_token
@@ -229,6 +229,19 @@ if settings.clerk_auth_enabled:
             "Set these env vars or set CLERK_AUTH_ENABLED=false.",
             ", ".join(_missing),
         )
+
+# Fail-closed: warn if the Biomapper pre-resolver flag is on but its API key is unset.
+# The flag lives in pipeline_config (tuning), the secret in Settings (deployment); cross-check
+# both at startup so a flag-flip surfaces a misconfig immediately, not per-request. Lazy import
+# keeps pipeline_config off the module-import critical path and avoids any import cycle.
+from .graph.pipeline_config import get_pipeline_config  # noqa: E402
+
+_biomapper_reason = biomapper_misconfig_reason(
+    get_pipeline_config().entity_resolution.biomapper.enabled,
+    settings.biomapper_api_key,
+)
+if _biomapper_reason:
+    logging.getLogger(__name__).critical(_biomapper_reason)
 
 
 def check_langfuse_health() -> tuple[bool, str | None]:
@@ -490,6 +503,7 @@ async def handle_pipeline_mode(
     websocket: WebSocket,
     content: str,
     connection_id: str,
+    biomapper_env: str | None = None,
 ) -> None:
     """
     Handle discovery pipeline mode - LangGraph multi-node workflow.
@@ -567,6 +581,7 @@ async def handle_pipeline_mode(
             query=content,
             conversation_history=list(history),
             config=pipeline_config,
+            biomapper_env=biomapper_env,
         ):
             if event["type"] != "node_update":
                 continue
@@ -836,10 +851,12 @@ async def websocket_chat(websocket: WebSocket):
 
             # Route based on agent_mode
             agent_mode = data.get("agent_mode", "classic")
+            # Optional prod/dev biomapper2 API toggle (mirrors biomapper-ui env routing).
+            biomapper_env = data.get("biomapper_env")
 
             try:
                 if agent_mode == "pipeline":
-                    await handle_pipeline_mode(websocket, content, connection_id)
+                    await handle_pipeline_mode(websocket, content, connection_id, biomapper_env)
                 else:
                     await handle_classic_mode(websocket, content, connection_id)
             except Exception as e:

--- a/backend/tests/test_biomapper_client.py
+++ b/backend/tests/test_biomapper_client.py
@@ -1,0 +1,160 @@
+"""Tests for the Biomapper pre-resolver wrapper (Unit 2).
+
+The wrapper lazy-imports ``biomapper`` inside ``resolve_entity``; we patch
+``biomapper.BioMapperClient`` with a fake async context manager and use REAL
+``MappingResult`` objects so the ``confidence_tier`` @property (dropped by ``model_dump()``)
+is exercised exactly as in production.
+"""
+
+import logging
+
+import pytest
+from biomapper import (
+    BioMapperAuthError,
+    BioMapperError,
+    BioMapperRateLimitError,
+    MappingResult,
+)
+
+from kestrel_backend import biomapper_client
+from kestrel_backend.biomapper_client import biolink_class_for, resolve_entity
+
+
+class _FakeClient:
+    """Async-context-manager stand-in for BioMapperClient; records the last map_entity call."""
+
+    last_call: dict = {}
+
+    def __init__(self, result=None, exc=None):
+        self._result = result
+        self._exc = exc
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def map_entity(self, name, entity_type, **kwargs):
+        _FakeClient.last_call = {"name": name, "entity_type": entity_type}
+        if self._exc is not None:
+            raise self._exc
+        return self._result
+
+
+def _install(monkeypatch, *, result=None, exc=None):
+    """Patch biomapper.BioMapperClient to yield a fake returning `result` or raising `exc`."""
+    _FakeClient.last_call = {}
+    monkeypatch.setattr(
+        "biomapper.BioMapperClient",
+        lambda **kwargs: _FakeClient(result=result, exc=exc),
+    )
+
+
+def _result(curie="NCBIGene:7132", score=2.5, resolved=True, xrefs=None):
+    return MappingResult(
+        query_name="TNFRSF1A",
+        resolved=resolved,
+        primary_curie=curie,
+        confidence_score=score,
+        identifiers={},
+        kg_equivalent_ids=xrefs or {"HGNC": ["HGNC:11916"], "NCBIGene": ["NCBIGene:7132"]},
+    )
+
+
+class TestBiolinkMapping:
+    def test_known_hints(self):
+        assert biolink_class_for("gene") == "biolink:Gene"
+        assert biolink_class_for("protein") == "biolink:Protein"
+        assert biolink_class_for("metabolite") == "biolink:SmallMolecule"
+        assert biolink_class_for("GENE") == "biolink:Gene"  # case-insensitive
+
+    def test_unknown_or_missing_hint(self):
+        assert biolink_class_for(None) is None
+        assert biolink_class_for("") is None
+        assert biolink_class_for("disease") is None
+
+
+class TestResolveHappyPath:
+    async def test_high_tier_returns_dict(self, monkeypatch):
+        _install(monkeypatch, result=_result(score=2.5))
+        out = await resolve_entity("TNFRSF1A", "gene")
+        assert out is not None
+        assert out["curie"] == "NCBIGene:7132"
+        assert out["tier"] == "high"
+        assert out["xrefs"]["HGNC"] == ["HGNC:11916"]
+        # The correct Biolink class was passed to Biomapper.
+        assert _FakeClient.last_call["entity_type"] == "biolink:Gene"
+
+    async def test_medium_tier_accepted(self, monkeypatch):
+        _install(monkeypatch, result=_result(score=1.5))  # >=1.0 -> medium
+        out = await resolve_entity("TNFRSF1A", "gene")
+        assert out is not None and out["tier"] == "medium"
+
+    async def test_confidence_tier_read_via_attribute_not_model_dump(self, monkeypatch):
+        # Guards the load-bearing gotcha: model_dump() drops the computed tier.
+        res = _result(score=2.5)
+        assert "confidence_tier" not in res.model_dump()
+        assert res.confidence_tier == "high"
+        _install(monkeypatch, result=res)
+        out = await resolve_entity("TNFRSF1A", "gene")
+        assert out is not None and out["tier"] == "high"
+
+
+class TestResolveGateAndSkips:
+    async def test_low_tier_returns_none(self, monkeypatch):
+        _install(monkeypatch, result=_result(score=0.5))  # <1.0 -> low, below medium gate
+        assert await resolve_entity("TNFRSF1A", "gene") is None
+
+    async def test_unknown_tier_none_score_returns_none(self, monkeypatch):
+        _install(monkeypatch, result=_result(score=None))
+        assert await resolve_entity("TNFRSF1A", "gene") is None
+
+    async def test_unknown_hint_skips_biomapper(self, monkeypatch):
+        _install(monkeypatch, result=_result())
+        assert await resolve_entity("whatever", None) is None
+        # Biomapper must not have been called at all.
+        assert _FakeClient.last_call == {}
+
+    async def test_not_resolved_returns_none(self, monkeypatch):
+        _install(monkeypatch, result=_result(resolved=False))
+        assert await resolve_entity("TNFRSF1A", "gene") is None
+
+    async def test_malformed_curie_returns_none(self, monkeypatch):
+        _install(monkeypatch, result=_result(curie="not a curie!!", score=2.5))
+        assert await resolve_entity("TNFRSF1A", "gene") is None
+
+
+class TestErrorTaxonomy:
+    async def test_rate_limit_returns_none(self, monkeypatch):
+        _install(monkeypatch, exc=BioMapperRateLimitError("slow down"))
+        assert await resolve_entity("TNFRSF1A", "gene") is None
+
+    async def test_base_error_returns_none(self, monkeypatch):
+        _install(monkeypatch, exc=BioMapperError("boom"))
+        assert await resolve_entity("TNFRSF1A", "gene") is None
+
+    async def test_transport_error_returns_none(self, monkeypatch):
+        _install(monkeypatch, exc=RuntimeError("connection reset"))
+        assert await resolve_entity("TNFRSF1A", "gene") is None
+
+    async def test_auth_error_propagates(self, monkeypatch):
+        _install(monkeypatch, exc=BioMapperAuthError("bad key"))
+        with pytest.raises(BioMapperAuthError):
+            await resolve_entity("TNFRSF1A", "gene")
+
+
+class TestSecretHygiene:
+    async def test_api_key_never_logged(self, monkeypatch, caplog):
+        sentinel = "SENTINEL_BIOMAPPER_KEY_should_never_appear"
+        monkeypatch.setenv("BIOMAPPER_API_KEY", sentinel)
+        from kestrel_backend.config import get_settings
+
+        get_settings.cache_clear()
+        try:
+            _install(monkeypatch, exc=BioMapperError("boom"))  # forces a fallback log line
+            with caplog.at_level(logging.DEBUG, logger=biomapper_client.logger.name):
+                await resolve_entity("TNFRSF1A", "gene")
+            assert sentinel not in caplog.text
+        finally:
+            get_settings.cache_clear()

--- a/backend/tests/test_biomapper_eval.py
+++ b/backend/tests/test_biomapper_eval.py
@@ -1,0 +1,94 @@
+"""Tests for the biomapper resolution gold-set eval (Unit 5)."""
+
+import json
+
+from kestrel_backend.evals.biomapper_resolution import run_eval
+
+_GOLD = [
+    {"name": "TNFRSF1A", "entity_type_hint": "gene", "expected_curie": "NCBIGene:7132"},
+    {"name": "LDLR", "entity_type_hint": "gene", "expected_curie": "NCBIGene:3949"},
+    {"name": "GH1", "entity_type_hint": "gene", "expected_curie": "NCBIGene:2688", "known_residual": True},
+]
+_EXPECT = {e["name"]: e["expected_curie"] for e in _GOLD}
+
+
+def _resolve_correct():
+    async def fn(name, hint, base_url=None):
+        return {"curie": _EXPECT[name], "tier": "high"}
+    return fn
+
+
+async def _reconcile_echo(r, hint):
+    return (r["curie"], "biolink:Gene")
+
+
+class TestEvaluate:
+    async def test_all_correct(self):
+        rows = await run_eval.evaluate(_GOLD, base_url=None,
+                                       resolve_fn=_resolve_correct(), reconcile_fn=_reconcile_echo)
+        s = run_eval.summarize(rows)
+        assert s["accuracy"] == 1.0
+        assert s["biomapper_hit_rate"] == 1.0
+        assert s["mismatched"] == 0
+        assert all(r["method"] == "biomapper" for r in rows)
+
+    async def test_residual_excluded_from_adjusted_accuracy(self):
+        # GH1 falls back (unresolved); accuracy drops but accuracy_excl_residual stays 1.0.
+        async def resolve_miss_gh1(name, hint, base_url=None):
+            if name == "GH1":
+                return None
+            return {"curie": _EXPECT[name], "tier": "high"}
+        rows = await run_eval.evaluate(_GOLD, base_url=None,
+                                       resolve_fn=resolve_miss_gh1, reconcile_fn=_reconcile_echo)
+        s = run_eval.summarize(rows)
+        assert s["correct"] == 2 and s["total"] == 3
+        assert s["accuracy_excl_residual"] == 1.0  # 2/2 non-residual correct
+        assert s["known_residuals"] == 1
+
+    async def test_wrong_species_counts_as_mismatch(self):
+        async def resolve_ortholog(name, hint, base_url=None):
+            return {"curie": "NCBIGene:397020", "tier": "high"}  # ortholog for everything
+        rows = await run_eval.evaluate(_GOLD, base_url=None,
+                                       resolve_fn=resolve_ortholog, reconcile_fn=_reconcile_echo)
+        s = run_eval.summarize(rows)
+        assert s["accuracy"] == 0.0
+        assert s["mismatched"] == 3  # resolved but != expected human CURIE
+
+    async def test_degraded_backend_detected(self):
+        async def resolve_none(name, hint, base_url=None):
+            return None  # throttle signature: nothing resolves
+        rows = await run_eval.evaluate(_GOLD, base_url=None,
+                                       resolve_fn=resolve_none, reconcile_fn=_reconcile_echo)
+        s = run_eval.summarize(rows)
+        assert s["degraded_backend_suspected"] is True
+        assert s["biomapper_hit_rate"] == 0.0
+
+
+class TestArtifact:
+    def test_artifact_has_pinned_inputs_and_no_key(self):
+        rows = [{"name": "X", "entity_type_hint": "gene", "expected_curie": "NCBIGene:1",
+                 "resolved_curie": "NCBIGene:1", "method": "biomapper", "correct": True,
+                 "known_residual": False}]
+        art = run_eval.build_artifact(rows, base_url="https://dev.example/api/v1", env="dev",
+                                      ts="20260616T000000Z")
+        repro = art["reproduce_inputs"]
+        assert repro["biomapper_env"] == "dev"
+        assert repro["biomapper_base_url"] == "https://dev.example/api/v1"
+        assert "gold_set_sha" in repro and "biomapper_version" in repro
+        # The API key must never appear anywhere in the artifact.
+        blob = json.dumps(art)
+        assert "api_key" not in blob.lower()
+        assert "BIOMAPPER_API_KEY" not in blob
+
+    def test_default_artifact_path_is_timestamped(self):
+        p = run_eval.default_artifact_path("20260616T010203Z")
+        assert p.name == "biomapper_resolution_20260616T010203Z.json"
+        assert p.parent.name == "runs"
+
+    def test_gold_set_loads_with_expected_curies(self):
+        gold = run_eval.load_gold()
+        names = {e["name"] for e in gold}
+        assert {"TNFRSF1A", "LDLR", "GH1"} <= names
+        for e in gold:
+            assert e["expected_curie"].startswith("NCBIGene:")
+            assert e["entity_type_hint"] in {"gene", "protein", "metabolite"}

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,124 @@
+"""Tests for Settings env wiring and the Biomapper config guards (Unit 1)."""
+
+import pytest
+
+from kestrel_backend.config import (
+    Settings,
+    biomapper_misconfig_reason,
+    get_settings,
+    resolve_biomapper_base_url,
+)
+
+
+class TestBiomapperSettingsEnv:
+    """get_settings() reads the Biomapper secrets from the environment."""
+
+    def test_reads_biomapper_env(self, monkeypatch):
+        monkeypatch.setenv("BIOMAPPER_API_KEY", "test-key-123")
+        monkeypatch.setenv("BIOMAPPER_BASE_URL", "https://biomapper.example.org")
+        get_settings.cache_clear()
+        try:
+            settings = get_settings()
+            assert settings.biomapper_api_key == "test-key-123"
+            assert settings.biomapper_base_url == "https://biomapper.example.org"
+        finally:
+            get_settings.cache_clear()
+
+    def test_unset_biomapper_env_is_none(self, monkeypatch):
+        # get_settings() calls load_dotenv(), which would re-populate these from a real
+        # backend/.env on disk. Neutralize it so this asserts true "unset" behavior.
+        monkeypatch.setattr("kestrel_backend.config.load_dotenv", lambda *a, **k: False)
+        monkeypatch.delenv("BIOMAPPER_API_KEY", raising=False)
+        monkeypatch.delenv("BIOMAPPER_BASE_URL", raising=False)
+        get_settings.cache_clear()
+        try:
+            settings = get_settings()
+            assert settings.biomapper_api_key is None
+            assert settings.biomapper_base_url is None
+        finally:
+            get_settings.cache_clear()
+
+
+class TestBiomapperHttpsValidator:
+    """The API key must never be sent over plaintext HTTP."""
+
+    def test_http_base_url_with_key_rejected(self):
+        with pytest.raises(ValueError, match="HTTPS"):
+            Settings(
+                biomapper_api_key="secret",
+                biomapper_base_url="http://biomapper.example.org",
+            )
+
+    def test_https_base_url_with_key_ok(self):
+        s = Settings(
+            biomapper_api_key="secret",
+            biomapper_base_url="https://biomapper.example.org",
+        )
+        assert s.biomapper_base_url == "https://biomapper.example.org"
+
+    def test_http_base_url_without_key_allowed(self):
+        # No key set → nothing to leak; allowed (e.g. unused config).
+        s = Settings(biomapper_base_url="http://localhost:8001")
+        assert s.biomapper_base_url == "http://localhost:8001"
+
+    def test_none_base_url_with_key_ok(self):
+        # None base URL = client default (prod HTTPS); fine to have a key.
+        s = Settings(biomapper_api_key="secret", biomapper_base_url=None)
+        assert s.biomapper_api_key == "secret"
+
+
+class TestResolveBiomapperBaseUrl:
+    """The prod/dev API toggle resolves to the right base URL or raises a clear error."""
+
+    def _settings(self, **kw):
+        return Settings(**kw)
+
+    def test_default_none_env_is_production(self):
+        s = self._settings(biomapper_base_url="https://prod.example/api/v1")
+        assert resolve_biomapper_base_url(None, s) == "https://prod.example/api/v1"
+
+    def test_explicit_production(self):
+        s = self._settings(biomapper_base_url="https://prod.example/api/v1")
+        assert resolve_biomapper_base_url("production", s) == "https://prod.example/api/v1"
+
+    def test_dev_returns_dev_url(self):
+        s = self._settings(
+            biomapper_base_url="https://prod.example/api/v1",
+            biomapper_dev_base_url="https://dev.example/api/v1",
+        )
+        assert resolve_biomapper_base_url("dev", s) == "https://dev.example/api/v1"
+
+    def test_dev_unconfigured_raises(self):
+        s = self._settings(biomapper_base_url="https://prod.example/api/v1")
+        with pytest.raises(ValueError, match="not configured"):
+            resolve_biomapper_base_url("dev", s)
+
+    def test_invalid_env_raises(self):
+        with pytest.raises(ValueError, match="Invalid biomapper env"):
+            resolve_biomapper_base_url("staging", self._settings())
+
+    def test_production_with_no_url_is_none(self):
+        # None = biomapper client default (prod); valid.
+        assert resolve_biomapper_base_url("production", self._settings()) is None
+
+
+class TestBiomapperMisconfigReason:
+    """Fail-closed startup guard: enabled-but-no-key surfaces a CRITICAL reason."""
+
+    def test_enabled_without_key_returns_reason(self):
+        reason = biomapper_misconfig_reason(enabled=True, api_key=None)
+        assert reason is not None
+        assert "BIOMAPPER_API_KEY" in reason
+
+    def test_enabled_with_key_is_ok(self):
+        assert biomapper_misconfig_reason(enabled=True, api_key="k") is None
+
+    def test_disabled_is_always_ok(self):
+        assert biomapper_misconfig_reason(enabled=False, api_key=None) is None
+        assert biomapper_misconfig_reason(enabled=False, api_key="k") is None
+
+    def test_reason_does_not_leak_key(self):
+        # The reason is logged; it must never echo the secret value.
+        reason = biomapper_misconfig_reason(enabled=True, api_key=None)
+        assert reason is not None
+        assert "supersecretvalue" not in reason

--- a/backend/tests/test_entity_resolution_biomapper.py
+++ b/backend/tests/test_entity_resolution_biomapper.py
@@ -1,0 +1,179 @@
+"""Tests for the Biomapper pre-resolver: reconciliation helper (Unit 3) + node wiring (Unit 4)."""
+
+import json
+
+import pytest
+from biomapper import BioMapperAuthError
+
+from kestrel_backend.graph.nodes import entity_resolution
+from kestrel_backend.graph.nodes.entity_resolution import reconcile_to_kestrel, run
+from kestrel_backend.graph.pipeline_config import (
+    BiomapperConfig,
+    EntityResolutionConfig,
+    PipelineConfig,
+)
+
+
+# --------------------------- get_nodes envelope helpers ---------------------------
+
+def _gn_envelope(curie: str, node: dict | None, as_list: bool = False) -> dict:
+    """Build a Kestrel get_nodes MCP envelope.
+
+    Live shape (confirmed 2026-06-16): present -> {curie: {node}} (node dict directly);
+    `as_list=True` exercises the alternate {curie: [node]} wrapping; absent -> {curie: []}.
+    """
+    if node is None:
+        body = {curie: []}
+    else:
+        body = {curie: [node] if as_list else node}
+    return {"content": [{"type": "text", "text": json.dumps(body)}], "isError": False}
+
+
+def _human_gene_node(curie="NCBIGene:7132"):
+    return {"id": curie, "categories": ["biolink:Gene", "biolink:Protein"],
+            "equivalent_ids": [curie, "HGNC:11916", "UniProtKB:P19438"]}
+
+
+def _ortholog_node(curie="NCBIGene:397020"):
+    return {"id": curie, "categories": ["biolink:Gene", "biolink:Protein"],
+            "equivalent_ids": [curie, "RGD:14161077", "UniProtKB:P50555"]}  # no HGNC
+
+
+def _biomapper_result(curie="NCBIGene:7132", tier="high", xrefs=None):
+    return {"curie": curie, "tier": tier, "confidence": 2.5, "resolved_name": "TNFRSF1A",
+            "category": "biolink:Gene", "xrefs": xrefs or {"HGNC": ["11916"], "NCBIGene": ["7132"]}}
+
+
+# =============================== Unit 3: reconcile_to_kestrel ===============================
+
+class TestReconcile:
+    async def test_primary_confirms_with_human_marker(self, monkeypatch):
+        async def fake_get_nodes(tool, args):
+            return _gn_envelope(args["curies"], _human_gene_node(args["curies"]))
+        monkeypatch.setattr(entity_resolution, "call_kestrel_tool", fake_get_nodes)
+        out = await reconcile_to_kestrel(_biomapper_result(), "gene")
+        assert out == ("NCBIGene:7132", "biolink:Gene")
+
+    async def test_gene_without_hgnc_rejected(self, monkeypatch):
+        # Ortholog confirms in Kestrel but lacks HGNC → defense gate rejects; no other candidate → None.
+        async def fake(tool, args):
+            c = args["curies"]
+            # Only the ortholog primary exists; it has no HGNC equivalent.
+            return _gn_envelope(c, _ortholog_node(c) if c == "NCBIGene:397020" else None)
+        monkeypatch.setattr(entity_resolution, "call_kestrel_tool", fake)
+        # Build inline so xrefs is genuinely empty (the helper's `xrefs or {...}` would refill it).
+        result = {"curie": "NCBIGene:397020", "tier": "high", "resolved_name": "X", "xrefs": {}}
+        assert await reconcile_to_kestrel(result, "gene") is None
+
+    async def test_metabolite_skips_hgnc_gate(self, monkeypatch):
+        # A metabolite node with no HGNC is accepted (gate is gene/protein only).
+        node = {"id": "CHEBI:16946", "categories": ["biolink:ChemicalEntity"], "equivalent_ids": ["HMDB:H1"]}
+        async def fake(tool, args):
+            return _gn_envelope(args["curies"], node)
+        monkeypatch.setattr(entity_resolution, "call_kestrel_tool", fake)
+        out = await reconcile_to_kestrel(
+            {"curie": "CHEBI:16946", "tier": "high", "xrefs": {}}, "metabolite")
+        assert out == ("CHEBI:16946", "biolink:ChemicalEntity")
+
+    async def test_none_confirm_returns_none(self, monkeypatch):
+        async def fake(tool, args):
+            return _gn_envelope(args["curies"], None)  # empty list = absent
+        monkeypatch.setattr(entity_resolution, "call_kestrel_tool", fake)
+        assert await reconcile_to_kestrel(_biomapper_result(xrefs={}), "gene") is None
+
+    async def test_primary_absent_falls_to_xref(self, monkeypatch):
+        # primary_curie absent; the HGNC xref candidate confirms (human).
+        async def fake(tool, args):
+            c = args["curies"]
+            if c == "NCBIGene:7132":
+                return _gn_envelope(c, None)
+            if c == "HGNC:11916":
+                return _gn_envelope(c, _human_gene_node("NCBIGene:7132"))
+            return _gn_envelope(c, None)
+        monkeypatch.setattr(entity_resolution, "call_kestrel_tool", fake)
+        out = await reconcile_to_kestrel(_biomapper_result(), "gene")
+        assert out == ("NCBIGene:7132", "biolink:Gene")  # node.id, not the queried HGNC curie
+
+    async def test_accepts_list_wrapped_node_envelope(self, monkeypatch):
+        # Some Kestrel versions wrap the node as {curie: [node]}; both shapes must parse.
+        async def fake(tool, args):
+            return _gn_envelope(args["curies"], _human_gene_node(args["curies"]), as_list=True)
+        monkeypatch.setattr(entity_resolution, "call_kestrel_tool", fake)
+        out = await reconcile_to_kestrel(_biomapper_result(), "gene")
+        assert out == ("NCBIGene:7132", "biolink:Gene")
+
+    async def test_transport_error_tries_next_candidate(self, monkeypatch):
+        calls = {"n": 0}
+        async def fake(tool, args):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("kestrel down")
+            return _gn_envelope(args["curies"], _human_gene_node(args["curies"]))
+        monkeypatch.setattr(entity_resolution, "call_kestrel_tool", fake)
+        out = await reconcile_to_kestrel(_biomapper_result(), "gene")
+        assert out is not None and calls["n"] >= 2
+
+
+# =============================== Unit 4: run() pre-pass wiring ===============================
+
+def _enable_biomapper(monkeypatch):
+    cfg = PipelineConfig(entity_resolution=EntityResolutionConfig(biomapper=BiomapperConfig(enabled=True)))
+    monkeypatch.setattr(entity_resolution, "get_pipeline_config", lambda: cfg)
+
+
+class TestRunPrepass:
+    async def test_flag_off_does_not_call_biomapper(self, monkeypatch):
+        async def boom(*a, **k):
+            raise AssertionError("biomapper must not be called when flag is off")
+        monkeypatch.setattr(entity_resolution, "biomapper_resolve", boom)
+        # Tier 1 resolves the entity so it doesn't fall to SDK Tier 2.
+        async def fake_kestrel(tool, args):
+            return {"content": [{"text": json.dumps(
+                {args.get("search_text", ""): [{"id": "NCBIGene:7132", "name": "TNFRSF1A",
+                 "score": 2.0, "categories": ["biolink:Gene"]}]})}], "isError": False}
+        monkeypatch.setattr(entity_resolution, "call_kestrel_tool", fake_kestrel)
+        state = {"raw_entities": ["TNFRSF1A"], "entity_type_hints": {"TNFRSF1A": "gene"}, "entity_aliases": {}}
+        out = await run(state)
+        assert len(out["resolved_entities"]) == 1
+        assert out["resolved_entities"][0].method != "biomapper"
+
+    async def test_flag_on_hit_uses_biomapper_and_skips_tier1(self, monkeypatch):
+        _enable_biomapper(monkeypatch)
+        async def fake_bm(name, hint, base_url=None):
+            return _biomapper_result()
+        monkeypatch.setattr(entity_resolution, "biomapper_resolve", fake_bm)
+        seen_tools = []
+        async def fake_kestrel(tool, args):
+            seen_tools.append(tool)
+            assert tool == "get_nodes", f"hybrid_search should not run for a biomapper-confirmed entity (got {tool})"
+            return _gn_envelope(args["curies"], _human_gene_node(args["curies"]))
+        monkeypatch.setattr(entity_resolution, "call_kestrel_tool", fake_kestrel)
+        state = {"raw_entities": ["TNFRSF1A"], "entity_type_hints": {"TNFRSF1A": "gene"}, "entity_aliases": {}}
+        out = await run(state)
+        er = out["resolved_entities"][0]
+        assert er.method == "biomapper"
+        assert er.curie == "NCBIGene:7132"
+        assert "hybrid_search" not in seen_tools
+
+    async def test_flag_on_no_hint_skips_biomapper(self, monkeypatch):
+        _enable_biomapper(monkeypatch)
+        async def boom(*a, **k):
+            raise AssertionError("no hint → biomapper must be skipped")
+        monkeypatch.setattr(entity_resolution, "biomapper_resolve", boom)
+        async def fake_kestrel(tool, args):
+            return {"content": [{"text": json.dumps(
+                {args.get("search_text", ""): [{"id": "NCBIGene:7132", "name": "x",
+                 "score": 2.0, "categories": ["biolink:Gene"]}]})}], "isError": False}
+        monkeypatch.setattr(entity_resolution, "call_kestrel_tool", fake_kestrel)
+        state = {"raw_entities": ["TNFRSF1A"], "entity_type_hints": {}, "entity_aliases": {}}
+        out = await run(state)
+        assert len(out["resolved_entities"]) == 1
+
+    async def test_flag_on_auth_error_propagates(self, monkeypatch):
+        _enable_biomapper(monkeypatch)
+        async def fake_bm(name, hint, base_url=None):
+            raise BioMapperAuthError("bad key")
+        monkeypatch.setattr(entity_resolution, "biomapper_resolve", fake_bm)
+        state = {"raw_entities": ["TNFRSF1A"], "entity_type_hints": {"TNFRSF1A": "gene"}, "entity_aliases": {}}
+        with pytest.raises(BioMapperAuthError):
+            await run(state)

--- a/backend/tests/test_entity_resolution_biomapper.py
+++ b/backend/tests/test_entity_resolution_biomapper.py
@@ -137,7 +137,7 @@ class TestRunPrepass:
         assert len(out["resolved_entities"]) == 1
         assert out["resolved_entities"][0].method != "biomapper"
 
-    async def test_flag_on_hit_uses_biomapper_and_skips_tier1(self, monkeypatch):
+    async def test_flag_on_hit_uses_biomapper_and_skips_tier1(self, monkeypatch, caplog):
         _enable_biomapper(monkeypatch)
         async def fake_bm(name, hint, base_url=None):
             return _biomapper_result()
@@ -149,11 +149,16 @@ class TestRunPrepass:
             return _gn_envelope(args["curies"], _human_gene_node(args["curies"]))
         monkeypatch.setattr(entity_resolution, "call_kestrel_tool", fake_kestrel)
         state = {"raw_entities": ["TNFRSF1A"], "entity_type_hints": {"TNFRSF1A": "gene"}, "entity_aliases": {}}
-        out = await run(state)
+        with caplog.at_level("INFO", logger=entity_resolution.logger.name):
+            out = await run(state)
         er = out["resolved_entities"][0]
         assert er.method == "biomapper"
         assert er.curie == "NCBIGene:7132"
         assert "hybrid_search" not in seen_tools
+        # Greptile fix: the completion log breaks out biomapper and does NOT inflate tier2.
+        completion = next(m for m in caplog.messages if m.startswith("Completed entity_resolution"))
+        assert "biomapper=1" in completion
+        assert "tier1=0" in completion and "tier2=0" in completion
 
     async def test_flag_on_no_hint_skips_biomapper(self, monkeypatch):
         _enable_biomapper(monkeypatch)

--- a/backend/tests/test_pipeline_config.py
+++ b/backend/tests/test_pipeline_config.py
@@ -3,6 +3,7 @@
 import pytest
 
 from kestrel_backend.graph.pipeline_config import (
+    BiomapperConfig,
     ColdStartConfig,
     DirectKGConfig,
     EntityResolutionConfig,
@@ -34,6 +35,25 @@ class TestPipelineConfig:
         assert config.sdk_semaphore == 1
         assert config.batch_size == 6
         assert config.tier1_min_score == 0.6
+
+    def test_biomapper_defaults_flag_off(self):
+        """The biomapper pre-resolver is default-off (byte-identical to today when off)."""
+        biomapper = get_pipeline_config().entity_resolution.biomapper
+        assert biomapper.enabled is False
+        assert biomapper.species_default == "human"
+        assert biomapper.http_concurrency == 8
+        assert biomapper.node_timeout_seconds == 30.0
+
+    def test_biomapper_namespace_preference_has_required_classes(self):
+        """R5: per-class namespace preference is explicit config with gene/protein/metabolite."""
+        prefs = get_pipeline_config().entity_resolution.biomapper.namespace_preference
+        assert set(prefs) >= {"gene", "protein", "metabolite"}
+        # Genes/proteins anchor on the human-only HGNC namespace first (spike 2026-06-15).
+        assert prefs["gene"][0] == "HGNC"
+        assert prefs["protein"][0] == "HGNC"
+        # Metabolites have no HGNC analogue; CHEBI-first hypothesis.
+        assert prefs["metabolite"][0] == "CHEBI"
+        assert "HGNC" not in prefs["metabolite"]
 
     def test_triage_defaults(self):
         config = get_pipeline_config().triage
@@ -78,6 +98,17 @@ class TestConfigOverride:
             literature_grounding=LiteratureGroundingConfig(use_llm_classifier=True)
         )
         assert custom.literature_grounding.use_llm_classifier is True
+
+    def test_override_biomapper_enabled_flag(self):
+        """The biomapper flag round-trips True when overridden (the eventual flag-flip path)."""
+        custom = PipelineConfig(
+            entity_resolution=EntityResolutionConfig(
+                biomapper=BiomapperConfig(enabled=True)
+            )
+        )
+        assert custom.entity_resolution.biomapper.enabled is True
+        # Other entity_resolution fields keep defaults.
+        assert custom.entity_resolution.sdk_semaphore == 1
 
     def test_invalid_semaphore_raises(self):
         """Semaphore values must be positive."""

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -133,6 +133,20 @@ wheels = [
 ]
 
 [[package]]
+name = "biomapper"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/e2/e143b74577af2a4ac8f8901d3a54bf8ff84fb53b9057ad154ced3c3da037/biomapper-1.2.1.tar.gz", hash = "sha256:73fa2c08c379165c05004f0b48f98204ee81c5ab6864e8836b0045fbb4a5ffd1", size = 27902 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/2a/e67d1237fcc0aa9030bd5cb0a1172e11f8ea4b002dc27fb5774371511f5a/biomapper-1.2.1-py3-none-any.whl", hash = "sha256:4bb414716f2a9a0cabe1e839860b61a47168cc018a409188c5c1019af60c7616", size = 30365 },
+]
+
+[[package]]
 name = "blockbuster"
 version = "1.5.26"
 source = { registry = "https://pypi.org/simple" }
@@ -658,17 +672,18 @@ wheels = [
 
 [[package]]
 name = "httpx"
-version = "0.28.1"
+version = "0.27.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "certifi" },
     { name = "httpcore" },
     { name = "idna" },
+    { name = "sniffio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
+sdist = { url = "https://files.pythonhosted.org/packages/78/82/08f8c936781f67d9e6b9eeb8a0c8b4e406136ea4c3d1f89a5db71d42e0e6/httpx-0.27.2.tar.gz", hash = "sha256:f7c2be1d2f3c3c3160d441802406b206c2b76f5947b11115e6df10c6c65e66c2", size = 144189 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
+    { url = "https://files.pythonhosted.org/packages/56/95/9377bcb415797e44274b51d46e3249eba641711cf3348050f76ee7b15ffc/httpx-0.27.2-py3-none-any.whl", hash = "sha256:7bb2708e112d8fdd7829cd4243970f0c223274051cb35ee80c03301ee29a3df0", size = 76395 },
 ]
 
 [[package]]
@@ -865,6 +880,7 @@ dependencies = [
     { name = "alembic" },
     { name = "anthropic" },
     { name = "asyncpg" },
+    { name = "biomapper" },
     { name = "claude-agent-sdk" },
     { name = "defusedxml" },
     { name = "fastapi" },
@@ -900,6 +916,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.13.0" },
     { name = "anthropic", specifier = ">=0.42.0" },
     { name = "asyncpg", specifier = ">=0.31.0" },
+    { name = "biomapper", specifier = ">=1.2.1" },
     { name = "claude-agent-sdk", specifier = ">=0.1.0" },
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "fastapi", specifier = ">=0.115.0" },

--- a/client/src/components/BiomapperEnvToggle.tsx
+++ b/client/src/components/BiomapperEnvToggle.tsx
@@ -1,0 +1,81 @@
+import { cn } from "@/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { FlaskConical } from "lucide-react";
+import type { BiomapperEnv } from "@/types/messages";
+
+interface BiomapperEnvToggleProps {
+  env: BiomapperEnv;
+  onEnvChange: (env: BiomapperEnv) => void;
+  disabled?: boolean;
+}
+
+interface EnvButtonProps {
+  label: string;
+  isActive: boolean;
+  onClick: () => void;
+  disabled?: boolean;
+}
+
+function EnvButton({ label, isActive, onClick, disabled }: EnvButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        "px-2.5 py-1 text-xs font-medium rounded-md transition-colors",
+        isActive
+          ? "bg-background text-foreground shadow-sm"
+          : "text-muted-foreground hover:text-foreground",
+        disabled && "opacity-50 cursor-not-allowed",
+      )}
+    >
+      {label}
+    </button>
+  );
+}
+
+/**
+ * Prod/Dev toggle for the biomapper2 entity-resolution API used by the discovery pipeline.
+ * Mirrors biomapper-ui's environment toggle: the selected env is sent as `biomapper_env` on the
+ * WebSocket user_message and routes the backend pre-resolver to the prod or dev biomapper2 instance.
+ */
+export function BiomapperEnvToggle({ env, onEnvChange, disabled }: BiomapperEnvToggleProps) {
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="flex items-center gap-1.5" data-testid="biomapper-env-toggle">
+            <FlaskConical className="h-3.5 w-3.5 text-muted-foreground" />
+            <span className="text-xs text-muted-foreground">Biomapper</span>
+            <div className="flex items-center gap-1 p-0.5 bg-muted rounded-md">
+              <EnvButton
+                label="Prod"
+                isActive={env === "production"}
+                onClick={() => onEnvChange("production")}
+                disabled={disabled}
+              />
+              <EnvButton
+                label="Dev"
+                isActive={env === "dev"}
+                onClick={() => onEnvChange("dev")}
+                disabled={disabled}
+              />
+            </div>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" className="max-w-xs">
+          <p>
+            Which biomapper2 API the discovery pipeline uses for entity resolution.{" "}
+            <strong>Dev</strong> includes the HGNC human-gene fix (species-correct CURIEs);{" "}
+            <strong>Prod</strong> is the stable endpoint. Only affects Discovery Pipeline runs.
+          </p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/client/src/hooks/useWebSocket.ts
+++ b/client/src/hooks/useWebSocket.ts
@@ -8,6 +8,7 @@ import type {
   TraceMessage,
   SessionStats,
   AgentMode,
+  BiomapperEnv,
   PipelineProgress,
 } from "@/types/messages";
 
@@ -224,6 +225,8 @@ export function useWebSocket() {
   const [sessionStats, setSessionStats] = useState<SessionStats>(emptySessionStats());
   const [conversationId, setConversationId] = useState<string | null>(null);
   const [agentMode, setAgentMode] = useState<AgentMode>("classic");
+  // Prod/dev biomapper2 API toggle for the discovery pipeline (default prod).
+  const [biomapperEnv, setBiomapperEnv] = useState<BiomapperEnv>("production");
   const [pipelineProgress, setPipelineProgress] = useState<PipelineProgress | null>(null);
 
   // Clerk auth: get a fresh session token for WebSocket connections.
@@ -576,10 +579,11 @@ export function useWebSocket() {
           type: "user_message",
           content,
           agent_mode: agentMode,
+          biomapper_env: biomapperEnv,
         }),
       );
     },
-    [runDemoScenario, agentMode],
+    [runDemoScenario, agentMode, biomapperEnv],
   );
 
   const clearMessages = useCallback(() => {
@@ -616,6 +620,8 @@ export function useWebSocket() {
     conversationId,
     agentMode,
     setAgentMode,
+    biomapperEnv,
+    setBiomapperEnv,
     pipelineProgress,
     sendMessage,
     clearMessages,

--- a/client/src/pages/chat.tsx
+++ b/client/src/pages/chat.tsx
@@ -3,6 +3,7 @@ import { Header } from "@/components/Header";
 import { ChatArea } from "@/components/ChatArea";
 import { ChatInput } from "@/components/ChatInput";
 import { ModeToggle } from "@/components/ModeToggle";
+import { BiomapperEnvToggle } from "@/components/BiomapperEnvToggle";
 import { PipelineProgress } from "@/components/PipelineProgress";
 import { useWebSocket } from "@/hooks/useWebSocket";
 import type { ErrorMessage } from "@/types/messages";
@@ -16,6 +17,8 @@ export default function ChatPage() {
     conversationId,
     agentMode,
     setAgentMode,
+    biomapperEnv,
+    setBiomapperEnv,
     pipelineProgress,
     sendMessage,
     clearMessages,
@@ -53,12 +56,20 @@ export default function ChatPage() {
       />
       
       {/* Mode Toggle - below header, above messages */}
-      <div className="px-4 py-2 border-b flex justify-center">
+      <div className="px-4 py-2 border-b flex items-center justify-center gap-4">
         <ModeToggle
           mode={agentMode}
           onModeChange={setAgentMode}
           disabled={isAgentResponding}
         />
+        {/* Biomapper prod/dev API toggle — only relevant to the discovery pipeline's resolver. */}
+        {agentMode === "pipeline" && (
+          <BiomapperEnvToggle
+            env={biomapperEnv}
+            onEnvChange={setBiomapperEnv}
+            disabled={isAgentResponding}
+          />
+        )}
       </div>
 
       <ChatArea

--- a/client/src/types/messages.ts
+++ b/client/src/types/messages.ts
@@ -2,6 +2,9 @@ export type ConnectionStatus = "connecting" | "connected" | "disconnected" | "re
 
 export type AgentMode = "classic" | "pipeline";
 
+// Which biomapper2 API the discovery pipeline's entity resolution targets (prod/dev toggle).
+export type BiomapperEnv = "production" | "dev";
+
 export type UserMessage = {
   id: string;
   type: "user";

--- a/deploy/dev/.env.example
+++ b/deploy/dev/.env.example
@@ -7,6 +7,12 @@ RATE_LIMIT_PER_MINUTE=20
 # Kestrel MCP Server (required for knowledge graph access)
 KESTREL_API_KEY=
 
+# Biomapper2 entity resolution (only needed when the biomapper pre-resolver flag is enabled).
+# Use a DEV-specific key (dev and prod share the host; do not reuse the prod key). HTTPS only.
+# BIOMAPPER_API_KEY=
+# BIOMAPPER_BASE_URL=https://biomapper.expertintheloop.io  # unset = client default (prod)
+# BIOMAPPER_DEV_BASE_URL=https://dev-biomapper.expertintheloop.io/api/v1  # prod/dev toggle target
+
 # Database (separate dev database to prevent migration conflicts with prod)
 DATABASE_URL=postgresql://user:password@localhost:5432/kraken_dev
 


### PR DESCRIPTION
## Summary

Adds a **flag-gated biomapper2 pre-resolver** to the discovery pipeline's `entity_resolution` node, fixing the **wrong-species / false-cold-start** CURIEs (e.g. `TNFRSF1A` resolving to a pig/rat ortholog instead of human), plus a **per-run prod/dev biomapper2 API toggle** mirroring biomapper-ui's env routing.

**Default-off** — flag-off behavior is byte-identical to today. Safe to merge; lit up by a follow-up flag flip after dev soak.

## Why

biomapper2's gene/protein resolution *is* Kestrel hybrid search underneath, which ranks non-human orthologs #1 for bare human symbols. The upstream fix shipped in [biomapper2 PR #69](https://github.com/Phenome-Health/biomapper2/pull/69) (`prefer_human`, live on dev). This PR consumes it: biomapper resolves → reconciles against Kestrel (existence + HGNC human-marker defense gate) → falls back to the existing Kestrel tiers on any miss.

## What's in it

**Backend**
- `biomapper_client.py` — async wrapper (Biolink-class map, confidence-tier gate, error taxonomy, CURIE validation, secret hygiene; lazy import)
- `entity_resolution.py` — flag-gated pre-pass + `reconcile_to_kestrel` (get_nodes existence + HGNC gate); excludes confirmed entities from the Tier-1 gather
- `pipeline_config.py` — default-off `BiomapperConfig`; `config.py` — secrets, HTTPS validator, startup misconfig guard, `resolve_biomapper_base_url()` for the toggle
- `state.py` — `method` widened to `str` (admits `"biomapper"`; **also fixes a pre-existing alias-path `ValidationError` crash**) + `biomapper_env`; threaded WS → runner → node
- `evals/biomapper_resolution/` — gold-set merge gate on the production path

**Frontend**
- `BiomapperEnvToggle` (Prod/Dev) shown in Discovery Pipeline mode; `biomapper_env` sent on `user_message`

## Validation

- **Live vs dev biomapper2**: `TNFRSF1A→NCBIGene:7132`, `LDLR→NCBIGene:3949` (`method=biomapper`); toggle switches prod/dev endpoints
- **Gold-set gate**: 6/6 non-residual genes → correct human NCBIGene, **zero wrong-species**; `GH1` the lone Kestrel-recall residual (HGNC gate rejected its ortholog → honest miss)
- **64 unit tests green**; `tsc` + Vite build clean

## Known residual

`GH1`'s human node (`NCBIGene:2688`) is absent from Kestrel hybrid-search entirely (a Kestrel recall gap, filed in the BioMapper wiki) — falls back to the ortholog. Not fixable kraken- or biomapper2-side.

## Follow-ups (not in this PR)

- Populate `BIOMAPPER_API_KEY` / `BIOMAPPER_BASE_URL` / `BIOMAPPER_DEV_BASE_URL` on the dev host
- Flag-flip to default-on after dev soak
- biomapper2 **prod is intentionally left unfixed for an ablation study** — the prod/dev toggle enables that comparison

🤖 Generated with [Claude Code](https://claude.com/claude-code)
