### PR TITLE
Fix/validated bridge provenance

### DIFF
--- a/backend/src/kestrel_backend/bridge_grounding/provenance.py
+++ b/backend/src/kestrel_backend/bridge_grounding/provenance.py
@@ -80,25 +80,51 @@ def _parse_full_edges(resp: Any) -> list[dict[str, Any]]:
     return [e for e in values if isinstance(e, dict)]
 
 
+# one_hop_query edge cap. If a node returns this many edges the result is likely TRUNCATED, so a
+# missing X–Y edge may simply lie beyond the cap (a hub-node false 'none').
+_LEG_EDGE_LIMIT = 3000
+
+
+async def _leg_edges_from(curie_start: str) -> tuple[list[dict[str, Any]], bool]:
+    """Full one-hop edges from a node + whether the result was likely truncated. Best-effort."""
+    try:
+        resp = await call_kestrel_tool(
+            "one_hop_query", {"start_node_ids": curie_start, "mode": "full", "limit": _LEG_EDGE_LIMIT})
+    except Exception as e:  # best-effort: a Kestrel failure on one leg → no edges
+        logger.warning("bridge provenance: one_hop_query failed for %s: %s", curie_start, e)
+        return [], False
+    edges = _parse_full_edges(resp)
+    return edges, len(edges) >= _LEG_EDGE_LIMIT
+
+
+def _best_tier(edges: list[dict[str, Any]], other_curie: str) -> str:
+    """Best evidence tier over edges that touch other_curie, or 'none'."""
+    best = "none"
+    for edge in edges:
+        if other_curie not in (edge.get("subject"), edge.get("object")):
+            continue
+        tier = evidence_tier(edge)
+        if TIER_RANK[tier] > TIER_RANK[best]:
+            best = tier
+    return best
+
+
 async def leg_tier(curie_x: str, curie_y: str) -> str:
     """Best evidence tier over the X–Y edges, or 'none' if there is no edge.
 
     Fetches one_hop_query from X in full mode (the proven probe call — start-only, NOT end_node_ids),
     then filters client-side to edges that also touch Y. Best-effort: returns 'none' on any failure.
+
+    Hub guard: if X is a high-degree node its edge list may be truncated at the cap, so the true X–Y
+    edge can lie beyond it (a false 'none' that mislabels a well-supported bridge). When the X fetch
+    is truncated AND no X–Y edge is found, retry from Y (often the lower-degree endpoint) before
+    concluding 'none'. Both-hub bridges can still miss, but that is rare and degrades conservatively.
     """
-    try:
-        resp = await call_kestrel_tool(
-            "one_hop_query", {"start_node_ids": curie_x, "mode": "full", "limit": 3000})
-    except Exception as e:  # best-effort: a Kestrel failure on one leg → 'none'
-        logger.warning("bridge provenance: one_hop_query failed for %s: %s", curie_x, e)
-        return "none"
-    best = "none"
-    for edge in _parse_full_edges(resp):
-        if curie_y not in (edge.get("subject"), edge.get("object")):
-            continue
-        tier = evidence_tier(edge)
-        if TIER_RANK[tier] > TIER_RANK[best]:
-            best = tier
+    edges_x, truncated_x = await _leg_edges_from(curie_x)
+    best = _best_tier(edges_x, curie_y)
+    if best == "none" and truncated_x:
+        edges_y, _ = await _leg_edges_from(curie_y)
+        best = _best_tier(edges_y, curie_x)
     return best
 
 

--- a/backend/src/kestrel_backend/graph/nodes/hypothesis_extraction.py
+++ b/backend/src/kestrel_backend/graph/nodes/hypothesis_extraction.py
@@ -98,6 +98,11 @@ async def validate_bridge_hypotheses(bridges: list[Bridge]) -> list[Bridge]:
                     entities=bridge.entities,
                     entity_names=bridge.entity_names,
                     predicates=bridge.predicates,
