### PR TITLE
feat(bridge-grounding): evidence-provenance labeler node (L2 + L3)

### DIFF
--- a/backend/src/kestrel_backend/graph/builder.py
+++ b/backend/src/kestrel_backend/graph/builder.py
@@ -20,7 +20,7 @@ from langgraph.graph import StateGraph, END
 from .state import DiscoveryState
 from .nodes import (
     intake, entity_resolution, triage, direct_kg, cold_start,
-    pathway_enrichment, integration, temporal, synthesis, literature_grounding
+    pathway_enrichment, integration, bridge_grounding, temporal, synthesis, literature_grounding
 )
 
 
@@ -129,6 +129,7 @@ def build_discovery_graph() -> StateGraph:
     workflow.add_node("cold_start", cold_start.run)
     workflow.add_node("pathway_enrichment", pathway_enrichment.run)
     workflow.add_node("integration", integration.run)
+    workflow.add_node("bridge_grounding", bridge_grounding.run)
     workflow.add_node("temporal", temporal.run)
     workflow.add_node("synthesis", synthesis.run)
     workflow.add_node("literature_grounding", literature_grounding.run)
@@ -157,18 +158,23 @@ def build_discovery_graph() -> StateGraph:
     # Pathway enrichment flows to integration
     workflow.add_edge("pathway_enrichment", "integration")
 
-    # Conditional routing after integration: temporal (if longitudinal) or synthesis
+    # bridge_grounding sits before synthesis on BOTH inbound paths so neither study type
+    # bypasses it: the non-longitudinal branch routes integration -> bridge_grounding (map below),
+    # and the longitudinal branch routes temporal -> bridge_grounding (edge below).
     workflow.add_conditional_edges(
         "integration",
         route_after_integration,
         {
             "temporal": "temporal",
-            "synthesis": "synthesis",
+            "synthesis": "bridge_grounding",  # non-longitudinal: integration -> bridge_grounding
         }
     )
 
-    # Temporal flows to synthesis
-    workflow.add_edge("temporal", "synthesis")
+    # Longitudinal: temporal -> bridge_grounding (not straight to synthesis)
+    workflow.add_edge("temporal", "bridge_grounding")
+
+    # bridge_grounding -> synthesis (single join point for both paths)
+    workflow.add_edge("bridge_grounding", "synthesis")
 
     # Synthesis flows to literature grounding
     workflow.add_edge("synthesis", "literature_grounding")

--- a/backend/src/kestrel_backend/graph/nodes/__init__.py
+++ b/backend/src/kestrel_backend/graph/nodes/__init__.py
@@ -9,6 +9,7 @@ Phase 2: + triage, direct_kg, cold_start
 Phase 4a: + pathway_enrichment
 Phase 4b: + integration, temporal
 Phase 5b: + literature_grounding
+L3: + bridge_grounding (evidence-provenance labeler, before synthesis)
 """
 
 from . import intake
@@ -18,6 +19,7 @@ from . import direct_kg
 from . import cold_start
 from . import pathway_enrichment
 from . import integration
+from . import bridge_grounding
 from . import temporal
 from . import synthesis
 from . import literature_grounding
@@ -30,6 +32,7 @@ __all__ = [
     "cold_start",
     "pathway_enrichment",
     "integration",
+    "bridge_grounding",
     "temporal",
     "synthesis",
     "literature_grounding",

--- a/backend/src/kestrel_backend/graph/nodes/bridge_grounding.py
+++ b/backend/src/kestrel_backend/graph/nodes/bridge_grounding.py
@@ -1,0 +1,74 @@
+"""L3 — bridge_grounding node: attach a deterministic evidence-provenance label to bridges.
+
+For each ordered 3-node multi-hop bridge (A→B→C), label each leg's best KG-edge evidence tier
+(via L1 ``provenance.leg_tier``) and compose a per-bridge chain summary (``provenance.bridge_label``).
+Writes the labeled bridges to the separate ``grounded_bridges`` state key (NOT ``bridges``, whose
+operator.add reducer would duplicate). Best-effort and never throws: a failure on one bridge is
+isolated to ``bridge_grounding_errors`` and the node still returns.
+
+Ships ``enabled=False`` (no-op, no Kestrel calls) until L4's validation eval gates the flip.
+"""
+
+import logging
+from typing import Any
+
+from ..pipeline_config import get_pipeline_config
+from ..state import BridgeGrounding, DiscoveryState, LegSummary
+from ..state_contracts import (
+    BridgeGroundingInput,
+    BridgeGroundingOutput,
+    validate_state,
+)
+from ...bridge_grounding.provenance import bridge_label, leg_tier
+
+logger = logging.getLogger(__name__)
+
+
+def _is_scoreable(bridge: Any) -> bool:
+    """Ordered 3-node multi-hop bridges only.
+
+    ``predicate_directions`` is non-empty ONLY for multi-hop bridges (subgraph "connecting"
+    bridges leave it ``[]``); combined with the 3-entity check this selects A→B→C chains and
+    excludes subgraph / 2-node / 4+-node bridges.
+    """
+    return len(bridge.entities) == 3 and bool(bridge.predicate_directions)
+
+
+@validate_state(BridgeGroundingInput, BridgeGroundingOutput)
+async def run(state: DiscoveryState) -> dict[str, Any]:
+    """Label ordered 3-node bridges with their evidence provenance; default-off no-op."""
+    # Read the flag fresh (not an import-time singleton) so get_pipeline_config.cache_clear() in
+    # tests takes effect. Flag-off → no Kestrel calls, empty grounded_bridges.
+    cfg = get_pipeline_config().bridge_grounding
+    if not cfg.enabled:
+        return {}
+
+    bridges = state.get("bridges", []) or []
+    scoreable = [b for b in bridges if _is_scoreable(b)][: cfg.max_scored_bridges]
+    logger.info(
+        "bridge_grounding: labeling %d/%d bridges (max_scored=%d)",
+        len(scoreable), len(bridges), cfg.max_scored_bridges,
+    )
+
+    grounded: list[Any] = []
+    errors: list[str] = []
+    for b in scoreable:
+        try:
+            a, mid, c = b.entities
+            # leg_tier is best-effort (returns "none" on a Kestrel failure, never raises).
+            t1 = await leg_tier(a, mid)
+            t2 = await leg_tier(mid, c)
+            grounding = BridgeGrounding(
+                legs=[
+                    LegSummary(from_curie=a, to_curie=mid, evidence_tier=t1),
+                    LegSummary(from_curie=mid, to_curie=c, evidence_tier=t2),
+                ],
+                label=bridge_label(t1, t2),
+            )
+            grounded.append(b.model_copy(update={"grounding": grounding}))
+        except Exception as e:  # per-bridge isolation: degrade this bridge, keep the node alive
+            logger.warning("bridge_grounding: failed for %s: %s", b.path_description, e)
+            errors.append(f"bridge_grounding: {b.path_description}: {e}")
+            grounded.append(b.model_copy(update={"grounding": BridgeGrounding(legs=[], label="no KG edge")}))
+
+    return {"grounded_bridges": grounded, "bridge_grounding_errors": errors}

--- a/backend/src/kestrel_backend/graph/nodes/synthesis.py
+++ b/backend/src/kestrel_backend/graph/nodes/synthesis.py
@@ -423,10 +423,38 @@ def format_hub_warnings(hub_flags: list[str]) -> str:
     return "\n".join(lines)
 
 
-def format_bridges(bridges: list[Bridge]) -> str:
-    """Format cross-type bridges discovered during integration analysis."""
+def format_bridges(
+    bridges: list[Bridge],
+    grounding_labels: dict[tuple[str, ...], str] | None = None,
+) -> str:
+    """Format cross-type bridges discovered during integration analysis.
+
+    ``grounding_labels`` maps a bridge's ``tuple(entities)`` to its evidence-provenance chain
+    label (from the bridge_grounding node, via ``grounded_bridges``). When present, the label is
+    rendered per bridge so the researcher sees what kind of evidence backs each leg.
+    """
     if not bridges:
         return ""
+
+    labels = grounding_labels or {}
+
+    def _render(b: Bridge) -> None:
+        novelty_tag = "Known" if b.novelty == "known" else "Inferred"
+        lines.append(f"\n**{b.path_description}** [{novelty_tag}]")
+        if b.entity_names:
+            path_with_names = " -> ".join(
+                f"{name} (`{curie}`)" for name, curie in zip(b.entity_names, b.entities)
+            )
+            lines.append(f"  - Path: {path_with_names}")
+        else:
+            lines.append(f"  - Entities: {' -> '.join(b.entities)}")
+        if b.predicates:
+            lines.append(f"  - Predicates: {' -> '.join(b.predicates)}")
+        if b.significance:
+            lines.append(f"  - **Significance**: {b.significance}")
+        label = labels.get(tuple(b.entities))
+        if label:
+            lines.append(f"  - **Evidence provenance**: {label}")
 
     lines = ["## Cross-Type Bridges\n"]
     lines.append("*Multi-hop paths connecting different entity types across the analysis.*\n")
@@ -438,40 +466,26 @@ def format_bridges(bridges: list[Bridge]) -> str:
     if tier2:
         lines.append("### High-Confidence Bridges (Tier 2)")
         for b in tier2:
-            novelty_tag = "Known" if b.novelty == "known" else "Inferred"
-            lines.append(f"\n**{b.path_description}** [{novelty_tag}]")
-            if b.entity_names:
-                path_with_names = " -> ".join(
-                    f"{name} (`{curie}`)"
-                    for name, curie in zip(b.entity_names, b.entities)
-                )
-                lines.append(f"  - Path: {path_with_names}")
-            else:
-                lines.append(f"  - Entities: {' -> '.join(b.entities)}")
-            if b.predicates:
-                lines.append(f"  - Predicates: {' -> '.join(b.predicates)}")
-            if b.significance:
-                lines.append(f"  - **Significance**: {b.significance}")
+            _render(b)
         lines.append("")
 
     if tier3:
         lines.append("### Speculative Bridges (Tier 3)")
         for b in tier3:
-            novelty_tag = "Known" if b.novelty == "known" else "Inferred"
-            lines.append(f"\n**{b.path_description}** [{novelty_tag}]")
-            if b.entity_names:
-                path_with_names = " -> ".join(
-                    f"{name} (`{curie}`)"
-                    for name, curie in zip(b.entity_names, b.entities)
-                )
-                lines.append(f"  - Path: {path_with_names}")
-            else:
-                lines.append(f"  - Entities: {' -> '.join(b.entities)}")
-            if b.significance:
-                lines.append(f"  - **Significance**: {b.significance}")
+            _render(b)
         lines.append("")
 
     return "\n".join(lines)
+
+
+def grounding_labels_from_state(state: DiscoveryState) -> dict[tuple[str, ...], str]:
+    """Build a {tuple(entities) -> chain label} map from grounded_bridges for bridge rendering."""
+    labels: dict[tuple[str, ...], str] = {}
+    for gb in state.get("grounded_bridges", []) or []:
+        grounding = getattr(gb, "grounding", None)
+        if grounding is not None and getattr(grounding, "label", ""):
+            labels[tuple(gb.entities)] = grounding.label
+    return labels
 
 
 def format_gap_entities(gaps: list[GapEntity]) -> str:
@@ -658,7 +672,7 @@ def assemble_synthesis_context(state: DiscoveryState) -> str:
     
     # Cross-type bridges
     bridges = state.get("bridges", [])
-    bridges_section = format_bridges(bridges)
+    bridges_section = format_bridges(bridges, grounding_labels_from_state(state))
     if bridges_section:
         sections.append(bridges_section)
     
@@ -752,7 +766,7 @@ def fallback_report(state: DiscoveryState) -> str:
         report_lines.append(enrichment_section)
 
     # Cross-type bridges - Phase 4b
-    bridges_section = format_bridges(bridges)
+    bridges_section = format_bridges(bridges, grounding_labels_from_state(state))
     if bridges_section:
         report_lines.append(bridges_section)
 

--- a/backend/src/kestrel_backend/graph/nodes/synthesis.py
+++ b/backend/src/kestrel_backend/graph/nodes/synthesis.py
@@ -438,7 +438,9 @@ def format_bridges(
 
     labels = grounding_labels or {}
 
-    def _render(b: Bridge) -> None:
+    def _render(b: Bridge, show_predicates: bool) -> None:
+        # show_predicates preserves the original behavior: Tier 2 lists per-hop predicates,
+        # Tier 3 (speculative) deliberately omits them.
         novelty_tag = "Known" if b.novelty == "known" else "Inferred"
         lines.append(f"\n**{b.path_description}** [{novelty_tag}]")
         if b.entity_names:
@@ -448,7 +450,7 @@ def format_bridges(
             lines.append(f"  - Path: {path_with_names}")
         else:
             lines.append(f"  - Entities: {' -> '.join(b.entities)}")
-        if b.predicates:
+        if show_predicates and b.predicates:
             lines.append(f"  - Predicates: {' -> '.join(b.predicates)}")
         if b.significance:
             lines.append(f"  - **Significance**: {b.significance}")
@@ -466,13 +468,13 @@ def format_bridges(
     if tier2:
         lines.append("### High-Confidence Bridges (Tier 2)")
         for b in tier2:
-            _render(b)
+            _render(b, show_predicates=True)
         lines.append("")
 
     if tier3:
         lines.append("### Speculative Bridges (Tier 3)")
         for b in tier3:
-            _render(b)
+            _render(b, show_predicates=False)
         lines.append("")
 
     return "\n".join(lines)

--- a/backend/src/kestrel_backend/graph/pipeline_config.py
+++ b/backend/src/kestrel_backend/graph/pipeline_config.py
@@ -243,6 +243,23 @@ class IntegrationConfig(BaseModel):
     )
 
 
+class BridgeGroundingConfig(BaseModel):
+    """Configuration for the bridge_grounding node (deterministic evidence-provenance labeler)."""
+
+    enabled: bool = Field(
+        default=False,
+        description="Ship default-off (eval-only). Flip to True is a one-line follow-up gated on "
+        "L4's validation eval over real bridges (docs/plans/2026-06-17-002-feat-bridge-evidence-"
+        "provenance-labeler-plan.md). When False the node is a no-op (no Kestrel calls).",
+    )
+    max_scored_bridges: int = Field(
+        default=20,
+        description="Cap on ordered 3-node bridges labeled per run. Each costs 2 one_hop_query "
+        "full calls, so this bounds the added Kestrel load (2 * max_scored_bridges per run). "
+        "(The per-leg edge limit is fixed at L1's leg_tier constant.)",
+    )
+
+
 class PipelineConfig(BaseModel):
     """Top-level pipeline configuration with per-node sub-models.
 
