### PR TITLE
perf(bridge-grounding): parallelize legs + cache per-CURIE fetches

### DIFF
--- a/backend/src/kestrel_backend/bridge_grounding/provenance.py
+++ b/backend/src/kestrel_backend/bridge_grounding/provenance.py
@@ -153,7 +153,7 @@ def cached_leg_fetcher(concurrency: int = 8):
             async def _go() -> tuple[list[dict[str, Any]], bool]:
                 async with sem:
                     return await _leg_edges_from(curie)
-            task = asyncio.ensure_future(_go())
+            task = asyncio.create_task(_go())
             cache[curie] = task
         return await task
 

--- a/backend/src/kestrel_backend/bridge_grounding/provenance.py
+++ b/backend/src/kestrel_backend/bridge_grounding/provenance.py
@@ -8,6 +8,7 @@ logic validated by `assessment_data/kg_bridge_leg_probe.py`.
 Tier ordering (best→worst): curated-causal > curated-associative > curated-neutral > text-mined > none.
 """
 
+import asyncio
 import json
 import logging
 from typing import Any
@@ -109,7 +110,7 @@ def _best_tier(edges: list[dict[str, Any]], other_curie: str) -> str:
     return best
 
 
-async def leg_tier(curie_x: str, curie_y: str) -> str:
+async def leg_tier(curie_x: str, curie_y: str, *, fetch: Any = None) -> str:
     """Best evidence tier over the X–Y edges, or 'none' if there is no edge.
 
     Fetches one_hop_query from X in full mode (the proven probe call — start-only, NOT end_node_ids),
@@ -119,13 +120,44 @@ async def leg_tier(curie_x: str, curie_y: str) -> str:
     edge can lie beyond it (a false 'none' that mislabels a well-supported bridge). When the X fetch
     is truncated AND no X–Y edge is found, retry from Y (often the lower-degree endpoint) before
     concluding 'none'. Both-hub bridges can still miss, but that is rare and degrades conservatively.
+
+    ``fetch`` overrides the per-leg edge fetch (async ``(curie) -> (edges, truncated)``); defaults to
+    a direct Kestrel call. The bridge_grounding node passes a :func:`cached_leg_fetcher` so a CURIE
+    shared across the run's bridges is fetched once instead of once per leg.
     """
-    edges_x, truncated_x = await _leg_edges_from(curie_x)
+    _fetch = fetch or _leg_edges_from
+    edges_x, truncated_x = await _fetch(curie_x)
     best = _best_tier(edges_x, curie_y)
     if best == "none" and truncated_x:
-        edges_y, _ = await _leg_edges_from(curie_y)
+        edges_y, _ = await _fetch(curie_y)
         best = _best_tier(edges_y, curie_x)
     return best
+
+
+def cached_leg_fetcher(concurrency: int = 8):
+    """Build a single-flight, concurrency-bounded leg-edge fetcher for ONE bridge_grounding run.
+
+    The full-mode ``one_hop_query`` behind each leg is the node's dominant cost, and a co-expression
+    module's bridges heavily share endpoints (the same hub CURIE recurs across bridges). The returned
+    async ``fetch(curie) -> (edges, truncated)`` (a) fetches each CURIE at most once — concurrent
+    callers await the same in-flight task — and (b) caps concurrent Kestrel calls at ``concurrency``.
+    Pass it to :func:`leg_tier` via ``fetch=``. A fresh cache is built per call, so it never serves
+    stale KG reads across runs.
+    """
+    sem = asyncio.Semaphore(concurrency)
+    cache: dict[str, "asyncio.Future[tuple[list[dict[str, Any]], bool]]"] = {}
+
+    async def fetch(curie: str) -> tuple[list[dict[str, Any]], bool]:
+        task = cache.get(curie)
+        if task is None:
+            async def _go() -> tuple[list[dict[str, Any]], bool]:
+                async with sem:
+                    return await _leg_edges_from(curie)
+            task = asyncio.ensure_future(_go())
+            cache[curie] = task
+        return await task
+
+    return fetch
 
 
 def bridge_label(leg1_tier: str, leg2_tier: str) -> str:

--- a/backend/src/kestrel_backend/graph/nodes/bridge_grounding.py
+++ b/backend/src/kestrel_backend/graph/nodes/bridge_grounding.py
@@ -9,6 +9,7 @@ isolated to ``bridge_grounding_errors`` and the node still returns.
 Ships ``enabled=False`` (no-op, no Kestrel calls) until L4's validation eval gates the flip.
 """
 