+                    # Carry predicate_directions through the upgrade: bridge_grounding._is_scoreable
+                    # gates on a truthy predicate_directions, so dropping it here would silently
+                    # exclude exactly the KG-validated bridges (the most confidently confirmed ones)
+                    # from provenance labeling.
+                    predicate_directions=bridge.predicate_directions,
                     tier=2,  # UPGRADED
                     novelty="known",  # Now verified in KG
                     significance=bridge.significance + " [KG-validated]",

--- a/backend/src/kestrel_backend/graph/nodes/synthesis.py
+++ b/backend/src/kestrel_backend/graph/nodes/synthesis.py
@@ -444,6 +444,12 @@ def format_bridges(
 
     labels = grounding_labels or {}
 
+    # Initialise `lines` BEFORE the _render closure that appends to it: the closure captures it by
+    # reference, so defining the list first keeps the dependency obvious and avoids an UnboundLocalError
+    # if a future refactor ever calls _render before this point.
+    lines = ["## Cross-Type Bridges\n"]
+    lines.append("*Multi-hop paths connecting different entity types across the analysis.*\n")
+
     def _render(b: Bridge, show_predicates: bool) -> None:
         # show_predicates preserves the original behavior: Tier 2 lists per-hop predicates,
         # Tier 3 (speculative) deliberately omits them.
@@ -463,9 +469,6 @@ def format_bridges(
         label = labels.get(tuple(b.entities))
         if label:
             lines.append(f"  - **Evidence provenance**: {label}")
-
-    lines = ["## Cross-Type Bridges\n"]
-    lines.append("*Multi-hop paths connecting different entity types across the analysis.*\n")
 
     # Separate by tier
     tier2 = [b for b in bridges if b.tier == 2]

--- a/backend/src/kestrel_backend/kestrel_client.py
+++ b/backend/src/kestrel_backend/kestrel_client.py
@@ -541,12 +541,15 @@ def parse_kestrel_response(envelope: dict[str, Any]) -> dict[str, Any]:
         if isinstance(end_id, str) and end_id and end_id not in seen_ends:
             seen_ends.add(end_id)
             end_node_ids.append(end_id)
-        # Scope edges to this result's edge_ids when resolvable, else scan all edges.
+        # Scope edges to this result's edge_ids when present. If edge_ids are specified but none
+        # resolve in norm_edges, do NOT fall back to all edges — in a multi-result response that
+        # borrows edges from other results and mis-attributes predicates/directions to this path's
+        # hops. Use the (possibly empty) scoped set instead; _hop_predicates then emits {None, None}
+        # for unresolved hops (honest "unknown") rather than a wrong predicate. Only when there is no
+        # edge_ids scoping at all do we scan the full edge map.
         eids = res.get("edge_ids")
         if isinstance(eids, list) and eids:
             cand = [norm_edges[str(eid)] for eid in eids if str(eid) in norm_edges]
-            if not cand:
-                cand = list(edges.values())
         else:
             cand = list(edges.values())
         tmap = _triple_map(cand)

--- a/backend/tests/test_bridge_provenance.py
+++ b/backend/tests/test_bridge_provenance.py
@@ -123,6 +123,47 @@ async def test_leg_tier_filters_to_target(monkeypatch):
     assert await leg_tier("A", "B") == "none"
 
 
+async def test_leg_tier_retries_from_other_endpoint_on_truncation(monkeypatch):
+    # Hub guard: X's edge list is TRUNCATED (hits the cap) with no A-B edge, so the true A-B edge
+    # may lie beyond the cap. The retry from B (lower-degree) finds the curated edge -> labeled,
+    # not a false 'none'. (Greptile PR #79 fix.)
+    import json
+    monkeypatch.setattr(provenance, "_LEG_EDGE_LIMIT", 2)
+    ab_edge = _edge("biolink:causes", "knowledge_assertion", "manual_agent", "A", "B")
+
+    class _DirectionalFake:
+        def __init__(self):
+            self.calls = []
+
+        async def __call__(self, tool, args):
+            start = args.get("start_node_ids")
+            self.calls.append(start)
+            if start == "A":  # hub: truncated (== cap) and no A-B edge
+                edges = [
+                    _edge("biolink:related_to", "not_provided", "text_mining_agent", "A", "Z1"),
+                    _edge("biolink:related_to", "not_provided", "text_mining_agent", "A", "Z2"),
+                ]
+            else:  # retry from B finds the real A-B edge
+                edges = [ab_edge]
+            body = json.dumps(
+                {"results": [], "nodes": {}, "edges": {str(i): e for i, e in enumerate(edges)}})
+            return {"content": [{"type": "text", "text": body}], "isError": False}
+
+    fake = _DirectionalFake()
+    monkeypatch.setattr(provenance, "call_kestrel_tool", fake)
+    assert await leg_tier("A", "B") == "curated-causal"
+    assert fake.calls == ["A", "B"]  # retried from the other endpoint
+
+
+async def test_leg_tier_no_retry_when_not_truncated(monkeypatch):
+    # Below the cap (not truncated) with no A-B edge -> 'none', and NO second probe call.
+    monkeypatch.setattr(provenance, "_LEG_EDGE_LIMIT", 100)
+    fake = _FakeKestrel([_edge("biolink:causes", "knowledge_assertion", "manual_agent", "A", "Z")])
+    monkeypatch.setattr(provenance, "call_kestrel_tool", fake)
+    assert await leg_tier("A", "B") == "none"
+    assert len(fake.calls) == 1  # no retry
+
+
 # --- bridge_label (compose two legs) ---------------------------------------------------
 
 def test_bridge_label_both_curated_causal():

--- a/backend/tests/test_hypothesis_extraction.py
+++ b/backend/tests/test_hypothesis_extraction.py
@@ -100,6 +100,33 @@ class TestHypothesisExtractionRun:
         assert bridge_hyps[0].tier == 3
 
     @pytest.mark.asyncio
+    async def test_upgraded_bridge_preserves_predicate_directions(self):
+        """Regression (Greptile P1): a Tier-3 bridge upgraded to Tier-2 must carry its
+        predicate_directions through, or bridge_grounding._is_scoreable silently skips exactly the
+        KG-validated bridges (it gates on a truthy predicate_directions)."""
+        bridge = Bridge(
+            path_description="glucose -> INS",
+            entities=["CHEBI:17234", "HGNC:6081"],
+            entity_names=["glucose", "INS"],
+            predicates=["biolink:affects"],
+            predicate_directions=[True],  # forward; list[bool | None] per the Bridge model
+            tier=3,
+            novelty="inferred",
+            significance="Speculative glucose-insulin bridge",
+        )
+        state = {"direct_findings": [_gate_finding()], "bridges": [bridge]}
+        with patch(
+            "src.kestrel_backend.graph.nodes.hypothesis_extraction.multi_hop_query",
+            new_callable=AsyncMock,
+        ) as mock_mhq:
+            mock_mhq.return_value = _path_found_response()
+            result = await run(state)
+
+        upgraded = result["bridges"][0]
+        assert upgraded.tier == 2
+        assert upgraded.predicate_directions == [True]  # carried through, not dropped to []
+
+    @pytest.mark.asyncio
     async def test_cold_start_only_empty_bridges(self):
         """No bridges, only a Tier-3 cold-start finding → hypotheses from cold-start, bridges []."""
         state = {

--- a/backend/tests/test_kestrel_parse.py
+++ b/backend/tests/test_kestrel_parse.py
@@ -203,13 +203,27 @@ def test_predicates_empty_edges_all_none_length_preserved():
     assert preds == [{"predicate": None, "forward": None}, {"predicate": None, "forward": None}]
 
 
-def test_predicate_edge_ids_scope_falls_back_to_all_when_unresolved():
-    # edge_ids reference ids absent from the edges dict -> fall back to scanning all edges.
+def test_predicate_edge_ids_specified_but_unresolved_does_not_borrow_other_edges():
+    # edge_ids are specified for this result but none resolve in the edges map. The scope must NOT
+    # fall back to all edges (that borrows edges from other results and mis-attributes predicates);
+    # the hop is honestly "unknown" -> {None, None}. (Greptile PR #79 fix.)
     env = _envelope({
         "results": [{"end_node_id": "B", "paths": [["A", "B"]], "edge_ids": [999]}],
         "nodes": {"A": {"name": "a"}, "B": {"name": "b"}},
         "edge_schema": SCHEMA,
-        "edges": {"7": _edge("A", "biolink:affects", "B", 7)},  # key 7, not 999
+        "edges": {"7": _edge("A", "biolink:affects", "B", 7)},  # key 7, not 999 -> unresolved
+    })
+    preds = parse_kestrel_response(env)["paths"][0]["predicates"]
+    assert preds == [{"predicate": None, "forward": None}]
+
+
+def test_predicate_no_edge_ids_scans_all_edges():
+    # When a result carries NO edge_ids scoping at all, scanning the full edge map is still correct.
+    env = _envelope({
+        "results": [{"end_node_id": "B", "paths": [["A", "B"]]}],  # no edge_ids
+        "nodes": {"A": {"name": "a"}, "B": {"name": "b"}},
+        "edge_schema": SCHEMA,
+        "edges": {"7": _edge("A", "biolink:affects", "B", 7)},
     })
     preds = parse_kestrel_response(env)["paths"][0]["predicates"]
     assert preds == [{"predicate": "biolink:affects", "forward": True}]


### PR DESCRIPTION
## Summary

Addresses the Greptile review feedback on PR #79 (dev → main promotion). Four code fixes
plus one deliberate non-change, all on the bridge-provenance / predicate-attribution path
that the ground-before-synthesis + bridge_grounding merge exercised.

## Fixes

**P1 — KG-validated bridges silently excluded from provenance labeling** (`hypothesis_extraction.py`)
When `validate_bridge_hypotheses` promotes a Tier-3 bridge to Tier-2, it rebuilt the `Bridge`
without `predicate_directions` (defaulting to `[]`). `bridge_grounding._is_scoreable` gates on a
truthy `predicate_directions`, so every KG-validated bridge — the *most* confidently confirmed
ones — was silently skipped for evidence-provenance labeling, while original Tier-2 bridges were
labeled. Now carries the field through the upgrade. Regression test included.

**P2 — hub-node leg may return a false "none"** (`bridge_grounding/provenance.py`)
`leg_tier` fetches one-hop edges from X (cap 3000) and filters client-side for Y. For a hub node
the true X–Y edge can lie beyond the cap → false "none" that mislabels a well-supported bridge.
Now: when the X fetch is truncated *and* no X–Y edge is found, retry from Y (often the
lower-degree endpoint) before concluding "none". Both-hub bridges can still miss (rare,
degrades conservatively).

**P2 — scoped-edge fallback borrows unrelated predicates** (`kestrel_client.py`)
When a result's `edge_ids` are specified but none resolve in the edge map, the parser fell back to
*all* edges — in a multi-result response that mis-attributes predicates/directions from other
results' paths. Now uses the (possibly empty) scoped set; unresolved hops emit `{None, None}`
(honest "unknown") instead of a wrong predicate. The all-edges scan stays only for results with no
`edge_ids` scoping at all.

**P2 — closure references `lines` before assignment** (`synthesis.py`)
`format_bridges` now initialises `lines` before the `_render` closure that appends to it (works
today via closure-by-reference; guards against an `UnboundLocalError` under a future early-call
refactor).

## Deliberately NOT changed

**P2 — `BioMapperAuthError` fails the whole entity_resolution node.** This is an intentional R6
fail-loud-on-misconfig design, backed by the `biomapper_client` contract ("BioMapperAuthError is
fatal → never silently degrade a bad key") and a dedicated test
(`test_flag_on_auth_error_propagates`). biomapper is default-off, so no prod exposure. Degrading
to Tier-1 would be a conscious change to the auth contract — tracked separately, not folded into
this review. (Replied on the PR #79 thread.)

## Tests

Updated/added: bridge upgrade preserves `predicate_directions`; `leg_tier` hub-retry +
no-retry-when-not-truncated; the parse test that encoded the old all-edges fallback rewritten to
assert no-borrow, plus a no-`edge_ids`-scans-all case. All touched suites green
(provenance, kestrel_parse, hypothesis_extraction, bridge_grounding_node, entity_resolution_biomapper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