@@ -258,6 +275,7 @@ class PipelineConfig(BaseModel):
     cold_start: ColdStartConfig = Field(default_factory=ColdStartConfig)
     literature_grounding: LiteratureGroundingConfig = Field(default_factory=LiteratureGroundingConfig)
     integration: IntegrationConfig = Field(default_factory=IntegrationConfig)
+    bridge_grounding: BridgeGroundingConfig = Field(default_factory=BridgeGroundingConfig)
 
 
 @lru_cache(maxsize=1)

--- a/backend/src/kestrel_backend/graph/state.py
+++ b/backend/src/kestrel_backend/graph/state.py
@@ -169,47 +169,35 @@ class BiologicalTheme(BaseModel):
 # =============================================================================
 
 class LegSummary(BaseModel):
-    """Per-leg labeling tally for one hop of a grounded bridge chain (A–B or B–C)."""
+    """Per-leg evidence-provenance summary for one hop of a grounded bridge chain (A–B or B–C).
+
+    Deterministic KG-edge provenance (no co-occurrence, no score): the best evidence tier over the
+    leg's KG edges, computed by ``bridge_grounding.provenance.leg_tier``.
+    """
 
     model_config = ConfigDict(frozen=True)
 
     from_curie: str = Field(..., description="Source CURIE of this leg")
     to_curie: str = Field(..., description="Target CURIE of this leg")
-    pool_size: int = Field(0, description="PMIDs retrieved for this leg's co-occurrence pool")
-    abstracts_with_bodies: int = Field(0, description="Pool PMIDs with a usable abstract body")
-    support: int = Field(0, description="Abstracts labeled supports_leg")
-    refute: int = Field(0, description="Abstracts labeled refutes_leg")
-    neither: int = Field(0, description="Abstracts labeled neither/inconclusive (inflates denominator)")
-    off_topic: int = Field(0, description="Abstracts labeled off_topic (excluded from the tally)")
-    dropped_co_mention: int = Field(0, description="PMIDs in both legs, kept-first into the other leg")
+    evidence_tier: str = Field(
+        ...,
+        description="Best evidence tier over the leg's KG edges: curated-causal | "
+        "curated-associative | curated-neutral | text-mined | none",
+    )
 
 
 class BridgeGrounding(BaseModel):
-    """Literature grounding-confidence signal attached to a 3-node Bridge (v1).
+    """Deterministic evidence-provenance label attached to a 3-node Bridge (no score, no LLM).
 