+import asyncio
 import logging
 from typing import Any
 
@@ -19,7 +20,7 @@ from ..state_contracts import (
     BridgeGroundingOutput,
     validate_state,
 )
-from ...bridge_grounding.provenance import bridge_label, leg_tier
+from ...bridge_grounding.provenance import bridge_label, cached_leg_fetcher, leg_tier
 
 logger = logging.getLogger(__name__)
 
@@ -50,14 +51,16 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
         len(scoreable), len(bridges), cfg.max_scored_bridges,
     )
 
-    grounded: list[Any] = []
-    errors: list[str] = []
-    for b in scoreable:
+    # One fetcher per run: bridges are labeled concurrently and a CURIE shared across bridges
+    # (hub endpoints recur in a co-expression module) is fetched once, not once per bridge.
+    fetch = cached_leg_fetcher(cfg.concurrency)
+
+    async def _label(b: Any) -> tuple[Any, str | None]:
         try:
             a, mid, c = b.entities
             # leg_tier is best-effort (returns "none" on a Kestrel failure, never raises).
-            t1 = await leg_tier(a, mid)
-            t2 = await leg_tier(mid, c)
+            t1 = await leg_tier(a, mid, fetch=fetch)
+            t2 = await leg_tier(mid, c, fetch=fetch)
             grounding = BridgeGrounding(
                 legs=[
                     LegSummary(from_curie=a, to_curie=mid, evidence_tier=t1),
@@ -65,10 +68,15 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
                 ],
                 label=bridge_label(t1, t2),
             )
-            grounded.append(b.model_copy(update={"grounding": grounding}))
+            return b.model_copy(update={"grounding": grounding}), None
         except Exception as e:  # per-bridge isolation: degrade this bridge, keep the node alive
             logger.warning("bridge_grounding: failed for %s: %s", b.path_description, e)
-            errors.append(f"bridge_grounding: {b.path_description}: {e}")
-            grounded.append(b.model_copy(update={"grounding": BridgeGrounding(legs=[], label="no KG edge")}))
+            return (
+                b.model_copy(update={"grounding": BridgeGrounding(legs=[], label="no KG edge")}),
+                f"bridge_grounding: {b.path_description}: {e}",
+            )
 
+    results = await asyncio.gather(*[_label(b) for b in scoreable])
+    grounded = [g for g, _ in results]
+    errors = [err for _, err in results if err is not None]
     return {"grounded_bridges": grounded, "bridge_grounding_errors": errors}

--- a/backend/src/kestrel_backend/graph/pipeline_config.py
+++ b/backend/src/kestrel_backend/graph/pipeline_config.py
@@ -280,9 +280,18 @@ class BridgeGroundingConfig(BaseModel):
     )
     max_scored_bridges: int = Field(
         default=20,
-        description="Cap on ordered 3-node bridges labeled per run. Each costs 2 one_hop_query "
-        "full calls, so this bounds the added Kestrel load (2 * max_scored_bridges per run). "
-        "(The per-leg edge limit is fixed at L1's leg_tier constant.)",
+        description="Cap on ordered 3-node bridges labeled per run. Each costs up to 2 one_hop_query "
+        "full calls, so this bounds the added Kestrel load. Per-CURIE fetches are cached within a "
+        "run, so the actual call count is the number of DISTINCT leg endpoints, often well below "
+        "2 * max_scored_bridges. (The per-leg edge limit is fixed at L1's leg_tier constant.)",
+    )
+    concurrency: int = Field(
+        default=8,
+        ge=1,
+        description="Max concurrent leg-edge one_hop_query calls. Bridges are labeled in parallel "
+        "and per-CURIE fetches are deduplicated within a run (cached_leg_fetcher), so a module whose "
+        "bridges share hub endpoints fetches each hub once instead of once per bridge. Bounds Kestrel "
+        "load while cutting the node's wall-clock from sequential ~O(2*bridges) fetches.",
     )
 
 

