### PR TITLE
feat(bridge-grounding): enable the evidence-provenance node (L4)

### DIFF
--- a/backend/assessment_data/bridge_grounding_eval.py
+++ b/backend/assessment_data/bridge_grounding_eval.py
@@ -1,0 +1,93 @@
+"""L4 — validation eval: the PRODUCTION evidence-provenance labeler over real discovered bridges.
+
+Reuses kg_bridge_leg_probe's bridge discovery (canonical endpoint pairs A→C, multi_hop_query
+max_path_length=2) to obtain real [A, B, C] bridges, then runs the *production* labeler
+(src.kestrel_backend.bridge_grounding.provenance.leg_tier + bridge_label) over each bridge's legs —
+exactly what the bridge_grounding node emits in the pipeline.
+
+Records the per-bridge chain-label distribution, the per-leg evidence-tier distribution, and the
+curated-causal leg fraction, and compares the latter to the kg_bridge_leg_probe baseline (~23%).
+This is a SANITY CHECK, not a calibration gate: the go signal for flipping the node enabled=True is a
+sensible (non-collapsed) distribution whose curated-causal leg fraction sits near the baseline — a
+material drop toward all-`none` would signal resolution residual voiding legs (hold the flip).
+
+The endpoints are hand-verified canonical CURIEs (MONDO/CHEBI/…) — i.e. exactly what Tier 1 (PR #75)
++ Tier 2 (biomapper2) resolution now produce — so this isolates the LABELER's behavior given correct
+resolution. Resolution quality itself is validated separately in those PRs.
+
+Persists a timestamped JSON artifact by default (expensive/live-run SOP).
+Usage: PYTHONPATH=. uv run python assessment_data/bridge_grounding_eval.py
+"""
+
+import asyncio
+import collections
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from assessment_data.kg_bridge_leg_probe import ENDPOINTS, bridges_for  # noqa: E402
+
+from src.kestrel_backend.bridge_grounding.provenance import bridge_label, leg_tier  # noqa: E402
+
+MAX_BRIDGES_PER_PAIR = 3  # bound the per-leg one_hop fetches (2 per bridge); leg_tier is heavy
+
+
+async def main():
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    out = {
+        "timestamp": stamp,
+        "note": "production labeler over real discovered bridges; canonical endpoints",
+        "max_bridges_per_pair": MAX_BRIDGES_PER_PAIR,
+        "endpoints": [],
+        "chain_labels": collections.Counter(),
+        "leg_tiers": collections.Counter(),
+    }
+    total_legs = cc_legs = 0
+    print(f"{'kind':5} {'endpoint':24} {'#br':4} chain labels")
+    print("-" * 100)
+    for label, a, c, kind in ENDPOINTS:
+        try:
+            paths, _edges, err = await bridges_for(a, c)
+        except Exception as ex:
+            print(f"{kind:5} {label:24} ERR {str(ex)[:50]}")
+            continue
+        if err or not paths:
+            print(f"{kind:5} {label:24} no-paths")
+            out["endpoints"].append({"label": label, "kind": kind, "bridges": 0})
+            continue
+        ep_labels = collections.Counter()
+        for path in paths[:MAX_BRIDGES_PER_PAIR]:
+            a0, b0, c0 = path
+            t1 = await leg_tier(a0, b0)
+            t2 = await leg_tier(b0, c0)
+            chain = bridge_label(t1, t2)
+            ep_labels[chain] += 1
+            out["chain_labels"][chain] += 1
+            out["leg_tiers"][t1] += 1
+            out["leg_tiers"][t2] += 1
+            total_legs += 2
+            cc_legs += int(t1 == "curated-causal") + int(t2 == "curated-causal")
+        out["endpoints"].append({
+            "label": label, "kind": kind, "bridges": sum(ep_labels.values()),
+            "chain_labels": dict(ep_labels)})
+        print(f"{kind:5} {label:24} {sum(ep_labels.values()):<4} {dict(ep_labels)}", flush=True)
+
+    print("-" * 100)
+    pct = (100 * cc_legs / total_legs) if total_legs else 0
+    out["curated_causal_legs"] = f"{cc_legs}/{total_legs}"
+    out["curated_causal_leg_pct"] = round(pct, 1)
+    out["chain_labels"] = dict(out["chain_labels"])
+    out["leg_tiers"] = dict(out["leg_tiers"])
+    print(f"curated-causal LEG fraction: {cc_legs}/{total_legs} ({pct:.0f}%)  [baseline ~23%]")
+    print(f"per-leg tier distribution:   {out['leg_tiers']}")
+    print(f"per-bridge chain labels:     {out['chain_labels']}")
+
+    rundir = Path(__file__).parent / "bridge_grounding_eval_runs"
+    rundir.mkdir(exist_ok=True)
+    art = rundir / f"{stamp}.json"
+    art.write_text(json.dumps(out, indent=2))
+    print(f"artifact: {art}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/src/kestrel_backend/graph/pipeline_config.py
+++ b/backend/src/kestrel_backend/graph/pipeline_config.py
@@ -247,10 +247,12 @@ class BridgeGroundingConfig(BaseModel):
     """Configuration for the bridge_grounding node (deterministic evidence-provenance labeler)."""
 
     enabled: bool = Field(
-        default=False,
-        description="Ship default-off (eval-only). Flip to True is a one-line follow-up gated on "
-        "L4's validation eval over real bridges (docs/plans/2026-06-17-002-feat-bridge-evidence-"
-        "provenance-labeler-plan.md). When False the node is a no-op (no Kestrel calls).",
+        default=True,
+        description="Enabled (L4 flip, 2026-06-18). The L4 validation eval over real bridges passed: "
+        "no all-`none` collapse and a 33% curated-causal leg fraction (>= the ~23% baseline) under "
+        "correct Tier 1 + Tier 2 resolution — see assessment_data/bridge_grounding_eval.py and "
+        "docs/plans/2026-06-17-002-feat-bridge-evidence-provenance-labeler-plan.md. When False the "
+        "node is a no-op (no Kestrel calls).",
     )
     max_scored_bridges: int = Field(
         default=20,

--- a/backend/tests/test_bridge_grounding_node.py
+++ b/backend/tests/test_bridge_grounding_node.py
@@ -39,12 +39,19 @@ def _stub_leg_tier(monkeypatch, tier="curated-causal", calls=None):
 # --- default-off no-op -----------------------------------------------------------------
 
 async def test_disabled_is_noop(monkeypatch):
-    # Default config is enabled=False; the node must do nothing and call no Kestrel.
+    # When disabled, the node must do nothing and call no Kestrel.
+    _enable(monkeypatch, enabled=False)
     async def boom(*a, **k):
         raise AssertionError("leg_tier must not be called when disabled")
     monkeypatch.setattr(bridge_grounding, "leg_tier", boom)
     out = await bridge_grounding.run({"bridges": [_bridge()]})
     assert out == {}
+
+
+def test_node_enabled_by_default():
+    # L4 flip: the node now ships enabled=True (validation eval passed 2026-06-18).
+    from kestrel_backend.graph.pipeline_config import BridgeGroundingConfig
+    assert BridgeGroundingConfig().enabled is True
 
 
 # --- happy path ------------------------------------------------------------------------

--- a/docs/plans/2026-06-17-002-feat-bridge-evidence-provenance-labeler-plan.md
+++ b/docs/plans/2026-06-17-002-feat-bridge-evidence-provenance-labeler-plan.md
@@ -362,7 +362,7 @@ one bridge degrades it (label `none`/error in `bridge_grounding_errors`), node s
   the node runs in each, not just one; `total_nodes`/`NODE_STATUS_MESSAGES` updated; synthesis renders the
   label; disabled = no-op.
 
-- [ ] **L4: Validation eval over real bridges + enablement flip (follow-up)**
+- [x] **L4: Validation eval over real bridges + enablement flip (follow-up)**
 
 **Goal:** Confirm the labeler produces a sensible label distribution on real, now-correctly-resolved
 bridges, then flip the node default to `enabled=True`.


### PR DESCRIPTION
## Summary

L4 (final unit) of the bridge evidence-provenance labeler: **flip `BridgeGroundingConfig.enabled` `False` → `True`** so the `bridge_grounding` node (merged in PR #77, default-off) now labels discovered bridges in every full-graph run. Plan: `docs/plans/2026-06-17-002-feat-bridge-evidence-provenance-labeler-plan.md`.

## Validation eval (the go gate)

Built `assessment_data/bridge_grounding_eval.py` — runs the **production** labeler (`provenance.leg_tier` + `bridge_label`) over real discovered bridges (canonical endpoint pairs spanning mechanisms + controls, discovered via `multi_hop_query`, under Tier 1 (PR #75) + Tier 2 (biomapper2, now live) resolution). Result over **24 bridges / 48 legs**:

| Signal | Result | Verdict |
|---|---|---|
| All-`none` collapse? | **zero** `none` legs / "no KG edge" labels | ✅ no resolution-residual voiding |
| curated-causal leg fraction | **33%** (16/48) vs ~23% baseline | ✅ at/above the healthy band |
| Distribution | curated-neutral 20 · curated-causal 16 · curated-associative 10 · text-mined 2 | ✅ sensible, differentiated |

Per-bridge labels: `weakest leg curated-neutral` ×20, `both legs curated-causal` ×3 (metformin~T2D, imatinib~CML), `weakest leg text-mined` ×1. Artifact committed: `assessment_data/bridge_grounding_eval_runs/20260618T175046Z.json`.

(The labeler reports *what evidence exists*, not *is this a real mechanism* — so mechanism vs control endpoints don't separate, which is correct for the deterministic-label reframe.)

## Behavior change

- The node now runs in every full-graph discovery: 2 `one_hop_query` full calls per scored bridge, bounded by `max_scored_bridges=20`; best-effort per-bridge error isolation; never throws. Synthesis reports gain the per-bridge **Evidence provenance** line.
- `test_disabled_is_noop` updated to disable explicitly (no longer relies on the default); added a default-enabled assertion.

## Tests

- 42 bridge/config/model tests pass; the graph-execution test files (`test_runner_config`, `test_assessment_capture`, `test_assessment_runner`) pass after the flip (the node degrades gracefully when Kestrel is mocked/absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)