-    v1 ships ratio + counts only. The headline ``support_fraction`` is the WEAKER leg's
-    supports/total_labeled (min-leg gating); the stronger leg is retained as a secondary
-    ranking key so a downstream ranker isn't forced to sort on the lossy min-only scalar.
-    Beta-Binomial CI (``ci_low``/``ci_high``) is deferred to v2 (null in v1). The qualitative
-    band surfaced to researchers is computed at render time from ``decision`` + ``support_fraction``
-    via config thresholds — NOT stored here (it is threshold-dependent).
+    Per leg, the best evidence tier from the leg's KG edges; per bridge, a human-readable chain
+    summary (``label``) composed by ``bridge_grounding.provenance.bridge_label``. Makes no
+    confidence/mechanism claim — it reports *what kind of evidence* backs each leg.
     """
 
     model_config = ConfigDict(frozen=True)
 
-    support_fraction: float = Field(
-        ..., ge=0, le=1, description="v1 headline = weaker leg's supports/total_labeled")
-    strong_leg_fraction: float | None = Field(
-        None, ge=0, le=1, description="Secondary ranking key: stronger leg's support_fraction")
-    strong_leg_n: int | None = Field(
-        None, description="total_labeled behind strong_leg_fraction")
-    ci_low: float | None = Field(None, description="v2-only Beta-Binomial CI lower bound; null in v1")
-    ci_high: float | None = Field(None, description="v2-only Beta-Binomial CI upper bound; null in v1")
-    decision: Literal["grounded", "ungrounded", "insufficient_literature"] = Field(
-        ..., description="Structured chain verdict")
-    legs: list[LegSummary] = Field(default_factory=list, description="Per-leg labeling tallies")
-    rationale: str = Field(default="", description="Mediated-chain composition rationale")
-    chain_pmids: list[str] = Field(default_factory=list, description="PMIDs cited in the chain verdict")
+    legs: list[LegSummary] = Field(default_factory=list, description="Per-leg evidence tiers")
+    label: str = Field(..., description="Chain summary, e.g. 'both legs curated-causal' / 'no KG edge'")
 
 
 class Bridge(BaseModel):

--- a/backend/src/kestrel_backend/protocol.py
+++ b/backend/src/kestrel_backend/protocol.py
@@ -74,7 +74,7 @@ class PipelineProgressMessage(BaseModel):
     node: str                    # Current node name (e.g., "entity_resolution")
     message: str                 # User-friendly status message
     nodes_completed: int         # Number of nodes finished
-    total_nodes: int = 10        # Total nodes in pipeline
+    total_nodes: int = 11        # Total nodes in pipeline (incl. bridge_grounding)
 
 
 class PipelineNodeDetailMessage(BaseModel):
@@ -136,6 +136,7 @@ NODE_STATUS_MESSAGES = {
     "cold_start": "Investigating sparse entities...",
     "pathway_enrichment": "Finding shared biological pathways...",
     "integration": "Detecting cross-type bridges...",
+    "bridge_grounding": "Labeling bridge evidence provenance...",
     "temporal": "Applying temporal reasoning...",
     "synthesis": "Generating discovery report...",
     "literature_grounding": "Grounding hypotheses with literature citations...",

--- a/backend/tests/test_bridge_grounding_models.py
+++ b/backend/tests/test_bridge_grounding_models.py
@@ -1,6 +1,6 @@
-"""U1 — BridgeGrounding / LegSummary models, Bridge.grounding field, and contracts.
+"""L2 — BridgeGrounding / LegSummary provenance models, Bridge.grounding field, and contracts.
 
-The grounding signal is attached to a frozen Bridge via model_copy and written to a separate
+The provenance label is attached to a frozen Bridge via model_copy and written to a separate
 `grounded_bridges` state key (NOT `bridges`, whose operator.add reducer would duplicate). The
 output contract defaults every field so a partial/early return still validates (never-throws).
 
@@ -18,11 +18,8 @@ from src.kestrel_backend.graph.state_contracts import (
 )
 
 
-def _leg(support=2, refute=0, neither=1, off_topic=0):
-    return LegSummary(
-        from_curie="A", to_curie="B", pool_size=10, abstracts_with_bodies=8,
-        support=support, refute=refute, neither=neither, off_topic=off_topic,
-    )
+def _leg(from_curie="A", to_curie="B", evidence_tier="curated-causal"):
+    return LegSummary(from_curie=from_curie, to_curie=to_curie, evidence_tier=evidence_tier)
 
 
 def _bridge():
@@ -38,50 +35,55 @@ def _bridge():
     )
 
 
-# --- BridgeGrounding model -------------------------------------------------------------
+# --- LegSummary (minimal provenance shape) ---------------------------------------------
 
-def test_grounding_minimal_defaults():
-    g = BridgeGrounding(support_fraction=0.67, decision="grounded")
-    assert g.support_fraction == 0.67
-    assert g.decision == "grounded"
-    # v2-only and secondary fields default to None / empty in v1.
-    assert g.ci_low is None and g.ci_high is None
-    assert g.strong_leg_fraction is None and g.strong_leg_n is None
-    assert g.legs == [] and g.chain_pmids == [] and g.rationale == ""
+def test_leg_summary_minimal_fields():
+    leg = LegSummary(from_curie="CHEBI:1", to_curie="HGNC:2", evidence_tier="text-mined")
+    assert leg.from_curie == "CHEBI:1"
+    assert leg.to_curie == "HGNC:2"
+    assert leg.evidence_tier == "text-mined"
+
+
+def test_leg_summary_is_frozen():
+    leg = _leg()
+    with pytest.raises(ValidationError):
+        leg.evidence_tier = "none"  # frozen
+
+
+def test_leg_summary_dropped_v1_tally_fields():
+    # The v1 co-occurrence tally fields are gone (not merely optional).
+    for gone in ("support", "refute", "neither", "off_topic", "pool_size", "dropped_co_mention"):
+        assert gone not in LegSummary.model_fields
+
+
+# --- BridgeGrounding (legs + chain label) ----------------------------------------------
+
+def test_grounding_carries_legs_and_label():
+    g = BridgeGrounding(
+        legs=[_leg(evidence_tier="curated-causal"), _leg(from_curie="B", to_curie="C",
+              evidence_tier="text-mined")],
+        label="weakest leg text-mined",
+    )
+    assert g.label == "weakest leg text-mined"
+    assert len(g.legs) == 2 and g.legs[0].evidence_tier == "curated-causal"
+
+
+def test_grounding_legs_default_empty():
+    g = BridgeGrounding(label="no KG edge")
+    assert g.legs == []
 
 
 def test_grounding_is_frozen():
-    g = BridgeGrounding(support_fraction=0.5, decision="ungrounded")
+    g = BridgeGrounding(label="both legs curated-causal")
     with pytest.raises(ValidationError):
-        g.support_fraction = 0.9  # frozen
+        g.label = "changed"  # frozen
 
 
-def test_support_fraction_bounds_enforced():
-    for bad in (-0.1, 1.1):
-        with pytest.raises(ValidationError):
-            BridgeGrounding(support_fraction=bad, decision="grounded")
-
-
-def test_decision_enum_constrained():
-    with pytest.raises(ValidationError):
-        BridgeGrounding(support_fraction=0.5, decision="totally_grounded")
-
-
-def test_grounding_carries_legs_and_strong_leg():
-    g = BridgeGrounding(
-        support_fraction=0.55, strong_leg_fraction=0.95, strong_leg_n=20,
-        decision="grounded", legs=[_leg(), _leg(support=19, neither=1)],
-        rationale="A affects B which relates to C", chain_pmids=["1", "2"],
-    )
-    assert g.strong_leg_fraction == 0.95 and g.strong_leg_n == 20
-    assert len(g.legs) == 2 and g.legs[0].support == 2
-
-
-# --- LegSummary ------------------------------------------------------------------------
-
-def test_leg_summary_defaults():
-    leg = LegSummary(from_curie="A", to_curie="B")
-    assert leg.pool_size == 0 and leg.support == 0 and leg.dropped_co_mention == 0
+def test_grounding_dropped_v1_score_fields():
+    # The v1 score/verdict fields are gone (not just optional) — the score is abandoned.
+    for gone in ("support_fraction", "decision", "strong_leg_fraction", "strong_leg_n",
+                 "ci_low", "ci_high", "rationale", "chain_pmids"):
+        assert gone not in BridgeGrounding.model_fields
 
 
 # --- Bridge.grounding field ------------------------------------------------------------
@@ -93,7 +95,7 @@ def test_bridge_grounding_defaults_none_backward_compatible():
 
 def test_attach_grounding_via_model_copy_does_not_mutate_original():
     b = _bridge()
-    g = BridgeGrounding(support_fraction=0.67, decision="grounded")
+    g = BridgeGrounding(legs=[_leg()], label="both legs curated-causal")
     grounded = b.model_copy(update={"grounding": g})
     assert grounded.grounding is g
     assert b.grounding is None  # frozen original untouched
@@ -102,19 +104,20 @@ def test_attach_grounding_via_model_copy_does_not_mutate_original():
 
 def test_bridge_roundtrips_with_grounding_serialized():
     b = _bridge().model_copy(update={"grounding": BridgeGrounding(
-        support_fraction=0.5, decision="ungrounded")})
+        legs=[_leg(evidence_tier="curated-associative")], label="weakest leg curated-associative")})
     restored = Bridge.model_validate(b.model_dump())
     assert restored.grounding is not None
-    assert restored.grounding.decision == "ungrounded"
+    assert restored.grounding.label == "weakest leg curated-associative"
+    assert restored.grounding.legs[0].evidence_tier == "curated-associative"
 
 
 def test_grounded_bridges_join_back_by_entities_tuple():
     # grounded_bridges is a subset; consumers join to the original list by the entities tuple.
     b = _bridge()
     grounded = b.model_copy(update={"grounding": BridgeGrounding(
-        support_fraction=0.8, decision="grounded")})
+        legs=[_leg()], label="both legs curated-causal")})
     by_entities = {tuple(x.entities): x for x in [grounded]}
-    assert by_entities[tuple(b.entities)].grounding.support_fraction == 0.8
+    assert by_entities[tuple(b.entities)].grounding.label == "both legs curated-causal"
 
 
 # --- Contracts -------------------------------------------------------------------------

--- a/backend/tests/test_bridge_grounding_node.py
+++ b/backend/tests/test_bridge_grounding_node.py
@@ -144,6 +144,21 @@ def test_format_bridges_without_labels_omits_provenance_line():
     assert "Evidence provenance" not in out
 
 
+def test_format_bridges_tier2_includes_predicates():
+    out = format_bridges([_bridge(tier=2)])
+    assert "Predicates:" in out  # Tier 2 lists per-hop predicates
+
+
+def test_format_bridges_tier3_omits_predicates_keeps_label():
+    # Regression guard: the _render refactor must preserve the original behavior — Tier 3
+    # (speculative) bridges deliberately OMIT the Predicates line (Greptile PR #77).
+    b = _bridge(tier=3)
+    out = format_bridges([b], {tuple(b.entities): "weakest leg text-mined"})
+    assert "### Speculative Bridges (Tier 3)" in out
+    assert "Predicates:" not in out  # omitted for Tier 3
+    assert "**Evidence provenance**: weakest leg text-mined" in out  # label still rendered
+
+
 def test_grounding_labels_from_state_builds_map():
     b = _bridge()
     gb = b.model_copy(update={"grounding": BridgeGrounding(legs=[], label="no KG edge")})

--- a/backend/tests/test_bridge_grounding_node.py
+++ b/backend/tests/test_bridge_grounding_node.py
@@ -1,0 +1,151 @@
+"""L3 — bridge_grounding node: labeling, default-off no-op, filtering, error isolation,
+graph wiring (both study-type paths), and synthesis rendering of the provenance label.
+"""
+
+from kestrel_backend.graph.builder import build_discovery_graph
+from kestrel_backend.graph.nodes import bridge_grounding
+from kestrel_backend.graph.nodes.synthesis import format_bridges, grounding_labels_from_state
+from kestrel_backend.graph.pipeline_config import BridgeGroundingConfig, PipelineConfig
+from kestrel_backend.graph.state import Bridge, BridgeGrounding
+
+
+def _bridge(entities=("CHEBI:1", "HGNC:2", "MONDO:3"), tier=2, predicate_directions=(True, False)):
+    return Bridge(
+        path_description="metabolite → gene → disease",
+        entities=list(entities),
+        entity_names=[],
+        predicates=["biolink:affects", "biolink:causes"],
+        predicate_directions=list(predicate_directions),
+        tier=tier,
+        novelty="inferred",
+        significance="why it matters",
+    )
+
+
+def _enable(monkeypatch, enabled=True, max_scored_bridges=20):
+    cfg = PipelineConfig(bridge_grounding=BridgeGroundingConfig(
+        enabled=enabled, max_scored_bridges=max_scored_bridges))
+    monkeypatch.setattr(bridge_grounding, "get_pipeline_config", lambda: cfg)
+
+
+def _stub_leg_tier(monkeypatch, tier="curated-causal", calls=None):
+    async def fake(x, y):
+        if calls is not None:
+            calls.append((x, y))
+        return tier
+    monkeypatch.setattr(bridge_grounding, "leg_tier", fake)
+
+
+# --- default-off no-op -----------------------------------------------------------------
+
+async def test_disabled_is_noop(monkeypatch):
+    # Default config is enabled=False; the node must do nothing and call no Kestrel.
+    async def boom(*a, **k):
+        raise AssertionError("leg_tier must not be called when disabled")
+    monkeypatch.setattr(bridge_grounding, "leg_tier", boom)
+    out = await bridge_grounding.run({"bridges": [_bridge()]})
+    assert out == {}
+
+
+# --- happy path ------------------------------------------------------------------------
+
+async def test_enabled_labels_curated_causal(monkeypatch):
+    _enable(monkeypatch)
+    calls = []
+    _stub_leg_tier(monkeypatch, "curated-causal", calls)
+    out = await bridge_grounding.run({"bridges": [_bridge()]})
+    grounded = out["grounded_bridges"]
+    assert len(grounded) == 1
+    g = grounded[0].grounding
+    assert g.label == "both legs curated-causal"
+    assert [leg.evidence_tier for leg in g.legs] == ["curated-causal", "curated-causal"]
+    assert [(leg.from_curie, leg.to_curie) for leg in g.legs] == [
+        ("CHEBI:1", "HGNC:2"), ("HGNC:2", "MONDO:3")]
+    assert calls == [("CHEBI:1", "HGNC:2"), ("HGNC:2", "MONDO:3")]  # 2 legs, start-only
+    assert out["bridge_grounding_errors"] == []
+
+
+async def test_weakest_leg_label(monkeypatch):
+    _enable(monkeypatch)
+    tiers = iter(["curated-causal", "text-mined"])
+    async def fake(x, y):
+        return next(tiers)
+    monkeypatch.setattr(bridge_grounding, "leg_tier", fake)
+    out = await bridge_grounding.run({"bridges": [_bridge()]})
+    assert out["grounded_bridges"][0].grounding.label == "weakest leg text-mined"
+
+
+# --- filtering -------------------------------------------------------------------------
+
+async def test_skips_non_3node_and_subgraph_bridges(monkeypatch):
+    _enable(monkeypatch)
+    calls = []
+    _stub_leg_tier(monkeypatch, "curated-causal", calls)
+    bridges = [
+        _bridge(entities=("A", "B"), predicate_directions=(True,)),          # 2-node
+        _bridge(entities=("A", "B", "C", "D"), predicate_directions=(True, False, True)),  # 4-node
+        _bridge(entities=("A", "B", "C"), predicate_directions=()),          # subgraph: pd == []
+    ]
+    out = await bridge_grounding.run({"bridges": bridges})
+    assert out["grounded_bridges"] == []
+    assert calls == []  # nothing scoreable → no Kestrel
+
+
+async def test_max_scored_bridges_cap(monkeypatch):
+    _enable(monkeypatch, max_scored_bridges=1)
+    _stub_leg_tier(monkeypatch, "curated-causal")
+    out = await bridge_grounding.run({"bridges": [_bridge(), _bridge(entities=("X:1", "Y:2", "Z:3"))]})
+    assert len(out["grounded_bridges"]) == 1  # capped
+
+
+# --- error isolation -------------------------------------------------------------------
+
+async def test_per_bridge_error_isolation(monkeypatch):
+    _enable(monkeypatch)
+    good = _bridge(entities=("CHEBI:1", "HGNC:2", "MONDO:3"))
+    bad = _bridge(entities=("X:1", "Y:2", "Z:3"))
+
+    async def fake(x, y):
+        if x == "X:1":
+            raise RuntimeError("kestrel boom")
+        return "curated-causal"
+    monkeypatch.setattr(bridge_grounding, "leg_tier", fake)
+    out = await bridge_grounding.run({"bridges": [good, bad]})
+    assert len(out["grounded_bridges"]) == 2  # both still returned
+    assert len(out["bridge_grounding_errors"]) == 1  # the bad one logged
+    by_entities = {tuple(b.entities): b for b in out["grounded_bridges"]}
+    assert by_entities[("CHEBI:1", "HGNC:2", "MONDO:3")].grounding.label == "both legs curated-causal"
+    assert by_entities[("X:1", "Y:2", "Z:3")].grounding.label == "no KG edge"  # degraded, not crashed
+
+
+# --- graph wiring (both study-type paths) ----------------------------------------------
+
+def test_graph_routes_through_bridge_grounding_both_paths():
+    edges = {(e.source, e.target) for e in build_discovery_graph().get_graph().edges}
+    assert ("bridge_grounding", "synthesis") in edges          # single join point
+    assert ("temporal", "bridge_grounding") in edges           # longitudinal path
+    assert ("integration", "bridge_grounding") in edges        # non-longitudinal conditional path
+    # Neither study type bypasses the node straight into synthesis:
+    assert ("temporal", "synthesis") not in edges
+    assert ("integration", "synthesis") not in edges
+
+
+# --- synthesis rendering ---------------------------------------------------------------
+
+def test_format_bridges_renders_provenance_label():
+    b = _bridge()
+    labels = {tuple(b.entities): "both legs curated-causal"}
+    out = format_bridges([b], labels)
+    assert "**Evidence provenance**: both legs curated-causal" in out
+
+
+def test_format_bridges_without_labels_omits_provenance_line():
+    out = format_bridges([_bridge()])
+    assert "Evidence provenance" not in out
+
+
+def test_grounding_labels_from_state_builds_map():
+    b = _bridge()
+    gb = b.model_copy(update={"grounding": BridgeGrounding(legs=[], label="no KG edge")})
+    m = grounding_labels_from_state({"grounded_bridges": [gb]})
+    assert m[tuple(b.entities)] == "no KG edge"

--- a/backend/tests/test_langgraph_prototype.py
+++ b/backend/tests/test_langgraph_prototype.py
@@ -1689,8 +1689,8 @@ class TestEndToEndPhase4b:
     """End-to-end tests for Phase 4b complete graph."""
 
     @pytest.mark.asyncio
-    async def test_graph_has_9_nodes(self):
-        """Graph should have 9 analysis nodes plus __start__."""
+    async def test_graph_has_expected_nodes(self):
+        """Graph should contain all analysis nodes including bridge_grounding (added in L3)."""
         graph = build_discovery_graph()
         node_names = list(graph.nodes.keys())
 
@@ -1702,6 +1702,7 @@ class TestEndToEndPhase4b:
             "cold_start",
             "pathway_enrichment",
             "integration",
+            "bridge_grounding",
             "temporal",
             "synthesis",
         ]
@@ -1709,8 +1710,8 @@ class TestEndToEndPhase4b:
         for node in expected_nodes:
             assert node in node_names, f"Missing node: {node}"
 
-        # Should have 9 analysis nodes + __start__
-        assert len(node_names) == 10, f"Expected 10 nodes (9 + __start__), got {len(node_names)}: {node_names}"
+        # 11 real nodes (10 + bridge_grounding) + __start__ = 12 as reported by the compiled graph.
+        assert len(node_names) == 12, f"Expected 12 nodes, got {len(node_names)}: {node_names}"
 
     @pytest.mark.asyncio
     async def test_full_pipeline_non_longitudinal(self):

--- a/docs/plans/2026-06-17-002-feat-bridge-evidence-provenance-labeler-plan.md
+++ b/docs/plans/2026-06-17-002-feat-bridge-evidence-provenance-labeler-plan.md
@@ -3,7 +3,7 @@ title: "feat: Bridge Evidence-Provenance Labeler"
 type: feat
 status: active
 date: 2026-06-17
-deepened: 2026-06-17
+deepened: 2026-06-18
 origin: backend/assessment_data/BRIDGE_GROUNDING_V2_FINDINGS.md
 ---
 
@@ -19,10 +19,19 @@ bridge gets a chain summary (e.g. "both legs curated-causal" … "text-mined onl
 label tells a researcher *what kind of evidence backs each leg*; it makes **no confidence claim**, so
 there is **no score, no LLM, and no calibration gate** (nothing to falsify).
 
+**The label drives a differential read** (its reason to exist over no-label): `curated-causal` legs point
+to a mechanistic link a curator asserted — trust it as a starting mechanism hypothesis; `text-mined` legs
+are co-mention-derived — treat as hypothesis-generating, needs literature follow-up before relying on it;
+`none` means the KG offers no direct edge — the bridge is speculative on that leg. Most discovered bridges
+will be mostly `text-mined`/`none` (only ~23% of legs are curated-causal); that is the honest signal, and
+the differential above is what makes surfacing it worthwhile rather than noise. L4 spot-checks this.
+
 This supersedes the v1 co-occurrence scorer and the v2 KG-provenance scorer, both of which failed to
 support a trustworthy per-bridge mechanism-confidence number (see origin findings). It reuses the
-committed v1 substrate (U1 model/state/contracts, the before-synthesis node-wiring design, default-off
-enablement, synthesis rendering) and the classification logic validated by the committed probes.
+committed v1 substrate (U1 model/state/contracts, the before-synthesis node-wiring *design* from the v1
+plan U5) and the classification logic validated by the committed probes. The `enabled=False` toggle and
+synthesis rendering are **new** to this work (the v1 scorer had no config toggle and never wired into
+synthesis) — see L3.
 
 ## Problem Frame
 
@@ -41,18 +50,34 @@ provenance label the data *can* support deterministically.
 - **R3.** Deterministic only — no score, no LLM, no co-occurrence retrieval, no calibration gate. → all
 - **R4.** Reuse U1 (`BridgeGrounding`/`grounded_bridges`/contracts) and the v1 plan U5 node-wiring design
   (before-synthesis, default-off, synthesis renders the label). → L2, L3
-- **R5.** Ship `enabled=False` (eval-only) until the entity-resolution wrong-namespace fix lands (label
-  accuracy depends on correct CURIEs — see the BioMapper wiki report). → L3
+- **R5.** Ship `enabled=False` and flip to enabled only after L4's validation eval (against a pre-committed
+  baseline, R5/L4) confirms the label distribution. The accuracy gate — the Tier 1 entity-resolution
+  wrong-namespace fix — **has now landed** (PR #75, merged to `dev`: category-constrained `resolve_via_api`
+  + disease intake hint), so discovered bridges resolve to correct-namespace CURIEs for the dominant cases.
+  **Honest caveat:** the within-category canonical-ranking residual (Tier 2, biomapper2, still in flight)
+  is **partially silent** — a leg resolving to a real-but-non-canonical same-category node (e.g. ICD
+  instead of MONDO) fetches *that* node's edges and may yield a `none`/`text-mined` tier indistinguishable
+  from a genuinely sparse leg. This is *why* the node ships default-off and the flip is gated on the
+  baseline-band eval rather than on Tier 1 alone; a material distribution shift is the aggregate signal for
+  the otherwise-silent residual. → L3, L4
 
 ## Scope Boundaries
 
 - Single-bridge labeling only; ordered 3-node multi-hop bridges (exclude subgraph "connecting" bridges).
 - **No** confidence score, ranking, LLM confirmation, co-occurrence retrieval, or Tier A calibration gate.
 
+- **In scope, as a separate pre-flight cleanup PR (PR-A, unit C1):** delete the superseded v1/v2 scorer
+  apparatus (`bridge_grounding/{retrieval,prompts,labeling,scoring,panel}.py` + their tests). No production
+  reader; the negative result is preserved in the findings docs, the `kg_bridge_*` probes (NOT deleted),
+  and git history. Ships **before** the feature PR (PR-B = L2 + L3) so the deletion has its own revert
+  handle and the feature diff stays focused. Sequencing it first also means L2's model change no longer
+  has the scorer modules as live constructors to worry about.
+
 ### Deferred to Separate Tasks
 
-- Entity-resolution wrong-namespace fix (the accuracy dependency) — separate BioMapper/kraken work; see
-  `docs/wiki/entity-resolution-namespace-fix.outline.md`.
+- Tier 2 within-category canonical / species ranking (MONDO-over-ICD, human/HGNC) — biomapper2, in
+  flight in parallel; `../biomapper2/AGENT-TASK-canonical-namespace-preference.md`. Not a blocker (its
+  residual is a surfaced label degradation, not a silent error).
 - Per-bridge UI-row rendering in `node_detail_extractors` (v1.1) — synthesis-report rendering is in scope.
 
 ## Context & Research
@@ -87,7 +112,8 @@ provenance label the data *can* support deterministically.
 
 - `[[bridge-grounding-v1-fails-calibration]]` — why the score was dropped (this reframe).
 - `[[biomapper2-wraps-kestrel-hgnc-marker]]` — resolution returns wrong-namespace CURIEs; the label is
-  only as good as the CURIEs, hence default-off until the resolution fix.
+  only as good as the CURIEs. Tier 1 (PR #75) cleared the cross-namespace blocker; ships `enabled=False`
+  pending L4's validation eval (Tier 2 within-category residual still in flight).
 - `[[persist-expensive-run-artifacts]]` — any eval run over real bridges auto-persists.
 
 ## Key Technical Decisions
@@ -97,12 +123,23 @@ provenance label the data *can* support deterministically.
 - **Fetch per-leg edges fresh via `one_hop_query` full mode; classify the dict edges directly.** Avoids
   extending `parse_kestrel_response` (which handles multi_hop *compact tuples*, not full-mode dicts) — no
   change to shared parsing code. The fetch returns ALL A-B edges, so "best tier over candidates" is natural.
+  **Why re-fetch (not thread integration's edges) is correct, not just convenient:** the label answers
+  *"what evidence exists between this resolved node pair?"* — a property of the pair (A,B), not of the one
+  traversal edge integration happened to pick. Re-fetching all A-B edges and taking the best tier answers
+  exactly that; same run, same CURIEs, so the view is consistent. Carrying provenance on the `Bridge` is
+  therefore a pure **cost** optimization (deferred), not a correctness fix.
 - **Static predicate-class set (the probe's), not `bmt`.** `bmt` is not a backend dependency; the static
   causal/associative/neutral set classified correctly in all three probes.
 - **Curated = `knowledge_level ∈ {knowledge_assertion, logical_entailment}` AND `agent_type ∈
   {manual_agent, manual_validation_of_automated_agent}`.** Text-mined (`agent_type=text_mining_agent` /
   `knowledge_level=not_provided`) is its own lower tier — a text-mined `causes` is NOT curated-causal.
-- **Ship default-off.** Label accuracy is gated on correct CURIEs (resolution fix); eval-only until then.
+- **Ship default-off, flip after a validation eval (not "until resolution lands" — that gate is met).**
+  The Tier 1 resolution fix has landed (PR #75), so the original blocker is cleared. The remaining
+  prudence is operational: a `bridge_grounding` node is a new in-pipeline step that adds Kestrel load
+  (two `one_hop_query` full calls per scored bridge), and Tier 2 is still in flight. So wire it
+  `enabled=False`, run L4's validation eval over real discovered bridges to confirm the label
+  distribution is sensible (not collapsed to `none`/`text-mined` from resolution residual), then flip
+  the default in a one-line follow-up. The flip is config-only — no graph surgery.
 
 ## Open Questions
 
@@ -110,13 +147,33 @@ provenance label the data *can* support deterministically.
 
 - *Where does provenance extraction live?* — In the labeler (reads one_hop-full dict edges), not
   `parse_kestrel_response`. Confirmed by the probes.
-- *How to fetch a single leg's edges?* — `one_hop_query` full mode with `start_node_ids`/`end_node_ids`
-  (multi_hop max_path_length=1 is rejected).
+- *How to fetch a single leg's edges?* — `one_hop_query` full mode with **`start_node_ids` only**, then
+  client-side filter the returned edges to those touching the target CURIE (server-side `end_node_ids` is
+  UNVERIFIED — see Context). This is what L1 shipped. (multi_hop max_path_length=1 is rejected.)
+- *L1 shipped API (verified 2026-06-18 in `bridge_grounding/provenance.py`):* `predicate_class(predicate)`,
+  `is_curated(kl, agent)`, `evidence_tier(edge: dict)` → `"curated-{class}"` | `"text-mined"`,
+  `leg_tier(curie_x, curie_y)` (async, start-only one_hop-full + client filter) → best tier | `"none"`,
+  `bridge_label(leg1_tier, leg2_tier)` → `"no KG edge"` | `"one leg unsupported"` |
+  `"both legs curated-causal"` | `"weakest leg {weaker}"`. **`leg_tier` returns only the tier string**
+  (not the winning edge's metadata) — bears on L2's LegSummary shape (below).
+- *L2 LegSummary shape (decision):* keep it **minimal** — `from_curie`, `to_curie`, `evidence_tier`.
+  L3 populates all three from `leg_tier(x, y)` (it already has x/y) with **no L1 change**. Drop the
+  richer `predicate`/`knowledge_level`/`agent_type`/`source` per-leg fields the original L2 sketched;
+  surfacing the winning edge's metadata would require extending `leg_tier`, deferred as an enrichment
+  only if synthesis rendering needs it.
+- *Enablement (decision):* default-off, flip after L4's validation eval (see R5 / Key Decisions).
+- *Superseded v1/v2 scorer modules (decision):* delete, as a separate pre-flight cleanup PR (PR-A / C1)
+  that lands before the feature PR (PR-B / L2+L3) — see Scope Boundaries and Phased Delivery.
+- *L3 wiring touch-points (verified 2026-06-18, unchanged by PR #74/#75):* `builder.py` still routes
+  `temporal`/`integration → synthesis` (no `bridge_grounding` node yet); `synthesis.py` does not read
+  `grounded_bridges`; no `BridgeGroundingConfig` exists; `protocol.total_nodes == 10`. The v1 U5 wiring
+  design applies as written.
 
 ### Deferred to Implementation
 
-- The exact chain-summary label vocabulary (e.g. how many named buckets) — settle against real bridge
-  output in L1's eval, but the per-leg tier set (R1) is fixed.
+- ~~The exact chain-summary label vocabulary~~ — **settled in L1** (`bridge_label` ships four labels:
+  `no KG edge` / `one leg unsupported` / `both legs curated-causal` / `weakest leg {weaker}`). L4's eval
+  may surface a refinement, but the vocabulary is fixed for L2/L3.
 - Whether to also persist the per-hop tier on the `Bridge` (vs re-fetch) for cost — start with re-fetch
   (simpler, matches probe); optimize only if the per-run Kestrel call count is a problem.
 
@@ -155,7 +212,7 @@ take the best tier, and compose a bridge chain-summary label.
 **Files:**
 - Create: `backend/src/kestrel_backend/bridge_grounding/provenance.py` — `predicate_class`,
   `is_curated`, `evidence_tier(edge)`, `leg_tier(curie_a, curie_b)` (async, one_hop-full fetch),
-  `bridge_label(legs)`.
+  `bridge_label(leg1_tier, leg2_tier)` (two tier strings → chain summary).
 - Test: `backend/tests/test_bridge_provenance.py`
 
 **Approach:**
@@ -185,66 +242,166 @@ test-first; the fetch (`leg_tier`) is a thin Kestrel wrapper tested with a mocke
 - Integration: `leg_tier` calls `one_hop_query` with `start_node_ids`/`mode:full` (mocked), then
   filters the returned dict edges client-side to those touching the target curie.
 
-- [ ] **L2: BridgeGrounding model adaptation (provenance label fields)**
+- [x] **C1: Pre-flight cleanup — delete superseded v1/v2 scorer modules (PR-A)**
+
+**Goal:** Remove the dead v1/v2 mechanism-scorer apparatus so the feature PR (and future readers) see one
+scoring path, not three. Ships as its own PR before L2/L3.
+
+**Requirements:** (supports R3 hygiene; no functional requirement)
+
+**Dependencies:** None. Lands first (before L2).
+
+**Files:**
+- Delete: `backend/src/kestrel_backend/bridge_grounding/{retrieval,prompts,labeling,scoring,panel}.py`.
+- Delete: `backend/tests/test_bridge_grounding_{retrieval,prompts,labeling,scoring}.py`,
+  `backend/tests/test_bridge_grounding_panel.py`.
+- Modify: `backend/src/kestrel_backend/bridge_grounding/__init__.py` — prune exports of the deleted modules.
+- Keep: `provenance.py` (L1), `__init__.py`, and the `backend/assessment_data/kg_bridge_*` probes
+  (the negative-result apparatus, incl. `kg_bridge_graded_probe.py` that produced AUC 0.61).
+
+**Approach:** Pure removal, no runtime change. **Before deleting**, grep `src/` (outside `bridge_grounding/`)
+and the whole test suite for imports of the five modules; resolve any dangling import (expected: none
+outside the deleted tests and `__init__`).
+
+**Execution note:** Mechanical deletion — no test-first; the verification is "the surviving suite imports
+and passes."
+
+**Test scenarios:**
+- `Test expectation: none` (pure deletion). Verification is the regression below.
+- Regression: full affected suite imports clean and passes after removal — no dangling import of a deleted
+  module from `__init__.py`, another test, or any `src/` module.
+
+**Verification:** The five modules + their tests are gone; `__init__.py` exports are pruned; the backend
+test suite (run affected files individually) imports and passes; no production code references the removed
+modules.
+
+- [x] **L2: BridgeGrounding model adaptation (provenance label fields)**
 
 **Goal:** Repurpose the U1 model to carry the per-leg tier + chain label instead of co-occurrence tallies.
 
 **Requirements:** R2, R4
 
-**Dependencies:** L1; reuses U1 (`BridgeGrounding`, `LegSummary`, `grounded_bridges`, contracts).
+**Dependencies:** L1; **C1 lands first** (the scorer modules that construct `BridgeGrounding`/`LegSummary`
+are gone, so the field change has no live non-test constructor to break); reuses U1
+(`BridgeGrounding`, `LegSummary`, `grounded_bridges`, contracts).
 
 **Files:**
-- Modify: `backend/src/kestrel_backend/graph/state.py` — `LegSummary` carries `from_curie`/`to_curie`/
-  `predicate`/`evidence_tier`/`knowledge_level`/`agent_type`/`source`; `BridgeGrounding` carries
-  `legs`/`label` (chain summary). **Not fully additive:** `BridgeGrounding.support_fraction` and
-  `decision` are currently **required** — to carry only `legs`+`label`, make them optional/defaulted or
-  remove them (the score is gone). The frozen-model + `model_copy` attach pattern is unchanged.
+- Modify: `backend/src/kestrel_backend/graph/state.py` — repurpose `LegSummary` to the **minimal**
+  provenance shape: `from_curie`, `to_curie`, `evidence_tier` (drop the v1 co-occurrence tally fields
+  `support`/`refute`/`neither`/`off_topic`/`dropped_co_mention`). `BridgeGrounding` carries `legs`
+  (`list[LegSummary]`, already present) + a new `label` (chain summary string). **Not fully additive:**
+  `BridgeGrounding.support_fraction` and `decision` are currently **required** v1-score fields — remove
+  them (the score is gone), along with the secondary `strong_leg_fraction`/`*_total` ranking fields. The
+  frozen-model + `model_copy` attach pattern is unchanged.
 - Test: `backend/tests/test_bridge_grounding_models.py` (rewrite U1's tests — they construct
-  `BridgeGrounding(support_fraction=…, decision=…)` and will break on the field change).
+  `BridgeGrounding(support_fraction=…, decision=…)` and `LegSummary(support=…)`, which break on the
+  field change).
 
-**Approach:** Reuse the no-reducer `grounded_bridges` key, the contracts, and the `entities`-tuple join
-from U1 unchanged. **Runtime-safe:** no production reader and none of the v1 scorer modules import
-`BridgeGrounding`/`LegSummary` (they operate on raw dicts) — the only breakage is
-`test_bridge_grounding_models.py`, rewritten here.
+**Approach:** L3 populates each `LegSummary` from L1 — `from_curie=x`, `to_curie=y`, and
+`evidence_tier = await leg_tier(x, y)` (**`leg_tier` is `async`** — the L3 node awaits it per leg and
+passes the resolved *string* into `LegSummary`; do not store the coroutine). **No change to L1's
+`leg_tier`** is needed. Reuse the no-reducer `grounded_bridges` key, the contracts, and the
+`entities`-tuple join from U1 unchanged. **Runtime-safe (verified):** `state_contracts.py`
+`BridgeGroundingOutput` references only `grounded_bridges`/`bridge_grounding_errors`/`model_usages` and
+`BridgeGroundingInput` reads `bridges` — neither touches the removed `support_fraction`/`decision`, so
+removing them does **not** break contract validation. No production reader consumes the removed fields,
+and with the v1 scorer modules already removed in C1, the only remaining `BridgeGrounding`/`LegSummary`
+constructor is `test_bridge_grounding_models.py` — rewritten here.
 
 **Test scenarios:**
-- Happy: a provenance `BridgeGrounding` (legs + label) round-trips (frozen, additive-safe serialization).
+- Happy: a provenance `BridgeGrounding` (legs of `{from_curie,to_curie,evidence_tier}` + `label`) round-trips (frozen serialization).
 - Edge: `model_copy` attach doesn't mutate the frozen original; join `grounded_bridges`→`bridges` by `entities`.
+- Edge: constructing `BridgeGrounding` without the removed `support_fraction`/`decision` succeeds (fields gone, not just optional).
 
-- [ ] **L3: `bridge_grounding` node + wiring + synthesis rendering**
+- [x] **L3: `bridge_grounding` node + wiring + synthesis rendering**
 
 **Goal:** A `bridge_grounding` node that labels ordered 3-node bridges and attaches `grounded_bridges`;
 wired before synthesis; default-off; synthesis renders the per-bridge label.
 
 **Requirements:** R3, R4, R5
 
-**Dependencies:** L1, L2; reuses the v1 plan U5 wiring design.
+**Dependencies:** L1, L2 (and C1 already merged); reuses the v1 plan U5 wiring design.
 
 **Files:**
 - Create: `backend/src/kestrel_backend/graph/nodes/bridge_grounding.py` (`@validate_state`; ordered-3-node
-  + exclude-subgraph filter; per-bridge `bridge_label` via L1; returns `grounded_bridges` +
+  + exclude-subgraph filter via `predicate_directions != []`; per-bridge: `leg_tier` per leg → build
+  `LegSummary`s → `bridge_label` → attach `BridgeGrounding` via `model_copy`; returns `grounded_bridges` +
   `bridge_grounding_errors`; best-effort, never throws).
-- Modify: `backend/src/kestrel_backend/graph/builder.py` (reroute `temporal`/`integration →
-  bridge_grounding → synthesis`, full graph only; leave post-synthesis `literature_grounding`).
-- Modify: `backend/src/kestrel_backend/graph/pipeline_config.py` (`BridgeGroundingConfig`,
-  `enabled=False` default, per-leg fetch limit, exclude-subgraph flag — mirror `IntegrationConfig`).
+- Modify: `backend/src/kestrel_backend/graph/builder.py` — synthesis has **two** inbound edges that must
+  **both** be redirected through the new node, or one study type bypasses it:
+  1. the conditional non-longitudinal path: in `route_after_integration`'s map, change the `"synthesis"`
+     target to `"bridge_grounding"`;
+  2. the longitudinal path: change `add_edge("temporal", "synthesis")` to `add_edge("temporal",
+     "bridge_grounding")`;
+  3. add `add_edge("bridge_grounding", "synthesis")`.
+  Full graph only; leave post-synthesis `literature_grounding`. *(Verified 2026-06-18: current wiring is
+  `integration → temporal|synthesis` via `route_after_integration` + `temporal → synthesis`; no
+  bridge_grounding node present. Redirecting only one path would silently skip the node for the other
+  study type.)*
+- Modify: `backend/src/kestrel_backend/graph/pipeline_config.py` (add `BridgeGroundingConfig` —
+  `enabled=False` default + per-leg/`max_scored_bridges` fetch limit; exclude-subgraph is a fixed
+  requirement, not a toggle — mirror `IntegrationConfig`; none exists today).
 - Modify: `backend/src/kestrel_backend/graph/nodes/synthesis.py` (read `grounded_bridges`, render the
-  per-bridge provenance label).
+  per-bridge provenance label; verified it does not read `grounded_bridges` today).
 - Modify: `backend/src/kestrel_backend/protocol.py` (add `NODE_STATUS_MESSAGES["bridge_grounding"]`;
-  `total_nodes` 10→11).
+  `total_nodes` 10→11; verified `total_nodes == 10`).
 - Test: `backend/tests/test_bridge_grounding_node.py` (sys.modules stub harness, per v1 plan U5).
 
 **Approach:** Mirror the v1 plan U5 wiring decisions (substrate-independent); the node calls L1's
-`bridge_label` per bridge instead of any scorer. Per-bridge isolation: a Kestrel failure on one bridge
-degrades it (label `none`/error in `bridge_grounding_errors`), node still returns.
+`leg_tier` + `bridge_label` per bridge instead of any scorer. Per-bridge isolation: a Kestrel failure on
+one bridge degrades it (label `none`/error in `bridge_grounding_errors`), node still returns. Ship
+`enabled=False` (flip is L4, config-only). The dead-scorer deletion is **not** here — it shipped in C1.
 
 **Test scenarios:**
-- Happy: a 3-node bridge with curated-causal legs → label attached, "both legs curated-causal".
-- Edge: `enabled=False` short-circuits (no Kestrel calls); skips subgraph/2-node/4+-node bridges.
+- Happy: a 3-node bridge with curated-causal legs → `BridgeGrounding` attached, label "both legs curated-causal".
+- Edge: `enabled=False` short-circuits (no Kestrel calls); skips subgraph/2-node/4+-node bridges (`predicate_directions == []`).
 - Error: a `one_hop_query` failure on one bridge → that bridge labeled `none` + `bridge_grounding_errors`
   entry, node still returns.
-- Integration: rewired graph routes through the node; `total_nodes`/`NODE_STATUS_MESSAGES` updated;
-  synthesis renders the label; disabled = no-op.
+- Integration (both study types): the rewired graph routes through `bridge_grounding` on **both** the
+  longitudinal path (via `temporal`) and the non-longitudinal path (via `route_after_integration`) — assert
+  the node runs in each, not just one; `total_nodes`/`NODE_STATUS_MESSAGES` updated; synthesis renders the
+  label; disabled = no-op.
+
+- [ ] **L4: Validation eval over real bridges + enablement flip (follow-up)**
+
+**Goal:** Confirm the labeler produces a sensible label distribution on real, now-correctly-resolved
+bridges, then flip the node default to `enabled=True`.
+
+**Requirements:** R5
+
+**Dependencies:** L3 (the wired node must exist). May run after L3 merges; the flip is a separate small change.
+
+**Files:**
+- Create/extend: an eval runner over real discovered bridges (reuse the `kg_bridge_leg_probe` harness in
+  `backend/assessment_data/`) — auto-persists results (per `[[persist-expensive-run-artifacts]]`).
+- Modify (the flip, follow-up): `backend/src/kestrel_backend/graph/pipeline_config.py`
+  (`BridgeGroundingConfig.enabled` default `False → True`).
+
+**Approach:** Run the labeler over a representative set of real discovery-pipeline bridges (post-PR #75
+resolution). The honest expected distribution is **already** skewed `text-mined`/`none` (only ~23% of
+legs are curated-causal), so "not all-`none`" is **not** a usable gate — Tier-2 residual would void *some*
+legs and shift the distribution toward `none` without collapsing it, landing in the indistinguishable
+middle. So the go/no-go must be **pre-committed against a reference baseline, not eyeballed:**
+- **Reference:** record the curated-causal / curated-* / text-mined / none **leg-fraction** from the
+  committed `kg_bridge_leg_probe` baseline (the ~23% curated-causal figure) as the expected healthy shape.
+- **Go criterion:** the live curated-causal leg-fraction over the sampled bridges falls within a
+  pre-committed tolerance band of that baseline; a material drop below the band signals resolution residual
+  voiding legs → **hold the flip / wait for Tier 2** (the exact band % is set when L4 runs, against the
+  recorded baseline).
+- **Usefulness spot-check (not just frequency):** on a small hand-picked sample, confirm the label changes
+  interpretation — a `curated-causal` leg points to a different researcher action than a `text-mined`/`none`
+  one (see Overview). A label that only ever restates "the KG is sparse here" earns no place in the report.
+This is a **sanity check, not a calibration gate** (no confidence claim to validate) — but the go decision
+is decidable against the pre-committed baseline, not a hindsight read.
+
+**Execution note:** This is eval tooling + a one-line config change, not a test-bearing feature unit.
+
+**Test scenarios:**
+- `Test expectation: none` — eval tooling (runnable harness) + a config-default change; covered by L3's
+  node tests for behavior. The eval's output is a persisted artifact, not an assertion.
+
+**Verification:** A persisted label-distribution artifact over real bridges, and (on a go decision) the
+`enabled` default flipped with the node observably running in a discovery run.
 
 ## System-Wide Impact
 
@@ -252,55 +409,62 @@ degrades it (label `none`/error in `bridge_grounding_errors`), node still return
   (2 `one_hop_query` full calls per scored bridge) — bounded by `max_scored_bridges`; node default-off.
 - **Error propagation:** per-bridge isolation → label `none` + `bridge_grounding_errors`; node never throws.
 - **State lifecycle:** `grounded_bridges` no-reducer key, single writer before synthesis reads it (U1).
-- **Unchanged invariants:** `Bridge`/`grounded_bridges`/contracts stay backward-compatible (field swap on
-  existing optional `BridgeGrounding`); `parse_kestrel_response` untouched (labeler reads one_hop dicts).
+- **Unchanged invariants:** `Bridge`, the `grounded_bridges`/`bridge_grounding_errors` state keys, and the
+  contracts registry stay intact; `parse_kestrel_response` untouched (labeler reads one_hop dicts). The
+  `BridgeGrounding`/`LegSummary` **field set changes** (remove v1 score/tally fields, add `label`/minimal
+  legs) — safe because the only constructors are the v1 scorer modules (deleted first in C1/PR-A) and the
+  rewritten model tests; no production reader consumes the removed fields, and `state_contracts` validators
+  don't reference them (verified).
 
 ## Risks & Dependencies
 
 | Risk | Mitigation |
 |------|------------|
-| Label accuracy depends on correct CURIEs; resolution returns wrong-namespace CURIEs | Ship `enabled=False`; gate production enablement on the entity-resolution fix (BioMapper wiki report); a mis-resolved leg labels `none`, surfaced honestly |
+| Label accuracy depends on correct CURIEs | Tier 1 fix landed (PR #75) — the dominant wrong-namespace cases (disease→pathway → zero edges) are fixed. Residual Tier 2 mis-ranking (non-canonical same-category node) is **partially silent**: a mis-resolved leg looks identical to a genuinely sparse one. Ship `enabled=False`; L4's **baseline-band** eval (live curated-causal leg-fraction vs the committed `kg_bridge_leg_probe` baseline) is the aggregate detector that gates the flip — not "not all-`none`", which the expected sparse distribution would always pass |
 | Most real bridges label `text-mined`/`none` (only ~23% legs curated-causal) | This is the honest, intended behavior — the label reports what evidence exists; it does not claim mechanism. Not a bug |
-| Per-leg `one_hop_query` full fetches add Kestrel load | Bounded by `max_scored_bridges` + default-off; optimize to carry provenance on the `Bridge` (deferred) only if needed |
-| Chain-summary label vocabulary churns | Settle the vocabulary in L1 against real bridge output before wiring L3 |
+| Per-leg `one_hop_query` full fetches add Kestrel load (2 full-mode calls × N scored bridges per run) | Bounded by a `max_scored_bridges` cap + default-off; **set a concrete cap and a per-call edge `limit` in `BridgeGroundingConfig`** (mirror `IntegrationConfig`'s bounds) so the load ceiling is explicit, not implied; optimize to carry provenance on the `Bridge` (deferred) only if the cap proves too tight |
+| Deleting the v1/v2 scorer modules breaks an unnoticed import | C1 (PR-A) greps `src/` (outside `bridge_grounding/`) and the test suite for imports of the five modules before removal, and verifies the surviving suite imports clean; isolating it as its own PR gives the deletion an independent revert handle |
 
 ## Phased Delivery
 
-The entity-resolution fix is a hard accuracy blocker with no committed timeline, and the node ships
-default-off, so the in-pipeline node (L3) buys nothing observable until that fix lands. Sequence
-accordingly so value ships now without premature graph surgery:
+The original accuracy blocker (the entity-resolution wrong-namespace fix) **has landed** — PR #75
+(Tier 1: category-constrained `resolve_via_api` + disease intake hint), merged to `dev`. Phase 1 (L1)
+shipped in PR #74. So this pass delivers the in-pipeline node, gated by a validation eval rather than by
+the resolution fix.
 
-### Phase 1 (now) — L1 only: the deterministic labeler + eval
-Build L1 (the pure `evidence_tier`/`predicate_class`/`bridge_label` classifiers + the per-leg
-`leg_tier` fetch) and run it as **eval tooling** over real discovered bridges (reuse the
-`kg_bridge_leg_probe` harness) to confirm the label distribution is sensible. This delivers the honest
-provenance signal immediately, with zero changes to the production graph, the state model, or synthesis.
+### Phase 1 (DONE) — L1: the deterministic labeler
+Shipped in PR #74 (commit 3885f05): the pure `evidence_tier`/`predicate_class`/`bridge_label` classifiers
++ the per-leg `leg_tier` fetch, 30 unit tests, eval-only.
 
-### Phase 2 (gated on the resolution fix being in a known release) — L2 + L3
-Adapt the model (L2) and wire the node + synthesis rendering + enablement (L3) only once the resolution
-fix is landing, since the in-pipeline label is both useless and inaccurate before then. **Trigger:** the
-biomapper/kraken resolution fix (`docs/wiki/entity-resolution-namespace-fix.outline.md`) is merged and
-verified; until then L2/L3 stay unbuilt rather than wired-but-disabled. Trim `BridgeGroundingConfig` to
-what actually varies at runtime (`enabled`, per-leg fetch limit) — the exclude-subgraph behavior is a
-fixed requirement, not a toggle.
+### Phase 2 (now) — two PRs off fresh branches from `dev`
+- **PR-A (C1): pre-flight cleanup** — delete the superseded v1/v2 scorer modules + tests. Pure removal, no
+  runtime change, trivial to review/revert; lands first.
+- **PR-B (L2 + L3): the feature** — minimal model adaptation (L2) + the `bridge_grounding` node, graph
+  rewiring (both inbound synthesis edges), synthesis rendering, and `enabled=False` (L3). Built on top of
+  PR-A. (The old `feat/bridge-grounding-scorer` branch merged in PR #74; both PRs start fresh from `dev`.)
 
-**Superseded-apparatus cleanup:** the v1 (U0–U4 + harness) and v2 (superseded) scorer code remains on
-the branch as the negative-result record. Decide its disposition when this work goes to a PR against
-`dev` — either delete the scorer/LLM/co-occurrence modules (`bridge_grounding/{retrieval,prompts,
-labeling,scoring,panel}.py` + their tests) or keep them explicitly as eval-only, so a reviewer is not
-left navigating three scoring paths.
+### Phase 3 (follow-up) — L4: validation eval + enablement flip
+Run the labeler over real, now-correctly-resolved bridges; confirm the label distribution is sensible
+(skewed `text-mined`/`none` is expected and honest; an all-`none` collapse is the signal to hold the flip
+/ wait on Tier 2). On a go decision, flip `BridgeGroundingConfig.enabled` default to `True` in a one-line
+follow-up. Tier 2 (biomapper2 within-category canonical ranking) is in flight in parallel and tightens
+label fidelity further, but is not required for the flip.
 
 ## Documentation / Operational Notes
 
-- Node ships `enabled=False` (eval-only) until the resolution fix lands.
-- An optional eval over real discovered bridges (reuse the `kg_bridge_leg_probe` harness) can sanity-check
-  the label distribution — this is a *sanity check, not a calibration gate* (no confidence claim to validate).
+- Node ships `enabled=False`; the flip to `True` (L4) is a one-line `pipeline_config` change gated on the
+  validation eval, not on further graph work.
+- L4's eval over real discovered bridges (reuse the `kg_bridge_leg_probe` harness) sanity-checks the label
+  distribution — a *sanity check, not a calibration gate* (no confidence claim to validate).
 
 ## Sources & References
 
 - **Origin document:** `backend/assessment_data/BRIDGE_GROUNDING_V2_FINDINGS.md`
-- Probes (the logic to productionize): `backend/assessment_data/kg_bridge_leg_probe.py`,
+- Probes (the logic productionized in L1): `backend/assessment_data/kg_bridge_leg_probe.py`,
   `kg_provenance_probe.py`, `kg_bridge_graded_probe.py`
 - v1 plan (reused U1 model + U5 wiring design): `docs/plans/2026-06-08-002-feat-bridge-grounding-scorer-plan.md`
-- Resolution dependency: `docs/wiki/entity-resolution-namespace-fix.outline.md`
-- Branch: `feat/bridge-grounding-scorer` (v1 U0–U4 + harness committed; v2 scorer superseded).
+- Accuracy dependency (LANDED): `docs/wiki/entity-resolution-namespace-fix.outline.md`; Tier 1 = PR #75
+  (`docs/plans/2026-06-17-003-feat-entity-resolution-category-filter-plan.md`), merged to `dev`.
+- Tier 2 (parallel, biomapper2): `../biomapper2/AGENT-TASK-canonical-namespace-preference.md`.
+- L1 shipped in PR #74 (branch `feat/bridge-grounding-scorer`, since merged to `dev`). **L2/L3/L4 start
+  from a fresh branch off `dev`** — the old scorer branch is merged and gone.


### PR DESCRIPTION
## Summary

Feature PR (**PR-B**) for the bridge evidence-provenance labeler (plan `docs/plans/2026-06-17-002-feat-bridge-evidence-provenance-labeler-plan.md`, units L2 + L3). Builds on PR-A (#76, the dead-scorer cleanup) and L1 (#74, the deterministic classifier). Attaches a deterministic per-bridge **evidence-provenance label** — `curated-causal` / `curated-associative` / `curated-neutral` / `text-mined` / `none` per leg, with a chain summary per bridge — to discovered 3-node bridges, rendered in the synthesis report. No score, no LLM, no calibration gate.

**Ships `enabled=False`** (no-op, no Kestrel calls). The flip to on is **L4**, a one-line follow-up gated on a validation eval over real bridges.

## L2 — minimal provenance model (`graph/state.py`)

- `LegSummary` → `{from_curie, to_curie, evidence_tier}` (dropped the v1 co-occurrence tally fields).
- `BridgeGrounding` → `{legs, label}` (removed the required v1 score/verdict fields `support_fraction`/`decision`/…).
- Safe: `state_contracts` reference only `grounded_bridges`/`bridge_grounding_errors`/`model_usages`; the only other constructors (the v1 scorer modules) were removed in PR-A.

## L3 — node + wiring + rendering

- **New `graph/nodes/bridge_grounding.py`**: selects ordered 3-node multi-hop bridges (`predicate_directions != []`), labels each leg via L1 `leg_tier`, composes the chain label via `bridge_label`, attaches `BridgeGrounding` to `grounded_bridges`. Best-effort — per-bridge error isolation, never throws.
- **`builder.py`**: routes **both** inbound synthesis paths through the node — the non-longitudinal conditional (`integration → bridge_grounding`) **and** the longitudinal edge (`temporal → bridge_grounding`) → `synthesis` — so neither study type bypasses it.
- **`pipeline_config.py`**: `BridgeGroundingConfig` (`enabled=False` default + `max_scored_bridges` cap bounding the added Kestrel load).
- **`synthesis.py`**: `format_bridges` renders the per-bridge provenance label (joined from `grounded_bridges` by entities tuple).
- **`protocol.py`**: `total_nodes` 10 → 11; `NODE_STATUS_MESSAGES` entry.

## Tests

- L2: rewritten `test_bridge_grounding_models.py` (minimal shape, removed-field guards, frozen, roundtrip, contracts).
- L3: new `test_bridge_grounding_node.py` (default-off no-op, labeling, 3-node/subgraph/2-node/4-node filtering, max-scored cap, per-bridge error isolation, **both-study-type graph routing**, synthesis rendering).
- Fixed a **pre-existing** stale graph-node-count assertion in `test_langgraph_prototype.py` (asserted 10; base was already 11; now 12 with the new node).
- **No new regressions:** the `test_websocket_routing` failures are pre-existing (verified identical on base via `git stash`); the `test_langgraph_prototype` synthesis-contract failures are likewise pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