--- a/backend/tests/test_bridge_grounding_node.py
+++ b/backend/tests/test_bridge_grounding_node.py
@@ -29,7 +29,7 @@ def _enable(monkeypatch, enabled=True, max_scored_bridges=20):
 
 
 def _stub_leg_tier(monkeypatch, tier="curated-causal", calls=None):
-    async def fake(x, y):
+    async def fake(x, y, **_):  # **_: the node passes fetch= (cached_leg_fetcher)
         if calls is not None:
             calls.append((x, y))
         return tier
@@ -75,7 +75,7 @@ async def test_enabled_labels_curated_causal(monkeypatch):
 async def test_weakest_leg_label(monkeypatch):
     _enable(monkeypatch)
     tiers = iter(["curated-causal", "text-mined"])
-    async def fake(x, y):
+    async def fake(x, y, **_):
         return next(tiers)
     monkeypatch.setattr(bridge_grounding, "leg_tier", fake)
     out = await bridge_grounding.run({"bridges": [_bridge()]})
@@ -112,7 +112,7 @@ async def test_per_bridge_error_isolation(monkeypatch):
     good = _bridge(entities=("CHEBI:1", "HGNC:2", "MONDO:3"))
     bad = _bridge(entities=("X:1", "Y:2", "Z:3"))
 
-    async def fake(x, y):
+    async def fake(x, y, **_):
         if x == "X:1":
             raise RuntimeError("kestrel boom")
         return "curated-causal"
@@ -176,3 +176,46 @@ def test_grounding_labels_from_state_builds_map():
     gb = b.model_copy(update={"grounding": BridgeGrounding(legs=[], label="no KG edge")})
     m = grounding_labels_from_state({"grounded_bridges": [gb]})
     assert m[tuple(b.entities)] == "no KG edge"
+
+
+# --- perf: parallel + per-CURIE fetch dedup --------------------------------------------
+
+async def test_node_dedups_shared_endpoint_fetches(monkeypatch):
+    # Two bridges sharing endpoints A,B (A->B->C and A->B->D): each unique start CURIE's
+    # expensive full-mode fetch runs ONCE for the run (cached_leg_fetcher), not once per bridge.
+    from collections import Counter
+    from kestrel_backend.bridge_grounding import provenance
+
+    _enable(monkeypatch)
+    fetched = []
+
+    async def fake_edges(curie):
+        fetched.append(curie)
+        return ([], False)  # no edges; we assert the FETCH accounting, not the tier
+
+    monkeypatch.setattr(provenance, "_leg_edges_from", fake_edges)
+    bridges = [_bridge(entities=("A", "B", "C")), _bridge(entities=("A", "B", "D"))]
+    out = await bridge_grounding.run({"bridges": bridges})
+
+    assert len(out["grounded_bridges"]) == 2
+    counts = Counter(fetched)
+    # Leg fetches are start-only: A (A->B) and B (B->C, B->D). Shared A,B fetched once each.
+    assert counts["A"] == 1, f"A fetched {counts['A']}x (expected 1 — cache miss)"
+    assert counts["B"] == 1, f"B fetched {counts['B']}x (expected 1 — cache miss)"
+
+
+async def test_node_parallel_preserves_per_bridge_labels(monkeypatch):
+    # Concurrency must not cross-contaminate labels: each bridge keeps its own legs' tiers.
+    _enable(monkeypatch)
+    tier_by_leg = {("A1", "B1"): "curated-causal", ("B1", "C1"): "curated-causal",
+                   ("A2", "B2"): "text-mined", ("B2", "C2"): "none"}
+
+    async def fake_leg_tier(x, y, **_):
+        return tier_by_leg[(x, y)]
+
+    monkeypatch.setattr(bridge_grounding, "leg_tier", fake_leg_tier)
+    bridges = [_bridge(entities=("A1", "B1", "C1")), _bridge(entities=("A2", "B2", "C2"))]
+    out = await bridge_grounding.run({"bridges": bridges})
+    by_entities = {tuple(b.entities): b for b in out["grounded_bridges"]}
+    assert by_entities[("A1", "B1", "C1")].grounding.label == "both legs curated-causal"
+    assert by_entities[("A2", "B2", "C2")].grounding.label == "one leg unsupported"

--- a/backend/tests/test_bridge_provenance.py
+++ b/backend/tests/test_bridge_provenance.py
@@ -6,11 +6,15 @@ knowledge_level + agent_type + Biolink predicate class. No score, no LLM.
 Run with: uv run python -m pytest tests/test_bridge_provenance.py -v
 """
 
+import asyncio
+import json
+
 import pytest
 
 from src.kestrel_backend.bridge_grounding import provenance
 from src.kestrel_backend.bridge_grounding.provenance import (
     bridge_label,
+    cached_leg_fetcher,
     evidence_tier,
     is_curated,
     leg_tier,
@@ -183,3 +187,81 @@ def test_bridge_label_weakest_leg():
     # Mixed tiers (both present) -> summarized by the weaker leg.
     assert bridge_label("curated-causal", "text-mined") == "weakest leg text-mined"
     assert bridge_label("curated-associative", "curated-neutral") == "weakest leg curated-neutral"
+
+
+# --- cached_leg_fetcher: single-flight + concurrency bound (perf optimization) ----------
+
+def _kestrel_resp(edges_by_id):
+    return {"content": [{"text": json.dumps({"edges": edges_by_id})}]}
+
+
+async def test_cached_leg_fetcher_single_flight(monkeypatch):
+    # Concurrent fetches for the SAME curie hit the underlying Kestrel call exactly once.
+    calls = []
+
+    async def fake_kestrel(tool, args):
+        calls.append(args["start_node_ids"])
+        await asyncio.sleep(0.01)  # keep the first call in-flight while the others arrive
+        return _kestrel_resp({})
+
+    monkeypatch.setattr(provenance, "call_kestrel_tool", fake_kestrel)
+    fetch = cached_leg_fetcher(concurrency=8)
+    await asyncio.gather(fetch("HGNC:1"), fetch("HGNC:1"), fetch("HGNC:1"))
+    assert calls == ["HGNC:1"]  # deduped to a single in-flight fetch
+
+
+async def test_cached_leg_fetcher_caches_repeat_fetches_distinct_curies(monkeypatch):
+    # A repeated curie is fetched once; distinct curies are each fetched once.
+    calls = []
+
+    async def fake_kestrel(tool, args):
+        calls.append(args["start_node_ids"])
+        return _kestrel_resp({})
+
+    monkeypatch.setattr(provenance, "call_kestrel_tool", fake_kestrel)
+    fetch = cached_leg_fetcher()
+    await fetch("A")
+    await fetch("B")
+    await fetch("A")
+    assert calls == ["A", "B"]  # A cached on the second call
+
+
+async def test_cached_leg_fetcher_bounds_concurrency(monkeypatch):
+    # No more than `concurrency` underlying Kestrel calls run at once.
+    inflight = 0
+    peak = 0
+
+    async def fake_kestrel(tool, args):
+        nonlocal inflight, peak
+        inflight += 1
+        peak = max(peak, inflight)
+        await asyncio.sleep(0.01)
+        inflight -= 1
+        return _kestrel_resp({})
+
+    monkeypatch.setattr(provenance, "call_kestrel_tool", fake_kestrel)
+    fetch = cached_leg_fetcher(concurrency=2)
+    await asyncio.gather(*[fetch(f"N:{i}") for i in range(10)])
+    assert peak <= 2
+
+
+# --- leg_tier: injectable fetch (so the node can pass a cached fetcher) -----------------
+
+async def test_leg_tier_uses_injected_fetch():
+    # leg_tier classifies using the injected fetch's edges (no real Kestrel call).
+    async def fetch(curie):
+        return ([_edge("biolink:causes", "knowledge_assertion", "manual_agent",
+                       subject="A", obj="B")], False)
+
+    assert await leg_tier("A", "B", fetch=fetch) == "curated-causal"
+
+
+async def test_leg_tier_injected_fetch_hub_retry():
+    # When the start node is truncated with no X-Y edge, leg_tier retries from Y via the same fetch.
+    async def fetch(curie):
+        if curie == "HUB":
+            return ([], True)  # truncated, no edge to Y found
+        return ([_edge("biolink:causes", "knowledge_assertion", "manual_agent",
+                       subject="Y", obj="HUB")], False)
+
+    assert await leg_tier("HUB", "Y", fetch=fetch) == "curated-causal"


### PR DESCRIPTION
## Summary

`bridge_grounding` is the dominant cost in a full discovery run — ~400s of an 18.8-min, 24-analyte C1 pilot (artifact `brown_c1_pilot_20260620T055649Z.json`). Profiling showed the ~400s is almost entirely avoidable overhead, not real work:

1. **Fully sequential.** The node labeled up to `max_scored_bridges=20` bridges one at a time, awaiting each leg serially → up to ~40 serialized `leg_tier` calls.
2. **No fetch caching.** Each `leg_tier(X,Y)` re-fetches X's entire edge list (full-mode `one_hop_query`, `limit=3000`). A co-expression module's bridges share hub endpoints — IL6 (~9.9k edges), HMOX1 (~8k), cortisol (~5.7k) — so the same expensive hub fetch was repeated once per bridge it appears in.

## Changes (behavior-preserving — identical labels)

- **Parallelize across bridges** with `asyncio.gather`, bounded by a new `BridgeGroundingConfig.concurrency` (default 8). The two legs within a bridge stay sequential so the start-only fetch order (and existing call-order assertions) are preserved.
- **`cached_leg_fetcher`** (in `provenance.py`): a single-flight, concurrency-bounded `fetch(curie) → (edges, truncated)`. Each distinct leg endpoint is fetched once per run (concurrent callers await the same in-flight task); passed into `leg_tier` via a new keyword-only `fetch=`.
- `leg_tier`'s default path (`fetch=None`) is unchanged, so other callers (the L4 eval) are unaffected. The cache is per-run only — never serves stale KG reads, and it reduces total Kestrel load.

Expected: ~400s → well under 60s on the pilot, with identical provenance labels.

> Note: `max_scored_bridges=20` caps bridge count, so this is a fixed cost reduction that speeds up every run — not a 217-scaling fix; a full-217 run's other nodes still scale with entity count.

## Tests (TDD — written first, watched fail)

- `cached_leg_fetcher`: single-flight dedup, concurrency bound (peak ≤ N), repeat/distinct caching.
- `leg_tier`: injected-fetch classification + hub-retry via the injected fetch.
- node: dedups shared endpoints (A→B→C & A→B→D fetch A,B once each), parallel execution preserves per-bridge labels.

Full bridge suite green (52 passed). The 33 `test_langgraph_prototype` failures are pre-existing — verified identical on the base commit (+14 new passing tests, nothing broken).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
