### PR TITLE
feat(perf-report): per-node pipeline performance report (disk-only v1)

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -2,3 +2,6 @@
 # Tier A calibration spike artifacts (expensive-run outputs; reproducible from manifest)
 assessment_data/bridge_grounding_tier_a_runs/
 assessment_data/kg_bridge_leg_runs/
+
+# Per-node performance reports (contain raw query + cost data; 600-perm, not for VCS)
+run_reports/

--- a/backend/src/kestrel_backend/graph/builder.py
+++ b/backend/src/kestrel_backend/graph/builder.py
@@ -22,7 +22,7 @@ from .timing import timed_node
 from .nodes import (
     intake, entity_resolution, triage, direct_kg, cold_start,
     pathway_enrichment, integration, bridge_grounding, temporal,
-    hypothesis_extraction, synthesis, literature_grounding
+    hypothesis_extraction, synthesis, literature_grounding, reporting
 )
 
 
@@ -148,6 +148,8 @@ def build_discovery_graph() -> StateGraph:
     workflow.add_node("hypothesis_extraction", timed_node("hypothesis_extraction", hypothesis_extraction.run))
     workflow.add_node("synthesis", timed_node("synthesis", synthesis.run))
     workflow.add_node("literature_grounding", timed_node("literature_grounding", literature_grounding.run))
+    # Terminal reporting node — runs last on every path, emits the perf report (fail-safe).
+    workflow.add_node("reporting", timed_node("reporting", reporting.run))
 
     # Linear edges: intake -> entity_resolution -> triage
     workflow.set_entry_point("intake")
@@ -196,7 +198,10 @@ def build_discovery_graph() -> StateGraph:
     workflow.add_edge("hypothesis_extraction", "bridge_grounding")
     workflow.add_edge("bridge_grounding", "literature_grounding")
     workflow.add_edge("literature_grounding", "synthesis")
-    workflow.add_edge("synthesis", END)
+    # synthesis -> reporting -> END: the perf report fires after the report is written,
+    # on every path (incl. Studio, which bypasses the runner).
+    workflow.add_edge("synthesis", "reporting")
+    workflow.add_edge("reporting", END)
 
     # Compile and return
     return workflow.compile()

--- a/backend/src/kestrel_backend/graph/builder.py
+++ b/backend/src/kestrel_backend/graph/builder.py
@@ -18,6 +18,7 @@ Full 12-node architecture (ground-before-synthesis + bridge evidence-provenance)
 from typing import Literal
 from langgraph.graph import StateGraph, END
 from .state import DiscoveryState
+from .timing import timed_node
 from .nodes import (
     intake, entity_resolution, triage, direct_kg, cold_start,
     pathway_enrichment, integration, bridge_grounding, temporal,
@@ -132,19 +133,21 @@ def build_discovery_graph() -> StateGraph:
     # Create graph with our state schema
     workflow = StateGraph(DiscoveryState)
 
-    # Add all 12 nodes
-    workflow.add_node("intake", intake.run)
-    workflow.add_node("entity_resolution", entity_resolution.run)
-    workflow.add_node("triage", triage.run)
-    workflow.add_node("direct_kg", direct_kg.run)
-    workflow.add_node("cold_start", cold_start.run)
-    workflow.add_node("pathway_enrichment", pathway_enrichment.run)
-    workflow.add_node("integration", integration.run)
-    workflow.add_node("bridge_grounding", bridge_grounding.run)
-    workflow.add_node("temporal", temporal.run)
-    workflow.add_node("hypothesis_extraction", hypothesis_extraction.run)
-    workflow.add_node("synthesis", synthesis.run)
-    workflow.add_node("literature_grounding", literature_grounding.run)
+    # Add all 12 nodes. Each is wrapped with timed_node so its wall-clock duration is
+    # recorded into node_timings (merged via the reducer) on every entry path. The wrapper
+    # is behavior-preserving — it only adds node_timings to the node's returned state.
+    workflow.add_node("intake", timed_node("intake", intake.run))
+    workflow.add_node("entity_resolution", timed_node("entity_resolution", entity_resolution.run))
+    workflow.add_node("triage", timed_node("triage", triage.run))
+    workflow.add_node("direct_kg", timed_node("direct_kg", direct_kg.run))
+    workflow.add_node("cold_start", timed_node("cold_start", cold_start.run))
+    workflow.add_node("pathway_enrichment", timed_node("pathway_enrichment", pathway_enrichment.run))
+    workflow.add_node("integration", timed_node("integration", integration.run))
+    workflow.add_node("bridge_grounding", timed_node("bridge_grounding", bridge_grounding.run))
+    workflow.add_node("temporal", timed_node("temporal", temporal.run))
+    workflow.add_node("hypothesis_extraction", timed_node("hypothesis_extraction", hypothesis_extraction.run))
+    workflow.add_node("synthesis", timed_node("synthesis", synthesis.run))
+    workflow.add_node("literature_grounding", timed_node("literature_grounding", literature_grounding.run))
 
     # Linear edges: intake -> entity_resolution -> triage
     workflow.set_entry_point("intake")

--- a/backend/src/kestrel_backend/graph/nodes/__init__.py
+++ b/backend/src/kestrel_backend/graph/nodes/__init__.py
@@ -25,6 +25,7 @@ from . import temporal
 from . import hypothesis_extraction
 from . import synthesis
 from . import literature_grounding
+from . import reporting
 
 __all__ = [
     "intake",
@@ -39,4 +40,5 @@ __all__ = [
     "hypothesis_extraction",
     "synthesis",
     "literature_grounding",
+    "reporting",
 ]

--- a/backend/src/kestrel_backend/graph/nodes/reporting.py
+++ b/backend/src/kestrel_backend/graph/nodes/reporting.py
@@ -26,27 +26,36 @@ from ..state import DiscoveryState
 logger = logging.getLogger(__name__)
 
 
+def _build_and_write(state: DiscoveryState, run_id: str) -> str:
+    """Build the report and write it to disk. Pure-blocking; runs in a worker thread.
+
+    Every blocking step lives here — ``get_git_sha`` (a subprocess with a 5s timeout,
+    blocking on its first uncached call after each restart), ``json.dumps`` of the full
+    state, and the file I/O + prune — so none of it stalls the asyncio event loop.
+    """
+    meta = {
+        "run_id": run_id,
+        "query": state.get("raw_query"),
+        "mode": "pipeline",
+        "biomapper_env": state.get("biomapper_env"),
+        "timestamp": run_reports_io.utc_timestamp(),
+        "git_sha": run_reports_io.get_git_sha(),
+    }
+    report = build_report(state, meta)
+    markdown = render_markdown(report)
+    result = run_reports_io.write_report(report, markdown, run_id=run_id)
+    return str(result["json"])
+
+
 async def run(state: DiscoveryState) -> dict[str, Any]:
     try:
         run_id = run_reports_io.new_run_id()
-        meta = {
-            "run_id": run_id,
-            "query": state.get("raw_query"),
-            "mode": "pipeline",
-            "biomapper_env": state.get("biomapper_env"),
-            "timestamp": run_reports_io.utc_timestamp(),
-            "git_sha": run_reports_io.get_git_sha(),
-        }
-        report = build_report(state, meta)
-        markdown = render_markdown(report)
-        # Offload the blocking disk write (json.dumps + file I/O + prune) to a thread so
-        # it never stalls the asyncio event loop between synthesis-complete and the final
-        # WebSocket message on the prod request path.
-        result = await asyncio.to_thread(
-            run_reports_io.write_report, report, markdown, run_id=run_id
-        )
+        # Offload ALL blocking work (git SHA lookup + report build + json.dumps + disk
+        # write + prune) to a thread so it never stalls the event loop between
+        # synthesis-complete and the final WebSocket message on the prod request path.
+        report_path = await asyncio.to_thread(_build_and_write, state, run_id)
         logger.info("Performance report written: run_id=%s", run_id)
-        return {"report_path": str(result["json"])}
+        return {"report_path": report_path}
     except Exception:  # noqa: BLE001 - reporting must never break a user-facing run (R4)
         logger.warning("Performance report failed; pipeline result unaffected", exc_info=True)
         return {}

--- a/backend/src/kestrel_backend/graph/nodes/reporting.py
+++ b/backend/src/kestrel_backend/graph/nodes/reporting.py
@@ -1,0 +1,46 @@
+"""Terminal reporting node: emit the per-node performance report to disk.
+
+Wired as ``synthesis -> reporting -> END``, so it runs last on every entry path
+(WebSocket, ``run_discovery``, LangGraph Studio) — a runner-level reporter would
+miss Studio, which invokes the compiled graph directly.
+
+Fail-safe (plan R4): the entire body is wrapped. On any failure it logs a
+warning and returns ``{}`` — a reporting failure can never break or delay a
+user-facing run. The reporter is read-only over state plus disk I/O.
+
+The terminal ``reporting`` node is intentionally absent from
+``NODE_STATUS_MESSAGES`` (so it stays invisible to the WS stream in v1) and is
+excluded from its own report: the ``timed_node`` wrapper records
+``node_timings["reporting"]`` only *after* this function returns, so the state
+this function reads never contains it.
+"""
+
+import logging
+from typing import Any
+
+from ... import run_reports_io
+from ..performance_report import build_report, render_markdown
+from ..state import DiscoveryState
+
+logger = logging.getLogger(__name__)
+
+
+async def run(state: DiscoveryState) -> dict[str, Any]:
+    try:
+        run_id = run_reports_io.new_run_id()
+        meta = {
+            "run_id": run_id,
+            "query": state.get("raw_query"),
+            "mode": "pipeline",
+            "biomapper_env": state.get("biomapper_env"),
+            "timestamp": run_reports_io.utc_timestamp(),
+            "git_sha": run_reports_io.get_git_sha(),
+        }
+        report = build_report(state, meta)
+        markdown = render_markdown(report)
+        result = run_reports_io.write_report(report, markdown, run_id=run_id)
+        logger.info("Performance report written: %s", result["json"])
+        return {"report_path": str(result["json"])}
+    except Exception:  # noqa: BLE001 - reporting must never break a user-facing run (R4)
+        logger.warning("Performance report failed; pipeline result unaffected", exc_info=True)
+        return {}

--- a/backend/src/kestrel_backend/graph/nodes/reporting.py
+++ b/backend/src/kestrel_backend/graph/nodes/reporting.py
@@ -15,6 +15,7 @@ excluded from its own report: the ``timed_node`` wrapper records
 this function reads never contains it.
 """
 
+import asyncio
 import logging
 from typing import Any
 
@@ -38,8 +39,13 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
         }
         report = build_report(state, meta)
         markdown = render_markdown(report)
-        result = run_reports_io.write_report(report, markdown, run_id=run_id)
-        logger.info("Performance report written: %s", result["json"])
+        # Offload the blocking disk write (json.dumps + file I/O + prune) to a thread so
+        # it never stalls the asyncio event loop between synthesis-complete and the final
+        # WebSocket message on the prod request path.
+        result = await asyncio.to_thread(
+            run_reports_io.write_report, report, markdown, run_id=run_id
+        )
+        logger.info("Performance report written: run_id=%s", run_id)
         return {"report_path": str(result["json"])}
     except Exception:  # noqa: BLE001 - reporting must never break a user-facing run (R4)
         logger.warning("Performance report failed; pipeline result unaffected", exc_info=True)

--- a/backend/src/kestrel_backend/graph/nodes/synthesis.py
+++ b/backend/src/kestrel_backend/graph/nodes/synthesis.py
@@ -989,6 +989,11 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
 
     # Phase C: LLM synthesis or fallback
     usage_record = None
+    # Run-level marker emitted when synthesis silently degrades to the deterministic
+    # fallback (plan Unit 7). The motivating case — context overflow — succeeds at the
+    # HTTP level but returns empty text, so the run otherwise reads as status=complete,
+    # errors=0 and the degradation is invisible. The marker surfaces it in the report.
+    fallback_marker: str | None = None
     if HAS_SDK:
         try:
             options = ClaudeAgentOptions(
@@ -1006,12 +1011,24 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
             # NOTE: query_with_usage joins text blocks with "", not "\n" (previous behavior).
             # All other nodes use "".join(); synthesis now matches them.
 
-            report = text if text.strip() else fallback_report(state)
+            if text.strip():
+                report = text
+            else:
+                report = fallback_report(state)
+                fallback_marker = (
+                    "synthesis: LLM returned empty output; fell back to deterministic "
+                    "report (possible context overflow)"
+                )
         except Exception as e:
             # Fallback on any SDK error
             report = fallback_report(state)
-            # Could log error here if needed
+            fallback_marker = (
+                f"synthesis: LLM call failed ({type(e).__name__}); fell back to "
+                "deterministic report"
+            )
     else:
+        # SDK unavailable is an environment condition, not a run-time degradation —
+        # no marker (avoids polluting errors in SDK-less dev/test environments).
         report = fallback_report(state)
 
     # Hypotheses are produced upstream (hypothesis_extraction) and grounded by
@@ -1034,7 +1051,11 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
     # Report-only return (R4/R12): hypotheses and bridges are produced/owned upstream now, so
     # synthesis must NOT re-emit them. extra='ignore' on SynthesisOutput would silently let a
     # stray `bridges` return through, so it is removed deliberately, not relied on to be dropped.
-    return {
+    result: dict[str, Any] = {
         "synthesis_report": report,
         "model_usages": [usage_record] if usage_record else [],
     }
+    # errors uses an operator.add reducer; only emit on a degraded fallback (Unit 7).
+    if fallback_marker:
+        result["errors"] = [fallback_marker]
+    return result

--- a/backend/src/kestrel_backend/graph/performance_report.py
+++ b/backend/src/kestrel_backend/graph/performance_report.py
@@ -1,0 +1,254 @@
+"""Build the per-node pipeline performance report (JSON + Markdown).
+
+Pure functions over the accumulated ``DiscoveryState`` plus run metadata — no I/O
+(disk emission lives in :mod:`kestrel_backend.run_reports_io`). ``build_report``
+returns a JSON-serializable dict; ``render_markdown`` renders it as
+Outline-publishable GFM.
+
+Schema (``report_version: 1``):
+    run_id, query (full — JSON only), mode, biomapper_env, timestamp, git_sha,
+    totals{wall_clock_s, input_tokens, output_tokens, cache_read_tokens,
+           cache_creation_tokens, total_tokens, mcp_tool_calls, cost_usd},
+    headline{top_bottleneck_node, top_cost_node},
+    errors[],
+    nodes[{node, status, duration_s, pct_of_total, input_tokens, output_tokens,
+           cache_read_tokens, cache_creation_tokens, models[], mcp_tool_calls,
+           cost_usd, findings}]
+
+Security (plan Unit 4, R6): the full ``query`` is in the JSON only;
+``render_markdown`` emits ``run_id`` and never the raw query, because the
+Markdown is the Outline-bound artifact.
+"""
+
+from typing import Any
+
+from .. import pricing
+from .node_detail_extractors import extract_node_details
+
+REPORT_VERSION = 1
+
+# Canonical pipeline node order (matches builder.py). The terminal `reporting`
+# node is intentionally excluded — it does not report on itself.
+PIPELINE_NODES = [
+    "intake",
+    "entity_resolution",
+    "triage",
+    "direct_kg",
+    "cold_start",
+    "pathway_enrichment",
+    "integration",
+    "temporal",
+    "hypothesis_extraction",
+    "bridge_grounding",
+    "literature_grounding",
+    "synthesis",
+]
+
+
+def _field(obj: Any, name: str, default: Any = 0) -> Any:
+    """Read ``name`` from a ModelUsageRecord (attr) or a plain dict."""
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
+def _group_usages_by_node(model_usages: list) -> dict[str, list]:
+    grouped: dict[str, list] = {}
+    for rec in model_usages or []:
+        node = _field(rec, "node_name", "") or "unknown"
+        grouped.setdefault(node, []).append(rec)
+    return grouped
+
+
+def _node_token_totals(records: list) -> dict[str, int]:
+    return {
+        "input_tokens": sum(_field(r, "input_tokens", 0) for r in records),
+        "output_tokens": sum(_field(r, "output_tokens", 0) for r in records),
+        "cache_read_tokens": sum(_field(r, "cache_read_tokens", 0) for r in records),
+        "cache_creation_tokens": sum(_field(r, "cache_creation_tokens", 0) for r in records),
+        "mcp_tool_calls": sum(_field(r, "mcp_tool_calls", 0) for r in records),
+    }
+
+
+def _node_cost(records: list) -> float | None:
+    """Per-node cost; None if every record's model is unknown (else sum of knowns)."""
+    costs = [
+        pricing.cost_of_record(
+            model_name=_field(r, "model_name", "") or "",
+            input_tokens=_field(r, "input_tokens", 0),
+            output_tokens=_field(r, "output_tokens", 0),
+            cache_read_tokens=_field(r, "cache_read_tokens", 0),
+            cache_creation_tokens=_field(r, "cache_creation_tokens", 0),
+        )
+        for r in records
+    ]
+    known = [c for c in costs if c is not None]
+    return sum(known) if known else None
+
+
+def build_report(state: dict, meta: dict) -> dict:
+    """Build the report dict from final state + run metadata.
+
+    ``meta`` keys: ``run_id``, ``query``, ``mode``, ``biomapper_env``,
+    ``timestamp``, ``git_sha``, and optionally ``wall_clock_s`` (the exact
+    measured run duration; if absent, the sum of per-node durations is used as
+    the percentage denominator).
+    """
+    node_timings: dict[str, float] = state.get("node_timings", {}) or {}
+    model_usages = state.get("model_usages", []) or []
+    errors = list(state.get("errors", []) or [])
+    usages_by_node = _group_usages_by_node(model_usages)
+
+    # Node set: canonical order, then any extras observed in timings/usages.
+    seen = set(PIPELINE_NODES)
+    extras = [n for n in (set(node_timings) | set(usages_by_node)) if n not in seen]
+    ordered_nodes = PIPELINE_NODES + sorted(extras)
+
+    # Denominator for pct_of_total: exact wall-clock if provided, else summed durations.
+    summed = sum(node_timings.values())
+    wall_clock = meta.get("wall_clock_s")
+    if not wall_clock or wall_clock <= 0:
+        wall_clock = summed
+    denom = wall_clock if wall_clock and wall_clock > 0 else None
+
+    nodes: list[dict] = []
+    for name in ordered_nodes:
+        ran = name in node_timings
+        records = usages_by_node.get(name, [])
+        if not ran and not records:
+            # Node never executed on this run (conditional branch skipped).
+            nodes.append({"node": name, "status": "skipped"})
+            continue
+        duration = node_timings.get(name)
+        toks = _node_token_totals(records)
+        models = sorted({_field(r, "model_name", "") for r in records if _field(r, "model_name", "")})
+        summary, _details = extract_node_details(name, state) if ran else ("", {})
+        nodes.append(
+            {
+                "node": name,
+                "status": "ran",
+                "duration_s": round(duration, 3) if duration is not None else None,
+                "pct_of_total": (
+                    round(100.0 * duration / denom, 1)
+                    if duration is not None and denom
+                    else None
+                ),
+                **toks,
+                "models": models,
+                "cost_usd": _node_cost(records),
+                "findings": summary,
+            }
+        )
+
+    total_cost = pricing.estimate_cost(model_usages)
+    totals = {
+        "wall_clock_s": round(wall_clock, 3) if wall_clock else 0.0,
+        "input_tokens": sum(_field(r, "input_tokens", 0) for r in model_usages),
+        "output_tokens": sum(_field(r, "output_tokens", 0) for r in model_usages),
+        "cache_read_tokens": sum(_field(r, "cache_read_tokens", 0) for r in model_usages),
+        "cache_creation_tokens": sum(_field(r, "cache_creation_tokens", 0) for r in model_usages),
+        "mcp_tool_calls": sum(_field(r, "mcp_tool_calls", 0) for r in model_usages),
+        "cost_usd": round(total_cost, 6),
+    }
+    totals["total_tokens"] = (
+        totals["input_tokens"]
+        + totals["output_tokens"]
+        + totals["cache_read_tokens"]
+        + totals["cache_creation_tokens"]
+    )
+
+    ran_nodes = [n for n in nodes if n["status"] == "ran"]
+    top_bottleneck = max(
+        (n for n in ran_nodes if n.get("duration_s") is not None),
+        key=lambda n: n["duration_s"],
+        default=None,
+    )
+    top_cost = max(
+        (n for n in ran_nodes if n.get("cost_usd") is not None),
+        key=lambda n: n["cost_usd"],
+        default=None,
+    )
+
+    return {
+        "report_version": REPORT_VERSION,
+        "run_id": meta.get("run_id"),
+        "query": meta.get("query"),  # full query — JSON only; markdown omits it
+        "mode": meta.get("mode"),
+        "biomapper_env": meta.get("biomapper_env"),
+        "timestamp": meta.get("timestamp"),
+        "git_sha": meta.get("git_sha"),
+        "totals": totals,
+        "headline": {
+            "top_bottleneck_node": top_bottleneck["node"] if top_bottleneck else None,
+            "top_cost_node": top_cost["node"] if top_cost else None,
+        },
+        "errors": errors,
+        "nodes": nodes,
+    }
+
+
+def _fmt_cost(c: float | None) -> str:
+    return f"${c:.4f}" if c is not None else "est. n/a"
+
+
+def render_markdown(report: dict) -> str:
+    """Render the report dict as Outline-publishable GFM. Never emits the raw query."""
+    t = report.get("totals", {})
+    h = report.get("headline", {})
+    lines: list[str] = []
+    lines.append("# Pipeline Performance Report")
+    lines.append("")
+    lines.append(f"- **Run:** `{report.get('run_id')}`")
+    lines.append(f"- **Mode:** {report.get('mode')} · **biomapper_env:** {report.get('biomapper_env')}")
+    lines.append(f"- **Timestamp:** {report.get('timestamp')} · **commit:** `{report.get('git_sha')}`")
+    lines.append(
+        f"- **Wall-clock:** {t.get('wall_clock_s')}s · "
+        f"**tokens:** {t.get('input_tokens')} in / {t.get('output_tokens')} out "
+        f"({t.get('cache_read_tokens')} cache-r, {t.get('cache_creation_tokens')} cache-w) · "
+        f"**est. cost:** {_fmt_cost(t.get('cost_usd'))}"
+    )
+    lines.append(
+        f"- **Top bottleneck:** {h.get('top_bottleneck_node') or 'n/a'} · "
+        f"**Top cost:** {h.get('top_cost_node') or 'n/a'}"
+    )
+    lines.append("")
+    lines.append(
+        "> Per-node durations for concurrent branches (`direct_kg` / `cold_start`) overlap, "
+        "so summed percentages can exceed 100%. Total wall-clock is the exact denominator."
+    )
+    lines.append("")
+    lines.append("## Per-node")
+    lines.append("")
+    lines.append("| Node | Status | Duration (s) | % | In | Out | Cache r/w | Model | MCP | Est. $ | Findings |")
+    lines.append("|---|---|---|---|---|---|---|---|---|---|---|")
+
+    # Rows: ran nodes sorted by duration desc, then skipped nodes.
+    ran = [n for n in report.get("nodes", []) if n.get("status") == "ran"]
+    skipped = [n for n in report.get("nodes", []) if n.get("status") != "ran"]
+    ran.sort(key=lambda n: (n.get("duration_s") or 0.0), reverse=True)
+    for n in ran + skipped:
+        if n.get("status") != "ran":
+            lines.append(f"| {n['node']} | skipped | – | – | – | – | – | – | – | – | – |")
+            continue
+        models = ", ".join(n.get("models", [])) or "–"
+        pct = f"{n['pct_of_total']}%" if n.get("pct_of_total") is not None else "–"
+        dur = n["duration_s"] if n.get("duration_s") is not None else "–"
+        cache = f"{n.get('cache_read_tokens', 0)}/{n.get('cache_creation_tokens', 0)}"
+        findings = (n.get("findings") or "").replace("|", "\\|").replace("\n", " ")
+        lines.append(
+            f"| {n['node']} | ran | {dur} | {pct} | {n.get('input_tokens', 0)} | "
+            f"{n.get('output_tokens', 0)} | {cache} | {models} | "
+            f"{n.get('mcp_tool_calls', 0)} | {_fmt_cost(n.get('cost_usd'))} | {findings} |"
+        )
+
+    lines.append("")
+    lines.append("## Errors")
+    lines.append("")
+    errs = report.get("errors", [])
+    if errs:
+        for e in errs:
+            lines.append(f"- {str(e).replace(chr(10), ' ')}")
+    else:
+        lines.append("None.")
+    lines.append("")
+    return "\n".join(lines)

--- a/backend/src/kestrel_backend/graph/performance_report.py
+++ b/backend/src/kestrel_backend/graph/performance_report.py
@@ -140,21 +140,17 @@ def build_report(state: dict, meta: dict) -> dict:
             }
         )
 
-    total_cost = pricing.estimate_cost(model_usages)
+    tok = _node_token_totals(model_usages)  # same 5 fields, computed once
     totals = {
         "wall_clock_s": round(wall_clock, 3) if wall_clock else 0.0,
-        "input_tokens": sum(_field(r, "input_tokens", 0) for r in model_usages),
-        "output_tokens": sum(_field(r, "output_tokens", 0) for r in model_usages),
-        "cache_read_tokens": sum(_field(r, "cache_read_tokens", 0) for r in model_usages),
-        "cache_creation_tokens": sum(_field(r, "cache_creation_tokens", 0) for r in model_usages),
-        "mcp_tool_calls": sum(_field(r, "mcp_tool_calls", 0) for r in model_usages),
-        "cost_usd": round(total_cost, 6),
+        **tok,
+        "cost_usd": round(pricing.estimate_cost(model_usages), 6),
     }
     totals["total_tokens"] = (
-        totals["input_tokens"]
-        + totals["output_tokens"]
-        + totals["cache_read_tokens"]
-        + totals["cache_creation_tokens"]
+        tok["input_tokens"]
+        + tok["output_tokens"]
+        + tok["cache_read_tokens"]
+        + tok["cache_creation_tokens"]
     )
 
     ran_nodes = [n for n in nodes if n["status"] == "ran"]

--- a/backend/src/kestrel_backend/graph/performance_report.py
+++ b/backend/src/kestrel_backend/graph/performance_report.py
@@ -104,11 +104,18 @@ def build_report(state: dict, meta: dict) -> dict:
     extras = [n for n in (set(node_timings) | set(usages_by_node)) if n not in seen]
     ordered_nodes = PIPELINE_NODES + sorted(extras)
 
-    # Denominator for pct_of_total: exact wall-clock if provided, else summed durations.
+    # Denominator for pct_of_total: exact wall-clock if the caller measured it, else
+    # the sum of per-node durations. The v1 reporting node has no true elapsed-time
+    # source, so it omits wall_clock_s and this falls back to "summed_estimate" — which
+    # overstates elapsed time when parallel branches overlap, and makes pct_of_total a
+    # share-of-summed-work (always <=100%) rather than share-of-elapsed.
     summed = sum(node_timings.values())
     wall_clock = meta.get("wall_clock_s")
     if not wall_clock or wall_clock <= 0:
         wall_clock = summed
+        wall_clock_source = "summed_estimate"
+    else:
+        wall_clock_source = "measured"
     denom = wall_clock if wall_clock and wall_clock > 0 else None
 
     nodes: list[dict] = []
@@ -143,9 +150,11 @@ def build_report(state: dict, meta: dict) -> dict:
     tok = _node_token_totals(model_usages)  # same 5 fields, computed once
     totals = {
         "wall_clock_s": round(wall_clock, 3) if wall_clock else 0.0,
+        "wall_clock_source": wall_clock_source,  # "measured" | "summed_estimate"
         **tok,
         "cost_usd": round(pricing.estimate_cost(model_usages), 6),
     }
+    # total_tokens is billing tokens only; mcp_tool_calls is a call count, not tokens.
     totals["total_tokens"] = (
         tok["input_tokens"]
         + tok["output_tokens"]
@@ -208,10 +217,17 @@ def render_markdown(report: dict) -> str:
         f"**Top cost:** {h.get('top_cost_node') or 'n/a'}"
     )
     lines.append("")
-    lines.append(
-        "> Per-node durations for concurrent branches (`direct_kg` / `cold_start`) overlap, "
-        "so summed percentages can exceed 100%. Total wall-clock is the exact denominator."
-    )
+    if t.get("wall_clock_source") == "measured":
+        lines.append(
+            "> `%` is each node's share of measured wall-clock. Concurrent branches "
+            "(`direct_kg` / `cold_start`) overlap, so per-node percentages can sum to >100%."
+        )
+    else:
+        lines.append(
+            "> Wall-clock is estimated as the **sum of per-node durations** (no measured "
+            "elapsed time available); for concurrent branches this overstates true elapsed "
+            "time. `%` is each node's share of that summed time."
+        )
     lines.append("")
     lines.append("## Per-node")
     lines.append("")

--- a/backend/src/kestrel_backend/graph/state.py
+++ b/backend/src/kestrel_backend/graph/state.py
@@ -478,3 +478,5 @@ class DiscoveryState(TypedDict, total=False):
     # and LangGraph raises InvalidUpdateError on concurrent writes to a non-reducer field.
     node_timings: Annotated[dict[str, float], merge_node_timings]  # Performance tracking
     cold_start_skipped_count: int  # Number of entities skipped by cold-start optimization
+    # Path to the performance report written by the terminal reporting node (observability).
+    report_path: str

--- a/backend/src/kestrel_backend/graph/state.py
+++ b/backend/src/kestrel_backend/graph/state.py
@@ -355,6 +355,26 @@ class ModelUsageRecord(BaseModel):
     available_tools: list[str] | None = Field(None, description="Tool names from SDK init event, if exposed")
 
 
+def merge_node_timings(
+    left: dict[str, float] | None,
+    right: dict[str, float] | None,
+) -> dict[str, float]:
+    """Reducer for ``node_timings``: key-merge per-node durations.
+
+    Required because parallel branches (direct_kg + cold_start) write
+    ``node_timings`` in the same superstep; without a reducer LangGraph raises
+    ``InvalidUpdateError``. Distinct node keys merge cleanly; a key collision
+    keeps the right-hand (later) value. Treats ``None``/missing as empty and
+    never raises (a reducer failure would break the whole run).
+    """
+    merged: dict[str, float] = {}
+    if left:
+        merged.update(left)
+    if right:
+        merged.update(right)
+    return merged
+
+
 class DiscoveryState(TypedDict, total=False):
     """
     State schema for the KRAKEN discovery workflow.
@@ -453,5 +473,8 @@ class DiscoveryState(TypedDict, total=False):
     # === Metadata ===
     # Uses operator.add reducer to accumulate errors from all nodes
     errors: Annotated[list[str], operator.add]
-    node_timings: dict[str, float]  # Performance tracking
+    # Per-node wall-clock, merged via merge_node_timings. A reducer is REQUIRED here:
+    # parallel branches (direct_kg + cold_start) write node_timings in the same superstep,
+    # and LangGraph raises InvalidUpdateError on concurrent writes to a non-reducer field.
+    node_timings: Annotated[dict[str, float], merge_node_timings]  # Performance tracking
     cold_start_skipped_count: int  # Number of entities skipped by cold-start optimization

--- a/backend/src/kestrel_backend/graph/timing.py
+++ b/backend/src/kestrel_backend/graph/timing.py
@@ -1,0 +1,66 @@
+"""Per-node timing wrapper for the discovery graph.
+
+Wraps each LangGraph node so its wall-clock duration is recorded into
+``state['node_timings']`` (merged across nodes via the ``merge_node_timings``
+reducer in :mod:`state`). Because the wrapper lives in the compiled graph, it
+captures timing on every entry path (WebSocket, ``run_discovery``, LangGraph
+Studio) and is concurrency-safe — each invocation writes into the per-run state,
+not a shared handler instance.
+
+Defensiveness (plan Unit 1, R4): the wrapper runs on every node, *outside* the
+reporting node's try/except. A failure in the wrapper's own timing/merge logic
+must never propagate into the pipeline — the wrapped node's result is returned
+unchanged. The wrapped node call itself is *not* guarded: a node raising is the
+node's own error and must surface as before.
+"""
+
+import logging
+import time
+from typing import Any, Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+NodeFn = Callable[[dict], Awaitable[Any]]
+
+
+def _attach_timing(result: Any, name: str, duration: float) -> dict:
+    """Return the node's result dict with ``node_timings`` for this node added.
+
+    Shallow-copies a dict result so reducer-bound values (lists of frozen
+    ``ModelUsageRecord`` / ``Finding``) pass through unchanged — never deep-copied
+    or reconstructed. ``None`` / non-dict returns yield a dict carrying only the
+    timing (LangGraph node returns are dicts or ``None``; a non-dict is already an
+    invalid state update, so we surface timing rather than crash).
+    """
+    if isinstance(result, dict):
+        merged = dict(result)
+    else:
+        merged = {}
+    merged["node_timings"] = {name: duration}
+    return merged
+
+
+def timed_node(name: str, fn: NodeFn) -> NodeFn:
+    """Wrap a graph node ``fn`` so it records its wall-clock duration.
+
+    One duration per node execution (the node's ``await`` wall-clock). For the
+    parallel ``direct_kg``/``cold_start`` superstep these overlap, so summed
+    per-node durations can exceed total wall-clock — total wall-clock is exact,
+    per-node is approximate under concurrency (surfaced as a caveat in the report).
+    """
+
+    async def wrapped(state: dict) -> Any:
+        start = time.time()
+        result = await fn(state)  # node errors surface unchanged (not guarded)
+        try:
+            return _attach_timing(result, name, time.time() - start)
+        except Exception:  # noqa: BLE001 - timing must never break the pipeline
+            logger.warning(
+                "timed_node(%s): timing/merge failed; passing node result through unchanged",
+                name,
+                exc_info=True,
+            )
+            return result
+
+    wrapped.__name__ = f"timed_{name}"
+    return wrapped

--- a/backend/src/kestrel_backend/graph/timing.py
+++ b/backend/src/kestrel_backend/graph/timing.py
@@ -14,6 +14,7 @@ unchanged. The wrapped node call itself is *not* guarded: a node raising is the
 node's own error and must surface as before.
 """
 
+import functools
 import logging
 import time
 from typing import Any, Awaitable, Callable
@@ -35,6 +36,15 @@ def _attach_timing(result: Any, name: str, duration: float) -> dict:
     if isinstance(result, dict):
         merged = dict(result)
     else:
+        if result is not None:
+            # A non-dict return is an invalid state update — we cannot merge it, so
+            # the node's output is dropped. Log it: silence would make a node that
+            # accidentally returns a non-dict a zero-signal correctness landmine.
+            logger.warning(
+                "timed_node(%s): node returned non-dict %s; state update dropped",
+                name,
+                type(result).__name__,
+            )
         merged = {}
     merged["node_timings"] = {name: duration}
     return merged
@@ -49,6 +59,7 @@ def timed_node(name: str, fn: NodeFn) -> NodeFn:
     per-node is approximate under concurrency (surfaced as a caveat in the report).
     """
 
+    @functools.wraps(fn)
     async def wrapped(state: dict) -> Any:
         start = time.time()
         result = await fn(state)  # node errors surface unchanged (not guarded)
@@ -62,5 +73,6 @@ def timed_node(name: str, fn: NodeFn) -> NodeFn:
             )
             return result
 
+    # Keep functools.wraps' metadata but give the wrapper a distinct, traceable name.
     wrapped.__name__ = f"timed_{name}"
     return wrapped

--- a/backend/src/kestrel_backend/main.py
+++ b/backend/src/kestrel_backend/main.py
@@ -520,8 +520,10 @@ async def handle_pipeline_mode(
     start_time = time.time()
     nodes_completed = 0
     accumulated_state: dict[str, Any] = {}
+    # node_timings is authoritative from the timed_node wrapper (graph/timing.py),
+    # accumulated below via an explicit dict-merge. Initialized empty for the
+    # no-nodes-ran case.
     node_timings: dict[str, float] = {}
-    node_start_times: dict[str, float] = {}
 
     langfuse = _get_pipeline_langfuse()
     trace = None
@@ -594,20 +596,28 @@ async def handle_pipeline_mode(
 
             for key, value in node_output.items():
                 existing = accumulated_state.get(key)
+                # node_timings is a dict reducer field (merge_node_timings) — merge it,
+                # don't last-write-wins. _get_concat_fields() only detects operator.add,
+                # so node_timings is NOT in CONCAT_LIST_FIELDS and would otherwise be
+                # overwritten on every yield, collapsing to the last node only.
+                if key == "node_timings" and isinstance(value, dict):
+                    merged = dict(existing) if isinstance(existing, dict) else {}
+                    merged.update(value)
+                    accumulated_state[key] = merged
                 # Only concatenate lists for fields with operator.add reducer
                 # Other fields use last-write-wins (e.g., hypotheses, synthesis_report)
-                if isinstance(existing, list) and isinstance(value, list) and key in CONCAT_LIST_FIELDS:
+                elif isinstance(existing, list) and isinstance(value, list) and key in CONCAT_LIST_FIELDS:
                     accumulated_state[key] = existing + value
                 else:
                     accumulated_state[key] = value
 
-            now = time.time()
-            node_start = node_start_times.get(node_name, now)
-            duration_ms = int((now - node_start) * 1000)
-            node_timings[node_name] = now - node_start
-
-            if node_name not in node_start_times:
-                node_start_times[node_name] = now
+            # Authoritative per-node duration comes from the timed_node wrapper
+            # (graph/timing.py), surfaced as node_output["node_timings"][node_name].
+            # This replaces the old first-seen/overwrite inline timing (which produced
+            # 0s on a node's only yield and over-counted multi-yield nodes).
+            node_duration = (node_output.get("node_timings") or {}).get(node_name)
+            duration_ms = int((node_duration or 0.0) * 1000)
+            node_timings = accumulated_state.get("node_timings", {})
 
             nodes_completed += 1
 

--- a/backend/src/kestrel_backend/pricing.py
+++ b/backend/src/kestrel_backend/pricing.py
@@ -1,0 +1,121 @@
+"""Per-model token pricing for the performance report's cost estimate.
+
+Generalizes the hardcoded Sonnet-4.5 computation in ``agent.py:340-348``
+(``TurnMetrics.cost_usd``) into a per-model rate map. Rates are USD per 1M
+tokens. Cost is an **estimate** — the table is maintained by hand and can drift
+from actual billing; ``LAST_VERIFIED`` records when it was last checked against
+the published pricing, and unknown models return ``None`` (logged) rather than a
+guessed number.
+
+Source: the ``claude-api`` skill reference (Anthropic published pricing).
+Cache-read ≈ 0.1× input; cache-write (5-minute TTL) ≈ 1.25× input.
+"""
+
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+# Last time the rates below were checked against published Anthropic pricing.
+LAST_VERIFIED = "2026-06-22"
+
+
+@dataclass(frozen=True)
+class Rate:
+    """USD per 1M tokens for one model family."""
+
+    input: float
+    output: float
+    cache_read: float
+    cache_creation: float
+
+
+# Keyed by a canonical family token (see _family_of). Rates per 1M tokens.
+_RATES: dict[str, Rate] = {
+    # Opus 4.5–4.8: $5 / $25 in/out.
+    "opus-4-8": Rate(5.0, 25.0, 0.50, 6.25),
+    "opus-4-7": Rate(5.0, 25.0, 0.50, 6.25),
+    "opus-4-6": Rate(5.0, 25.0, 0.50, 6.25),
+    "opus-4-5": Rate(5.0, 25.0, 0.50, 6.25),
+    # Opus 4.0 / 4.1 (legacy): $15 / $75 in/out.
+    "opus-4-1": Rate(15.0, 75.0, 1.50, 18.75),
+    "opus-4-0": Rate(15.0, 75.0, 1.50, 18.75),
+    # Sonnet 4.x (incl. claude-sonnet-4-20250514, the pipeline default): $3 / $15.
+    "sonnet-4": Rate(3.0, 15.0, 0.30, 3.75),
+    # Haiku 4.5: $1 / $5.
+    "haiku-4-5": Rate(1.0, 5.0, 0.10, 1.25),
+    # Fable 5 / Mythos 5: $10 / $50.
+    "fable-5": Rate(10.0, 50.0, 1.00, 12.50),
+    "mythos-5": Rate(10.0, 50.0, 1.00, 12.50),
+}
+
+
+def _family_of(model_name: str) -> str | None:
+    """Map a free-form model id to a canonical rate-map family token.
+
+    ``ModelUsageRecord.model_name`` is free-form (e.g. ``anthropic/claude-sonnet-4-20250514``,
+    ``claude-opus-4-8``). Normalize by lowercasing and matching the most specific
+    family key contained in the id. Returns ``None`` if no family matches.
+    """
+    if not model_name:
+        return None
+    name = model_name.lower()
+    # Most specific keys first so "opus-4-8" wins over a hypothetical "opus-4".
+    for family in sorted(_RATES, key=len, reverse=True):
+        if family in name:
+            return family
+    return None
+
+
+def rate_for(model_name: str) -> Rate | None:
+    """Return the Rate for a model id, or None (with a warning) if unknown."""
+    family = _family_of(model_name)
+    if family is None:
+        logger.warning("pricing: no rate for model %r — cost will be null", model_name)
+        return None
+    return _RATES[family]
+
+
+def cost_of_record(
+    *,
+    model_name: str,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cache_read_tokens: int = 0,
+    cache_creation_tokens: int = 0,
+) -> float | None:
+    """Estimated USD cost for one model-usage record, or None if the model is unknown.
+
+    Records are per-call deltas (each ``ModelUsageRecord`` is one API call), so summing
+    them is correct — there is no cumulative counter to double-count.
+    """
+    rate = rate_for(model_name)
+    if rate is None:
+        return None
+    return (
+        input_tokens * rate.input
+        + output_tokens * rate.output
+        + cache_read_tokens * rate.cache_read
+        + cache_creation_tokens * rate.cache_creation
+    ) / 1_000_000
+
+
+def estimate_cost(records) -> float:
+    """Total estimated USD across model-usage records.
+
+    Each record is a ``ModelUsageRecord`` (or any object exposing the same token
+    attributes). Records with an unknown model contribute 0 to the total (the
+    unknown is logged by ``rate_for``); an empty list returns 0.0.
+    """
+    total = 0.0
+    for r in records:
+        cost = cost_of_record(
+            model_name=getattr(r, "model_name", ""),
+            input_tokens=getattr(r, "input_tokens", 0),
+            output_tokens=getattr(r, "output_tokens", 0),
+            cache_read_tokens=getattr(r, "cache_read_tokens", 0),
+            cache_creation_tokens=getattr(r, "cache_creation_tokens", 0),
+        )
+        if cost is not None:
+            total += cost
+    return total

--- a/backend/src/kestrel_backend/run_reports_io.py
+++ b/backend/src/kestrel_backend/run_reports_io.py
@@ -1,0 +1,172 @@
+"""Durable, fail-safe artifact I/O for the per-node performance report.
+
+Surface-agnostic: this module owns disk emission only (atomic write, owner-only
+permissions, retention pruning, git SHA). It raises normally — the fail-safe
+wrapper that guarantees a reporting failure can never break a user-facing run
+lives in the reporting node (plan Unit 5). Retention pruning, however, is
+swallowed inside :func:`write_report` so a prune failure never blocks a write.
+
+Security (plan Unit 3): artifacts contain the raw user query and cost data.
+The directory is created mode 700 without a world-readable window, and each file
+is created mode 600 *at creation* (``O_EXCL``), never world-readable even
+transiently. Filenames use an opaque run-id, never a query slug.
+"""
+
+import functools
+import json
+import logging
+import os
+import subprocess
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RETENTION = 200
+ENV_RETENTION = "REPORT_RETENTION_MAX"
+
+# backend/run_reports/. This file is backend/src/kestrel_backend/run_reports_io.py,
+# so parents[2] is the backend/ root.
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_DIR = _BACKEND_ROOT / "run_reports"
+
+
+def new_run_id() -> str:
+    """Opaque, non-reversible run identifier (used in filenames and the report)."""
+    return uuid.uuid4().hex
+
+
+def utc_timestamp() -> str:
+    """UTC timestamp for filenames, matching the brown harness convention."""
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+@functools.lru_cache(maxsize=1)
+def get_git_sha() -> str:
+    """Deployed commit SHA, computed once and memoized (not per-request).
+
+    Catches only the expected failures and returns ``"unknown"`` without logging
+    the repo path (avoids leaking an absolute filesystem path into logs).
+    """
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=str(_BACKEND_ROOT),
+        )
+        return out.stdout.strip() or "unknown"
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        logger.warning("git_sha lookup failed; using 'unknown'")
+        return "unknown"
+
+
+def _ensure_dir(d: Path) -> None:
+    """Create ``d`` mode 700 without a world-readable window."""
+    old = os.umask(0o077)
+    try:
+        d.mkdir(mode=0o700, parents=True, exist_ok=True)
+    finally:
+        os.umask(old)
+    os.chmod(d, 0o700)  # enforce 700 even if the dir pre-existed with looser perms
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    """Write ``content`` to ``path`` atomically, mode 600 at creation.
+
+    Uses ``O_EXCL`` so the temp file is created mode 600 from the first byte
+    (never world-readable pre-chmod), then ``os.replace`` for an atomic rename —
+    a crash before the rename leaves no partial final file.
+    """
+    tmp = path.with_name(path.name + ".tmp")
+    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+        os.replace(str(tmp), str(path))
+    except BaseException:
+        # Clean up the temp on any failure (write or rename) so no partial file lingers.
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def _resolve_retention(max_pairs: int | None) -> int:
+    if max_pairs is not None:
+        return max_pairs
+    raw = os.environ.get(ENV_RETENTION)
+    if raw:
+        try:
+            return int(raw)
+        except ValueError:
+            logger.warning(
+                "invalid %s=%r; using default %d", ENV_RETENTION, raw, DEFAULT_RETENTION
+            )
+    return DEFAULT_RETENTION
+
+
+def _mtime(p: Path) -> float:
+    try:
+        return p.stat().st_mtime
+    except FileNotFoundError:
+        return 0.0  # concurrently deleted — sort it to the end
+
+
+def prune(out_dir: Path, *, max_pairs: int | None = None) -> int:
+    """Keep the newest ``max_pairs`` report pairs by mtime; delete older ones.
+
+    Best-effort under concurrent runs (``SDK_SEMAPHORE`` allows parallel writers):
+    ignores in-flight ``*.tmp`` files and swallows ``FileNotFoundError`` from a
+    concurrent pruner. Returns the number of pairs targeted for removal.
+    """
+    cap = _resolve_retention(max_pairs)
+    if cap <= 0:
+        return 0
+    d = Path(out_dir)
+    if not d.is_dir():
+        return 0
+    jsons = [p for p in d.glob("*.json") if not p.name.endswith(".tmp")]
+    jsons.sort(key=_mtime, reverse=True)  # newest first
+    stale_pairs = jsons[cap:]
+    for stale in stale_pairs:
+        for path in (stale, stale.with_suffix(".md")):
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass  # concurrent pruner already removed it
+    return len(stale_pairs)
+
+
+def write_report(
+    report_json: dict,
+    markdown: str,
+    *,
+    run_id: str | None = None,
+    out_dir: Path | str | None = None,
+    timestamp: str | None = None,
+    retention: int | None = None,
+) -> dict:
+    """Write the JSON + Markdown report pair to disk and prune old reports.
+
+    Returns ``{"json": Path, "md": Path, "run_id": str}``. May raise on a real
+    I/O failure (disk full, permissions) — the caller (reporting node) wraps this
+    so the run is never broken. Pruning is internally swallowed.
+    """
+    directory = Path(out_dir) if out_dir is not None else DEFAULT_DIR
+    rid = run_id or new_run_id()
+    ts = timestamp or utc_timestamp()
+    _ensure_dir(directory)
+    base = f"{ts}_{rid}"
+    json_path = directory / f"{base}.json"
+    md_path = directory / f"{base}.md"
+    _atomic_write(json_path, json.dumps(report_json, indent=2, default=str))
+    _atomic_write(md_path, markdown)
+    try:
+        prune(directory, max_pairs=retention)
+    except Exception:  # noqa: BLE001 - prune must never block a successful write
+        logger.warning("run_reports prune failed", exc_info=True)
+    return {"json": json_path, "md": md_path, "run_id": rid}

--- a/backend/src/kestrel_backend/run_reports_io.py
+++ b/backend/src/kestrel_backend/run_reports_io.py
@@ -17,6 +17,7 @@ import json
 import logging
 import os
 import subprocess
+import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -25,6 +26,9 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_RETENTION = 200
 ENV_RETENTION = "REPORT_RETENTION_MAX"
+# A live atomic write holds its .tmp for milliseconds; any .tmp older than this was
+# orphaned by a hard abort (SIGKILL/OOM) mid-write and is safe to sweep.
+_TMP_STALE_SECONDS = 300
 
 # backend/run_reports/. This file is backend/src/kestrel_backend/run_reports_io.py,
 # so parents[2] is the backend/ root.
@@ -119,6 +123,21 @@ def _mtime(p: Path) -> float:
         return 0.0  # concurrently deleted — sort it to the end
 
 
+def _sweep_stale_temps(d: Path) -> None:
+    """Delete orphaned ``*.tmp`` older than the stale threshold.
+
+    A concurrent writer's temp is milliseconds old, so it is never swept; only temps
+    left behind by a hard abort (SIGKILL/OOM between os.open and rename) are removed.
+    """
+    now = time.time()
+    for tmp in d.glob("*.tmp"):
+        try:
+            if now - tmp.stat().st_mtime > _TMP_STALE_SECONDS:
+                tmp.unlink()
+        except FileNotFoundError:
+            pass  # concurrently removed
+
+
 def prune(out_dir: Path, *, max_pairs: int | None = None) -> int:
     """Keep the newest ``max_pairs`` report pairs by mtime; delete older ones.
 
@@ -126,11 +145,14 @@ def prune(out_dir: Path, *, max_pairs: int | None = None) -> int:
     ignores in-flight ``*.tmp`` files and swallows ``FileNotFoundError`` from a
     concurrent pruner. Returns the number of pairs targeted for removal.
     """
-    cap = _resolve_retention(max_pairs)
-    if cap <= 0:
-        return 0
     d = Path(out_dir)
     if not d.is_dir():
+        return 0
+    # Sweep orphaned *.tmp left by a hard abort mid-write (O_EXCL can't self-heal, and
+    # the pair-cap loop below ignores *.tmp). Done regardless of the retention cap.
+    _sweep_stale_temps(d)
+    cap = _resolve_retention(max_pairs)
+    if cap <= 0:
         return 0
     jsons = [p for p in d.glob("*.json") if not p.name.endswith(".tmp")]
     jsons.sort(key=_mtime, reverse=True)  # newest first

--- a/backend/src/kestrel_backend/run_reports_io.py
+++ b/backend/src/kestrel_backend/run_reports_io.py
@@ -56,21 +56,24 @@ def get_git_sha() -> str:
             text=True,
             check=True,
             cwd=str(_BACKEND_ROOT),
+            timeout=5,  # never hang the event loop on a stalled/locked git (esp. GDrive-synced repo)
         )
         return out.stdout.strip() or "unknown"
-    except (subprocess.CalledProcessError, FileNotFoundError):
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
         logger.warning("git_sha lookup failed; using 'unknown'")
         return "unknown"
 
 
 def _ensure_dir(d: Path) -> None:
-    """Create ``d`` mode 700 without a world-readable window."""
-    old = os.umask(0o077)
-    try:
-        d.mkdir(mode=0o700, parents=True, exist_ok=True)
-    finally:
-        os.umask(old)
-    os.chmod(d, 0o700)  # enforce 700 even if the dir pre-existed with looser perms
+    """Create ``d`` mode 700, owner-only at every moment.
+
+    No ``os.umask`` (a process-global side effect that races under concurrency):
+    ``mkdir(mode=0o700)`` has no group/other bits for umask to *add*, so the dir is
+    never world-readable even at creation, and the explicit ``chmod`` enforces 700
+    on a dir that pre-existed with looser perms.
+    """
+    d.mkdir(mode=0o700, parents=True, exist_ok=True)
+    os.chmod(d, 0o700)
 
 
 def _atomic_write(path: Path, content: str) -> None:
@@ -164,7 +167,16 @@ def write_report(
     json_path = directory / f"{base}.json"
     md_path = directory / f"{base}.md"
     _atomic_write(json_path, json.dumps(report_json, indent=2, default=str))
-    _atomic_write(md_path, markdown)
+    try:
+        _atomic_write(md_path, markdown)
+    except BaseException:
+        # Keep the pair atomic: don't leave an orphaned .json (which holds the raw
+        # query) on disk if the markdown half fails.
+        try:
+            os.unlink(json_path)
+        except FileNotFoundError:
+            pass
+        raise
     try:
         prune(directory, max_pairs=retention)
     except Exception:  # noqa: BLE001 - prune must never block a successful write

--- a/backend/tests/test_langgraph_prototype.py
+++ b/backend/tests/test_langgraph_prototype.py
@@ -1693,7 +1693,7 @@ class TestEndToEndPhase4b:
     @pytest.mark.asyncio
     async def test_graph_has_all_expected_nodes(self):
         """Graph should have all 12 analysis nodes (ground-before-synthesis + bridge_grounding
-        evidence-provenance labeler) plus __start__."""
+        evidence-provenance labeler) plus the terminal reporting node and __start__."""
         graph = build_discovery_graph()
         node_names = list(graph.nodes.keys())
 
@@ -1710,13 +1710,14 @@ class TestEndToEndPhase4b:
             "hypothesis_extraction",
             "literature_grounding",
             "synthesis",
+            "reporting",
         ]
 
         for node in expected_nodes:
             assert node in node_names, f"Missing node: {node}"
 
-        # 12 analysis nodes (incl. bridge_grounding + hypothesis_extraction) + __start__
-        assert len(node_names) == 13, f"Expected 13 nodes (12 + __start__), got {len(node_names)}: {node_names}"
+        # 12 analysis nodes + reporting (terminal perf-report node) + __start__
+        assert len(node_names) == 14, f"Expected 14 nodes (13 + __start__), got {len(node_names)}: {node_names}"
 
     @pytest.mark.asyncio
     async def test_full_pipeline_non_longitudinal(self):
@@ -2461,8 +2462,9 @@ class TestGroundBeforeSynthesisTopology:
         node_names = [n for n in graph.nodes.keys() if n != "__start__"]
         assert "hypothesis_extraction" in node_names
         assert "bridge_grounding" in node_names
-        # 12 analysis nodes + __start__ in the raw dict.
-        assert len(graph.nodes.keys()) == 13, f"got {len(graph.nodes.keys())}: {list(graph.nodes.keys())}"
+        assert "reporting" in node_names
+        # 12 analysis nodes + reporting + __start__ in the raw dict.
+        assert len(graph.nodes.keys()) == 14, f"got {len(graph.nodes.keys())}: {list(graph.nodes.keys())}"
 
     def test_new_edges_present_old_edges_gone(self):
         graph = build_discovery_graph()
@@ -2473,8 +2475,11 @@ class TestGroundBeforeSynthesisTopology:
         assert ("hypothesis_extraction", "bridge_grounding") in edges
         assert ("bridge_grounding", "literature_grounding") in edges
         assert ("literature_grounding", "synthesis") in edges
-        assert ("synthesis", "__end__") in edges
+        # synthesis now flows into the terminal reporting node, then END
+        assert ("synthesis", "reporting") in edges
+        assert ("reporting", "__end__") in edges
         # Old topology removed
+        assert ("synthesis", "__end__") not in edges
         assert ("synthesis", "literature_grounding") not in edges
         assert ("literature_grounding", "__end__") not in edges
         assert ("temporal", "synthesis") not in edges

--- a/backend/tests/test_performance_report.py
+++ b/backend/tests/test_performance_report.py
@@ -129,6 +129,53 @@ def test_no_errors_renders_none():
     assert "## Errors\n\nNone." in md
 
 
+def test_node_with_usage_but_no_timing():
+    # Reverse of test_node_with_timing_but_no_usage: a node with model_usages but no
+    # node_timings entry (the extras/usages_by_node path) is reported as ran.
+    state = {
+        "node_timings": {"intake": 1.0},
+        "model_usages": [_usage("synthesis", input_tokens=500)],
+        "errors": [],
+    }
+    report = pr.build_report(state, _meta())
+    synth = next(n for n in report["nodes"] if n["node"] == "synthesis")
+    assert synth["status"] == "ran"
+    assert synth["duration_s"] is None
+    assert synth["input_tokens"] == 500
+
+
+def test_node_cost_mixed_known_and_unknown_models():
+    # A node with one known + one unknown model -> cost is the sum of the known only.
+    state = {
+        "node_timings": {"synthesis": 1.0},
+        "model_usages": [
+            _usage("synthesis", model="claude-sonnet-4-6", input_tokens=1_000_000),  # $3
+            _usage("synthesis", model="gpt-4o", input_tokens=1_000_000),  # unknown -> skipped
+        ],
+        "errors": [],
+    }
+    report = pr.build_report(state, _meta())
+    synth = next(n for n in report["nodes"] if n["node"] == "synthesis")
+    assert synth["cost_usd"] == 3.0  # known only, not None, not 0
+
+
+def test_summed_estimate_when_wall_clock_absent():
+    # The v1 reporting-node path: no wall_clock_s -> summed estimate, pct sums to 100%,
+    # and the markdown caveat reflects the estimate.
+    state = {
+        "node_timings": {"intake": 1.0, "synthesis": 3.0},
+        "model_usages": [],
+        "errors": [],
+    }
+    report = pr.build_report(state, _meta())  # no wall_clock_s
+    assert report["totals"]["wall_clock_source"] == "summed_estimate"
+    assert report["totals"]["wall_clock_s"] == 4.0
+    pcts = [n["pct_of_total"] for n in report["nodes"] if n.get("pct_of_total") is not None]
+    assert sum(pcts) == 100.0  # share-of-summed, never exceeds 100
+    md = pr.render_markdown(report)
+    assert "sum of per-node durations" in md
+
+
 def test_report_is_json_serializable():
     import json
 

--- a/backend/tests/test_performance_report.py
+++ b/backend/tests/test_performance_report.py
@@ -1,0 +1,141 @@
+"""Unit 4: report builder (state -> JSON dict + Markdown)."""
+
+from kestrel_backend.graph import performance_report as pr
+from kestrel_backend.graph.state import ModelUsageRecord
+
+
+def _usage(node, model="claude-sonnet-4-6", **kw):
+    return ModelUsageRecord(model_name=model, node_name=node, **kw)
+
+
+def _meta(**kw):
+    base = {
+        "run_id": "abc123",
+        "query": "SECRET PATIENT QUERY",
+        "mode": "pipeline",
+        "biomapper_env": "production",
+        "timestamp": "20260622T120000Z",
+        "git_sha": "deadbeef",
+    }
+    base.update(kw)
+    return base
+
+
+def test_happy_path_serial_nodes():
+    state = {
+        "node_timings": {"intake": 1.0, "synthesis": 3.0},
+        "model_usages": [
+            _usage("intake", input_tokens=100, output_tokens=10),
+            _usage("synthesis", input_tokens=1000, output_tokens=500, mcp_tool_calls=2),
+        ],
+        "errors": [],
+    }
+    report = pr.build_report(state, _meta(wall_clock_s=4.0))
+
+    by_node = {n["node"]: n for n in report["nodes"]}
+    assert by_node["intake"]["status"] == "ran"
+    assert by_node["intake"]["pct_of_total"] == 25.0
+    assert by_node["synthesis"]["pct_of_total"] == 75.0
+    assert by_node["synthesis"]["input_tokens"] == 1000
+    assert by_node["synthesis"]["mcp_tool_calls"] == 2
+    # Totals
+    assert report["totals"]["input_tokens"] == 1100
+    assert report["totals"]["output_tokens"] == 510
+    assert report["totals"]["wall_clock_s"] == 4.0
+    # Headline
+    assert report["headline"]["top_bottleneck_node"] == "synthesis"
+    assert report["headline"]["top_cost_node"] == "synthesis"
+
+
+def test_conditional_node_skipped():
+    state = {"node_timings": {"intake": 1.0}, "model_usages": [], "errors": []}
+    report = pr.build_report(state, _meta())
+    by_node = {n["node"]: n for n in report["nodes"]}
+    # cold_start never ran on this path
+    assert by_node["cold_start"]["status"] == "skipped"
+    assert "duration_s" not in by_node["cold_start"]
+
+
+def test_node_with_timing_but_no_usage():
+    state = {"node_timings": {"triage": 0.5}, "model_usages": [], "errors": []}
+    report = pr.build_report(state, _meta())
+    triage = next(n for n in report["nodes"] if n["node"] == "triage")
+    assert triage["status"] == "ran"
+    assert triage["input_tokens"] == 0
+    assert triage["cost_usd"] is None  # no usage records -> no cost
+
+
+def test_unknown_model_cost_none_and_renders_na():
+    state = {
+        "node_timings": {"synthesis": 1.0},
+        "model_usages": [_usage("synthesis", model="gpt-4o", input_tokens=1000)],
+        "errors": [],
+    }
+    report = pr.build_report(state, _meta())
+    synth = next(n for n in report["nodes"] if n["node"] == "synthesis")
+    assert synth["cost_usd"] is None
+    md = pr.render_markdown(report)
+    assert "est. n/a" in md  # rendered, not crashed
+
+
+def test_concurrency_pct_can_exceed_100_no_crash():
+    # Two nodes overlapping the same 2s wall-clock window: durations sum to 4 but
+    # wall-clock is 2 -> summed pct = 200%. Must not crash or clamp wrongly.
+    state = {
+        "node_timings": {"direct_kg": 2.0, "cold_start": 2.0},
+        "model_usages": [],
+        "errors": [],
+    }
+    report = pr.build_report(state, _meta(wall_clock_s=2.0))
+    by_node = {n["node"]: n for n in report["nodes"]}
+    assert by_node["direct_kg"]["pct_of_total"] == 100.0
+    assert by_node["cold_start"]["pct_of_total"] == 100.0  # sums to 200%
+    md = pr.render_markdown(report)
+    assert "overlap" in md.lower()  # caveat present
+
+
+def test_markdown_omits_raw_query_shows_run_id():
+    state = {"node_timings": {"intake": 1.0}, "model_usages": [], "errors": []}
+    report = pr.build_report(state, _meta(query="SECRET PATIENT QUERY", run_id="rid999"))
+    # JSON keeps the full query for reproducibility...
+    assert report["query"] == "SECRET PATIENT QUERY"
+    # ...the Markdown (Outline-bound) must not.
+    md = pr.render_markdown(report)
+    assert "SECRET PATIENT QUERY" not in md
+    assert "rid999" in md
+
+
+def test_markdown_is_valid_gfm_table():
+    state = {"node_timings": {"intake": 1.0}, "model_usages": [], "errors": []}
+    md = pr.render_markdown(pr.build_report(state, _meta()))
+    assert "| Node | Status |" in md
+    assert "|---|---|---|---|---|---|---|---|---|---|---|" in md
+    assert md.count("\n## ") >= 2  # Per-node + Errors sections
+
+
+def test_errors_rendered_at_run_level():
+    state = {
+        "node_timings": {"synthesis": 1.0},
+        "model_usages": [],
+        "errors": ["synthesis: fell back to deterministic report"],
+    }
+    md = pr.render_markdown(pr.build_report(state, _meta()))
+    assert "synthesis: fell back to deterministic report" in md
+
+
+def test_no_errors_renders_none():
+    state = {"node_timings": {"intake": 1.0}, "model_usages": [], "errors": []}
+    md = pr.render_markdown(pr.build_report(state, _meta()))
+    assert "## Errors\n\nNone." in md
+
+
+def test_report_is_json_serializable():
+    import json
+
+    state = {
+        "node_timings": {"synthesis": 1.0},
+        "model_usages": [_usage("synthesis", input_tokens=10)],
+        "errors": ["x"],
+    }
+    report = pr.build_report(state, _meta())
+    json.dumps(report)  # must not raise (no Pydantic objects leak into the dict)

--- a/backend/tests/test_pipeline_report_integration.py
+++ b/backend/tests/test_pipeline_report_integration.py
@@ -1,0 +1,141 @@
+"""Unit 6: WS-path node_timings regression guard + integration.
+
+Drives the real ``handle_pipeline_mode`` with a mocked ``stream_discovery`` that
+yields per-node ``node_timings`` deltas (as the timed_node wrapper produces), and
+asserts main.py's accumulator merges them into the full dict — the regression
+this unit prevents (a dict reducer field is not in CONCAT_LIST_FIELDS, so without
+an explicit dict-merge branch it collapses to last-write-wins).
+"""
+
+import json
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from src.kestrel_backend import main
+from src.kestrel_backend.graph import runner
+
+
+def _sent(ws):
+    return [json.loads(c.args[0]) for c in ws.send_text.call_args_list]
+
+
+def _multi_node_stream(query, conversation_history=None, config=None, biomapper_env=None):
+    """Yield three nodes, each carrying its own node_timings delta (wrapper shape)."""
+
+    async def _gen():
+        yield {
+            "type": "node_update",
+            "node": "intake",
+            "node_output": {"raw_entities": [], "node_timings": {"intake": 1.0}},
+        }
+        yield {
+            "type": "node_update",
+            "node": "triage",
+            "node_output": {"node_timings": {"triage": 2.0}},
+        }
+        yield {
+            "type": "node_update",
+            "node": "synthesis",
+            "node_output": {
+                "synthesis_report": "FINAL REPORT",
+                "node_timings": {"synthesis": 3.0},
+            },
+        }
+
+    return _gen()
+
+
+@pytest.fixture
+def captured_turn(monkeypatch):
+    """Disable langfuse, capture add_turn metrics, wire a conversation id."""
+    monkeypatch.setattr(main, "_get_pipeline_langfuse", lambda: None)
+    monkeypatch.setattr(runner, "stream_discovery", _multi_node_stream)
+
+    captured = {}
+
+    async def fake_add_turn(**kwargs):
+        captured.update(kwargs)
+        return uuid4()
+
+    monkeypatch.setattr(main, "add_turn", fake_add_turn)
+
+    conn = "conn-report-int"
+    main.conversation_ids[conn] = uuid4()
+    main.turn_counters[conn] = 0
+    yield conn, captured
+    main.conversation_ids.pop(conn, None)
+
+
+@pytest.mark.asyncio
+async def test_node_timings_merged_across_nodes(captured_turn):
+    conn, captured = captured_turn
+    ws = AsyncMock()
+    await main.handle_pipeline_mode(ws, "metabolite X disease Y", conn)
+
+    metrics = captured.get("metrics", {})
+    timings = metrics.get("node_timings", {})
+    # Regression guard: ALL three nodes present, not collapsed to the last one.
+    assert timings == {"intake": 1.0, "triage": 2.0, "synthesis": 3.0}
+
+
+@pytest.mark.asyncio
+async def test_authoritative_duration_in_detail_messages(captured_turn):
+    conn, _ = captured_turn
+    ws = AsyncMock()
+    await main.handle_pipeline_mode(ws, "q", conn)
+
+    details = {m["node"]: m for m in _sent(ws) if m.get("type") == "pipeline_node_detail"}
+    # duration_ms is sourced from the wrapper's authoritative per-node timing.
+    assert details["synthesis"]["duration_ms"] == 3000
+    assert details["intake"]["duration_ms"] == 1000
+
+
+@pytest.mark.asyncio
+async def test_ws_run_streams_normally(captured_turn):
+    conn, _ = captured_turn
+    ws = AsyncMock()
+    await main.handle_pipeline_mode(ws, "q", conn)
+    types = [m.get("type") for m in _sent(ws)]
+    assert "pipeline_complete" in types
+    assert "done" in types
+    assert "error" not in types
+
+
+@pytest.mark.asyncio
+async def test_reporting_node_in_stream_does_not_break_ws(captured_turn):
+    """A `reporting` node update in the stream (not in NODE_STATUS_MESSAGES) is skipped
+    by the WS accumulator and does not disrupt completion — fail-safe behavior of the
+    reporting node itself is covered in test_reporting_node.py."""
+    conn, _ = captured_turn
+
+    def stream_with_reporting(query, conversation_history=None, config=None, biomapper_env=None):
+        async def _gen():
+            yield {
+                "type": "node_update",
+                "node": "synthesis",
+                "node_output": {"synthesis_report": "R", "node_timings": {"synthesis": 1.0}},
+            }
+            yield {
+                "type": "node_update",
+                "node": "reporting",
+                "node_output": {"report_path": "/tmp/x.json", "node_timings": {"reporting": 0.1}},
+            }
+
+        return _gen()
+
+    import pytest as _pytest  # local to avoid confusion
+
+    monkeypatch = _pytest.MonkeyPatch()
+    monkeypatch.setattr(runner, "stream_discovery", stream_with_reporting)
+    try:
+        ws = AsyncMock()
+        await main.handle_pipeline_mode(ws, "q", conn)
+        types = [m.get("type") for m in _sent(ws)]
+        assert "pipeline_complete" in types and "done" in types
+        # reporting is invisible to the WS stream (not in NODE_STATUS_MESSAGES)
+        nodes = {m.get("node") for m in _sent(ws) if m.get("type") == "pipeline_progress"}
+        assert "reporting" not in nodes
+    finally:
+        monkeypatch.undo()

--- a/backend/tests/test_pricing.py
+++ b/backend/tests/test_pricing.py
@@ -1,0 +1,94 @@
+"""Unit 2: per-model pricing module."""
+
+from dataclasses import dataclass
+
+from kestrel_backend import pricing
+
+
+@dataclass
+class FakeUsage:
+    model_name: str
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
+
+
+def test_known_model_hand_computed_cost():
+    # Sonnet: 1M input + 1M output = $3 + $15 = $18.
+    cost = pricing.cost_of_record(
+        model_name="claude-sonnet-4-6", input_tokens=1_000_000, output_tokens=1_000_000
+    )
+    assert cost == 18.0
+
+
+def test_cache_tokens_included():
+    # Sonnet cache: 1M cache_read ($0.30) + 1M cache_creation ($3.75) = $4.05.
+    cost = pricing.cost_of_record(
+        model_name="claude-sonnet-4-6",
+        cache_read_tokens=1_000_000,
+        cache_creation_tokens=1_000_000,
+    )
+    assert round(cost, 6) == 4.05
+
+
+def test_freeform_model_name_normalizes():
+    # The pipeline's actual model_name shape.
+    assert pricing.rate_for("anthropic/claude-sonnet-4-20250514") == pricing.rate_for(
+        "claude-sonnet-4-6"
+    )
+
+
+def test_opus_distinct_from_sonnet():
+    opus = pricing.cost_of_record(model_name="claude-opus-4-8", input_tokens=1_000_000)
+    sonnet = pricing.cost_of_record(model_name="claude-sonnet-4-6", input_tokens=1_000_000)
+    assert opus == 5.0
+    assert sonnet == 3.0
+
+
+def test_reproduces_legacy_sonnet_number():
+    # Mirrors agent.py:340-348 TurnMetrics.cost_usd for a Sonnet-only call.
+    cost = pricing.cost_of_record(
+        model_name="claude-sonnet-4-20250514",
+        input_tokens=10_000,
+        output_tokens=2_000,
+        cache_read_tokens=5_000,
+        cache_creation_tokens=1_000,
+    )
+    expected = (10_000 * 3.0 + 2_000 * 15.0 + 5_000 * 0.30 + 1_000 * 3.75) / 1_000_000
+    assert round(cost, 10) == round(expected, 10)
+
+
+def test_unknown_model_returns_none(caplog):
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        cost = pricing.cost_of_record(model_name="gpt-4o", input_tokens=1_000)
+    assert cost is None
+    assert any("no rate for model" in rec.message for rec in caplog.records)
+
+
+def test_unknown_model_does_not_raise():
+    # estimate_cost must tolerate unknown models (contribute 0), never raise.
+    records = [
+        FakeUsage("claude-sonnet-4-6", input_tokens=1_000_000),  # $3
+        FakeUsage("some-unknown-model", input_tokens=1_000_000),  # 0
+    ]
+    assert pricing.estimate_cost(records) == 3.0
+
+
+def test_empty_records_is_zero_not_none():
+    assert pricing.estimate_cost([]) == 0.0
+
+
+def test_estimate_sums_per_call_deltas():
+    # Two separate calls sum (records are per-call deltas, safe to sum).
+    records = [
+        FakeUsage("claude-sonnet-4-6", input_tokens=1_000_000),
+        FakeUsage("claude-sonnet-4-6", output_tokens=1_000_000),
+    ]
+    assert pricing.estimate_cost(records) == 18.0
+
+
+def test_last_verified_present():
+    assert pricing.LAST_VERIFIED  # documented "as-of" date for drift tracking

--- a/backend/tests/test_reporting_node.py
+++ b/backend/tests/test_reporting_node.py
@@ -1,0 +1,76 @@
+"""Unit 5: reporting terminal node + graph wiring (fail-safe)."""
+
+import asyncio
+
+from kestrel_backend import run_reports_io
+from kestrel_backend.graph.builder import build_discovery_graph
+from kestrel_backend.graph.nodes import reporting
+
+
+def _state():
+    return {
+        "raw_query": "what connects X and Y?",
+        "biomapper_env": "production",
+        "node_timings": {"intake": 1.0, "synthesis": 2.0},
+        "model_usages": [],
+        "errors": [],
+    }
+
+
+def test_reporting_writes_pair(tmp_path, monkeypatch):
+    monkeypatch.setattr(run_reports_io, "DEFAULT_DIR", tmp_path)
+    result = asyncio.run(reporting.run(_state()))
+    assert "report_path" in result
+    assert list(tmp_path.glob("*.json")) and list(tmp_path.glob("*.md"))
+
+
+def test_reporting_omits_raw_query_from_markdown(tmp_path, monkeypatch):
+    monkeypatch.setattr(run_reports_io, "DEFAULT_DIR", tmp_path)
+    state = _state()
+    state["raw_query"] = "SECRET PATIENT QUERY"
+    asyncio.run(reporting.run(state))
+    md = next(tmp_path.glob("*.md")).read_text()
+    js = next(tmp_path.glob("*.json")).read_text()
+    assert "SECRET PATIENT QUERY" not in md  # markdown is Outline-bound
+    assert "SECRET PATIENT QUERY" in js  # full query retained in JSON
+
+
+def test_failsafe_on_write_error(tmp_path, monkeypatch):
+    # R4: a write failure is swallowed; run() returns {} and does not raise.
+    def boom(*_a, **_k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(reporting.run_reports_io, "write_report", boom)
+    result = asyncio.run(reporting.run(_state()))
+    assert result == {}
+
+
+def test_failsafe_on_build_error(monkeypatch):
+    # R4: a build failure (malformed state) is swallowed; no partial artifact, no raise.
+    def boom(*_a, **_k):
+        raise ValueError("malformed state")
+
+    monkeypatch.setattr(reporting, "build_report", boom)
+    result = asyncio.run(reporting.run(_state()))
+    assert result == {}
+
+
+def test_graph_wires_reporting_after_synthesis():
+    g = build_discovery_graph().get_graph()
+    node_ids = set(g.nodes)
+    assert "reporting" in node_ids
+    edges = {(e.source, e.target) for e in g.edges}
+    assert ("synthesis", "reporting") in edges
+    # reporting flows to END (LangGraph's terminal node id is "__end__")
+    assert any(src == "reporting" and tgt in ("__end__", "END") for src, tgt in edges)
+    # synthesis no longer goes directly to END
+    assert not any(
+        src == "synthesis" and tgt in ("__end__", "END") for src, tgt in edges
+    )
+
+
+def test_reporting_not_in_node_status_messages():
+    # Intentionally invisible to the WS stream in v1.
+    from kestrel_backend.protocol import NODE_STATUS_MESSAGES
+
+    assert "reporting" not in NODE_STATUS_MESSAGES

--- a/backend/tests/test_reporting_node.py
+++ b/backend/tests/test_reporting_node.py
@@ -74,3 +74,13 @@ def test_reporting_not_in_node_status_messages():
     from kestrel_backend.protocol import NODE_STATUS_MESSAGES
 
     assert "reporting" not in NODE_STATUS_MESSAGES
+
+
+def test_pipeline_nodes_matches_graph():
+    """Drift guard: every graph node (minus __start__/__end__/reporting) must be in
+    PIPELINE_NODES, else build_report silently marks a real node as an 'extra'."""
+    from kestrel_backend.graph.performance_report import PIPELINE_NODES
+
+    g = build_discovery_graph().get_graph()
+    graph_nodes = {n for n in g.nodes if n not in ("__start__", "__end__", "reporting")}
+    assert graph_nodes == set(PIPELINE_NODES)

--- a/backend/tests/test_run_reports_io.py
+++ b/backend/tests/test_run_reports_io.py
@@ -1,0 +1,142 @@
+"""Unit 3: artifact I/O — atomic write, perms, retention, git_sha."""
+
+import os
+import stat
+import subprocess
+
+import pytest
+
+from kestrel_backend import run_reports_io as io
+
+
+def _mode(p) -> int:
+    return stat.S_IMODE(os.stat(p).st_mode)
+
+
+def test_write_report_produces_pair_with_owner_only_perms(tmp_path):
+    result = io.write_report({"report_version": 1}, "# md", out_dir=tmp_path / "rr")
+    assert result["json"].exists() and result["md"].exists()
+    assert result["json"].suffix == ".json" and result["md"].suffix == ".md"
+    assert _mode(result["json"]) == 0o600
+    assert _mode(result["md"]) == 0o600
+    assert _mode(tmp_path / "rr") == 0o700
+
+
+def test_filename_uses_run_id_not_query(tmp_path):
+    result = io.write_report(
+        {"query": "secret patient query"}, "# md", out_dir=tmp_path, run_id="abc123"
+    )
+    assert "abc123" in result["json"].name
+    assert "secret" not in result["json"].name
+
+
+def test_temp_file_is_600_at_creation(tmp_path, monkeypatch):
+    # Capture the temp file's mode at the moment of rename — it must be 600 the
+    # whole time, never world-readable pre-chmod.
+    captured = {}
+    real_replace = os.replace
+
+    def spy_replace(src, dst):
+        captured["mode"] = stat.S_IMODE(os.stat(src).st_mode)
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(io.os, "replace", spy_replace)
+    io._atomic_write(tmp_path / "x.json", "data")
+    assert captured["mode"] == 0o600
+
+
+def test_atomic_write_leaves_no_tmp_on_success(tmp_path):
+    io.write_report({"a": 1}, "md", out_dir=tmp_path)
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_atomic_write_failure_leaves_no_partial_final(tmp_path, monkeypatch):
+    # If the write fails before rename, the final path must not exist.
+    target = tmp_path / "fail.json"
+
+    def boom(*_a, **_k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(io.os, "replace", boom)
+    with pytest.raises(OSError):
+        io._atomic_write(target, "data")
+    assert not target.exists()
+    assert list(tmp_path.glob("*.tmp")) == []  # temp cleaned up
+
+
+def test_prune_keeps_newest_cap_pairs(tmp_path):
+    # Create 205 pairs with strictly increasing mtimes; cap 200 keeps the newest 200.
+    for i in range(205):
+        base = tmp_path / f"r{i:03d}"
+        j = base.with_suffix(".json")
+        m = base.with_suffix(".md")
+        j.write_text("{}")
+        m.write_text("md")
+        os.utime(j, (i, i))  # older index = older mtime
+        os.utime(m, (i, i))
+    removed = io.prune(tmp_path, max_pairs=200)
+    assert removed == 5
+    remaining = sorted(p.stem for p in tmp_path.glob("*.json"))
+    assert len(remaining) == 200
+    assert "r000" not in remaining  # 5 oldest gone
+    assert "r004" not in remaining
+    assert "r005" in remaining
+
+
+def test_prune_ignores_tmp_files(tmp_path):
+    (tmp_path / "a.json").write_text("{}")
+    (tmp_path / "inflight.json.tmp").write_text("{}")
+    io.prune(tmp_path, max_pairs=200)
+    assert (tmp_path / "inflight.json.tmp").exists()  # in-flight write untouched
+
+
+def test_prune_tolerates_concurrent_deletion(tmp_path):
+    # Two prune passes target the same stale files; the second swallows FileNotFoundError.
+    for i in range(3):
+        base = tmp_path / f"r{i}"
+        base.with_suffix(".json").write_text("{}")
+        base.with_suffix(".md").write_text("md")
+        os.utime(base.with_suffix(".json"), (i, i))
+        os.utime(base.with_suffix(".md"), (i, i))
+    assert io.prune(tmp_path, max_pairs=1) == 2  # removes r0, r1
+    # Second pass with same cap: nothing left to remove, no error.
+    assert io.prune(tmp_path, max_pairs=1) == 0
+    assert (tmp_path / "r2.json").exists()  # newest survives
+
+
+def test_prune_respects_env_default(tmp_path, monkeypatch):
+    monkeypatch.setenv(io.ENV_RETENTION, "1")
+    for i in range(3):
+        base = tmp_path / f"r{i}"
+        base.with_suffix(".json").write_text("{}")
+        os.utime(base.with_suffix(".json"), (i, i))
+    assert io.prune(tmp_path) == 2  # env cap = 1
+
+
+def test_write_report_prune_failure_does_not_block_write(tmp_path, monkeypatch):
+    monkeypatch.setattr(io, "prune", lambda *a, **k: (_ for _ in ()).throw(OSError("boom")))
+    result = io.write_report({"a": 1}, "md", out_dir=tmp_path)
+    assert result["json"].exists()  # report still persisted despite prune failure
+
+
+def test_get_git_sha_returns_hex_in_repo():
+    io.get_git_sha.cache_clear()
+    sha = io.get_git_sha()
+    # In this repo it's a 40-char hex; tolerate "unknown" if git is somehow absent.
+    assert sha == "unknown" or (len(sha) == 40 and all(c in "0123456789abcdef" for c in sha))
+
+
+def test_get_git_sha_unknown_when_git_missing(tmp_path, monkeypatch, caplog):
+    import logging
+
+    io.get_git_sha.cache_clear()
+
+    def no_git(*_a, **_k):
+        raise FileNotFoundError("git not found")
+
+    monkeypatch.setattr(io.subprocess, "run", no_git)
+    with caplog.at_level(logging.WARNING):
+        assert io.get_git_sha() == "unknown"
+    io.get_git_sha.cache_clear()  # don't poison other tests
+    # No absolute path leaked into the log message.
+    assert all("/home/" not in rec.message for rec in caplog.records)

--- a/backend/tests/test_run_reports_io.py
+++ b/backend/tests/test_run_reports_io.py
@@ -83,11 +83,31 @@ def test_prune_keeps_newest_cap_pairs(tmp_path):
     assert "r005" in remaining
 
 
-def test_prune_ignores_tmp_files(tmp_path):
+def test_prune_ignores_fresh_tmp_files(tmp_path):
     (tmp_path / "a.json").write_text("{}")
-    (tmp_path / "inflight.json.tmp").write_text("{}")
+    (tmp_path / "inflight.json.tmp").write_text("{}")  # fresh => an in-flight write
     io.prune(tmp_path, max_pairs=200)
     assert (tmp_path / "inflight.json.tmp").exists()  # in-flight write untouched
+
+
+def test_prune_sweeps_stale_tmp_files(tmp_path):
+    # An orphaned .tmp (old mtime) left by a crashed write is swept; a fresh one is kept.
+    stale = tmp_path / "orphan.json.tmp"
+    stale.write_text("{}")
+    os.utime(stale, (1, 1))  # ancient mtime
+    fresh = tmp_path / "inflight.json.tmp"
+    fresh.write_text("{}")
+    io.prune(tmp_path, max_pairs=200)
+    assert not stale.exists()  # orphan swept
+    assert fresh.exists()  # live write preserved
+
+
+def test_prune_sweeps_stale_tmp_even_when_retention_disabled(tmp_path):
+    stale = tmp_path / "orphan.json.tmp"
+    stale.write_text("{}")
+    os.utime(stale, (1, 1))
+    io.prune(tmp_path, max_pairs=0)  # cap disabled, but temps still swept
+    assert not stale.exists()
 
 
 def test_prune_tolerates_concurrent_deletion(tmp_path):

--- a/backend/tests/test_run_reports_io.py
+++ b/backend/tests/test_run_reports_io.py
@@ -113,6 +113,34 @@ def test_prune_respects_env_default(tmp_path, monkeypatch):
     assert io.prune(tmp_path) == 2  # env cap = 1
 
 
+def test_prune_invalid_env_falls_back_to_default(tmp_path, monkeypatch, caplog):
+    import logging
+
+    monkeypatch.setenv(io.ENV_RETENTION, "not_a_number")
+    with caplog.at_level(logging.WARNING):
+        assert io._resolve_retention(None) == io.DEFAULT_RETENTION
+    assert any("invalid" in rec.message.lower() for rec in caplog.records)
+
+
+def test_write_report_unlinks_json_if_md_fails(tmp_path, monkeypatch):
+    # The pair must be atomic: a failed .md write must not leave an orphaned .json
+    # (which holds the raw query) behind.
+    calls = {"n": 0}
+    real_atomic = io._atomic_write
+
+    def flaky(path, content):
+        calls["n"] += 1
+        if calls["n"] == 2:  # second call is the .md write
+            raise OSError("md write failed")
+        return real_atomic(path, content)
+
+    monkeypatch.setattr(io, "_atomic_write", flaky)
+    with pytest.raises(OSError):
+        io.write_report({"query": "secret"}, "md", out_dir=tmp_path, run_id="r1")
+    assert list(tmp_path.glob("*.json")) == []  # json half cleaned up
+    assert list(tmp_path.glob("*.md")) == []
+
+
 def test_write_report_prune_failure_does_not_block_write(tmp_path, monkeypatch):
     monkeypatch.setattr(io, "prune", lambda *a, **k: (_ for _ in ()).throw(OSError("boom")))
     result = io.write_report({"a": 1}, "md", out_dir=tmp_path)

--- a/backend/tests/test_synthesis_fallback_marker.py
+++ b/backend/tests/test_synthesis_fallback_marker.py
@@ -1,0 +1,76 @@
+"""Unit 7: synthesis emits a run-level marker when it silently falls back.
+
+The motivating degradation (context overflow) returns HTTP-success with empty
+text, so without this marker the run reads as status=complete, errors=0 and the
+failure is invisible to the performance report.
+"""
+
+import asyncio
+
+import pytest
+
+from kestrel_backend.graph.nodes import synthesis
+from kestrel_backend.graph.state import Finding
+
+
+def _state():
+    # SynthesisInput requires at least one direct/cold_start finding.
+    return {
+        "raw_query": "what connects X and Y?",
+        "resolved_entities": [],
+        "direct_findings": [
+            Finding(entity="CHEBI:17234", claim="glucose assoc", tier=1, source="direct_kg")
+        ],
+        "cold_start_findings": [],
+        "hypotheses": [],
+        "bridges": [],
+    }
+
+
+def _run(state):
+    return asyncio.run(synthesis.run(state))
+
+
+def test_no_marker_on_successful_synthesis(monkeypatch):
+    async def ok(*_a, **_k):
+        return "A full synthesis report.", None
+
+    monkeypatch.setattr(synthesis, "HAS_SDK", True)
+    monkeypatch.setattr(synthesis, "query_with_usage", ok)
+    result = _run(_state())
+    assert result["synthesis_report"].startswith("A full synthesis report.")
+    assert not result.get("errors")  # no degradation -> no marker
+
+
+def test_marker_on_empty_llm_output(monkeypatch):
+    # The overflow case: HTTP-success but empty text.
+    async def empty(*_a, **_k):
+        return "   ", None
+
+    monkeypatch.setattr(synthesis, "HAS_SDK", True)
+    monkeypatch.setattr(synthesis, "query_with_usage", empty)
+    result = _run(_state())
+    assert "errors" in result
+    assert any("empty output" in e for e in result["errors"])
+    # report still produced via the deterministic fallback
+    assert result["synthesis_report"]
+
+
+def test_marker_on_sdk_exception(monkeypatch):
+    async def boom(*_a, **_k):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(synthesis, "HAS_SDK", True)
+    monkeypatch.setattr(synthesis, "query_with_usage", boom)
+    result = _run(_state())
+    assert "errors" in result
+    assert any("RuntimeError" in e and "LLM call failed" in e for e in result["errors"])
+    assert result["synthesis_report"]
+
+
+def test_no_marker_when_sdk_unavailable(monkeypatch):
+    # SDK-unavailable is an environment condition, not a degradation -> no marker.
+    monkeypatch.setattr(synthesis, "HAS_SDK", False)
+    result = _run(_state())
+    assert not result.get("errors")
+    assert result["synthesis_report"]

--- a/backend/tests/test_timing_wrapper.py
+++ b/backend/tests/test_timing_wrapper.py
@@ -46,12 +46,17 @@ def test_wraps_empty_dict_return():
     assert "integration" in result["node_timings"]
 
 
-def test_wraps_nondict_return_without_raising():
+def test_wraps_nondict_return_without_raising(caplog):
+    import logging
+
     async def node(state):
         return ["not", "a", "dict"]  # invalid state update, must not crash the wrapper
 
-    result = asyncio.run(timed_node("weird", node)({}))
+    with caplog.at_level(logging.WARNING):
+        result = asyncio.run(timed_node("weird", node)({}))
     assert result["node_timings"]["weird"] >= 0.0
+    # A dropped non-dict state update must not be silent.
+    assert any("non-dict" in rec.message for rec in caplog.records)
 
 
 def test_shallow_copy_preserves_reducer_values_identity():

--- a/backend/tests/test_timing_wrapper.py
+++ b/backend/tests/test_timing_wrapper.py
@@ -1,0 +1,148 @@
+"""Unit 1: per-node timing wrapper + node_timings merge reducer.
+
+Covers the plan's Unit 1 test scenarios: dict/None/non-dict returns, the
+defensive pass-through when the wrapper's own logic fails, the merge reducer
+under parallel branches, and an end-to-end check that a two-branch graph writes
+node_timings without raising LangGraph's InvalidUpdateError.
+"""
+
+import asyncio
+
+import pytest
+
+from kestrel_backend.graph import timing
+from kestrel_backend.graph.timing import timed_node
+from kestrel_backend.graph.state import merge_node_timings
+
+
+# --- timed_node wrapper ------------------------------------------------------
+
+def test_wraps_dict_return_adds_timing():
+    async def node(state):
+        return {"errors": ["x"]}
+
+    result = asyncio.run(timed_node("intake", node)({}))
+    assert result["errors"] == ["x"]
+    assert "node_timings" in result
+    assert set(result["node_timings"]) == {"intake"}
+    assert result["node_timings"]["intake"] >= 0.0
+
+
+def test_wraps_none_return_still_carries_timing():
+    async def node(state):
+        return None
+
+    result = asyncio.run(timed_node("triage", node)({}))
+    assert result == {"node_timings": {"triage": result["node_timings"]["triage"]}}
+    assert result["node_timings"]["triage"] >= 0.0
+
+
+def test_wraps_empty_dict_return():
+    async def node(state):
+        return {}
+
+    result = asyncio.run(timed_node("integration", node)({}))
+    assert list(result.keys()) == ["node_timings"]
+    assert "integration" in result["node_timings"]
+
+
+def test_wraps_nondict_return_without_raising():
+    async def node(state):
+        return ["not", "a", "dict"]  # invalid state update, must not crash the wrapper
+
+    result = asyncio.run(timed_node("weird", node)({}))
+    assert result["node_timings"]["weird"] >= 0.0
+
+
+def test_shallow_copy_preserves_reducer_values_identity():
+    # Reducer-bound list objects must pass through unchanged (not deep-copied / rebuilt).
+    sentinel = [object()]
+
+    async def node(state):
+        return {"model_usages": sentinel}
+
+    result = asyncio.run(timed_node("synthesis", node)({}))
+    assert result["model_usages"] is sentinel
+
+
+def test_duration_at_least_sleep():
+    async def node(state):
+        await asyncio.sleep(0.02)
+        return {}
+
+    result = asyncio.run(timed_node("slow", node)({}))
+    assert result["node_timings"]["slow"] >= 0.02
+
+
+def test_node_exception_propagates_unchanged():
+    # A node raising is the node's own error and must surface (wrapper does not guard fn()).
+    async def node(state):
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError, match="boom"):
+        asyncio.run(timed_node("intake", node)({}))
+
+
+def test_wrapper_defensive_when_timing_logic_raises(monkeypatch):
+    # If the wrapper's own timing/merge logic raises, the node's result returns unchanged.
+    original = {"errors": ["keep me"]}
+
+    async def node(state):
+        return original
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("timing exploded")
+
+    monkeypatch.setattr(timing, "_attach_timing", boom)
+    result = asyncio.run(timed_node("intake", node)({}))
+    assert result is original  # unchanged; pipeline unaffected
+
+
+# --- merge_node_timings reducer ----------------------------------------------
+
+def test_merge_disjoint_keys():
+    assert merge_node_timings({"direct_kg": 1.0}, {"cold_start": 2.0}) == {
+        "direct_kg": 1.0,
+        "cold_start": 2.0,
+    }
+
+
+def test_merge_handles_none_operands():
+    assert merge_node_timings(None, {"a": 1.0}) == {"a": 1.0}
+    assert merge_node_timings({"a": 1.0}, None) == {"a": 1.0}
+    assert merge_node_timings(None, None) == {}
+
+
+def test_merge_key_collision_keeps_right():
+    assert merge_node_timings({"a": 1.0}, {"a": 2.0}) == {"a": 2.0}
+
+
+# --- integration: reducer prevents InvalidUpdateError on parallel writes ------
+
+def test_two_parallel_branches_write_node_timings_without_error():
+    """A minimal graph fanning out to two nodes that both write node_timings must
+    merge (not raise InvalidUpdateError) and retain both keys."""
+    from typing import Annotated, TypedDict
+
+    from langgraph.graph import StateGraph, END
+
+    class MiniState(TypedDict, total=False):
+        node_timings: Annotated[dict, merge_node_timings]
+
+    async def left(state):
+        return {}
+
+    async def right(state):
+        return {}
+
+    g = StateGraph(MiniState)
+    g.add_node("left", timed_node("left", left))
+    g.add_node("right", timed_node("right", right))
+    # Fan out from entry to both, then both to END (same superstep convergence).
+    g.set_conditional_entry_point(lambda s: ["left", "right"], {"left": "left", "right": "right"})
+    g.add_edge("left", END)
+    g.add_edge("right", END)
+    compiled = g.compile()
+
+    result = asyncio.run(compiled.ainvoke({}))
+    assert set(result["node_timings"]) == {"left", "right"}

--- a/docs/brainstorms/2026-06-22-pipeline-node-performance-report-requirements.md
+++ b/docs/brainstorms/2026-06-22-pipeline-node-performance-report-requirements.md
@@ -1,0 +1,132 @@
+# Per-Node Pipeline Performance Report — Requirements
+
+_Brainstorm date: 2026-06-22 · Status: requirements — reviewed (7-persona document-review applied) + scope decided (disk-only v1, queries sensitive) · ready for ce:plan · Branch context: `perf/bridge-grounding-parallel-cache`_
+
+## Problem
+
+The KRAKEN discovery pipeline runs 12 nodes per query, each making paid LLM calls and MCP graph queries. When a run is slow, expensive, or degrades (e.g. the synthesis-overflow wall, `pathway_enrichment` at ~307s), there is **no single durable artifact that attributes time, tokens, cost, and failures to individual nodes**. Today the data is ~70% latent — and much of the aggregation logic already exists, scattered and not durably emitted:
+
+- Every node already times itself with `time.time()` and logs duration. The `DiscoveryState.node_timings` *TypedDict field* (`graph/state.py:456`) is never written, **but `main.py` already computes a local `node_timings` dict** (main.py:523, 605-610) inside the WebSocket handler and persists it to the Langfuse trace (main.py:686) and the DB turn metrics (main.py:714). So timing capture is not greenfield — it exists, only inside the WS path, and (see Key architectural constraint) it has a known overwrite bug.
+- `main.py` also already maintains an **accumulator** (`accumulated_state` merged via `CONCAT_LIST_FIELDS`, main.py:522, 595-602) that drains every streamed node delta — exactly the "accumulate as it streams" mechanism this report needs.
+- `model_usages` (`graph/state.py:451`, frozen `ModelUsageRecord` at `:337`) already captures per-node `input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_creation_tokens`, `mcp_tool_calls`, and `available_tools`, each tagged with `node_name`.
+- Per-node **counts already have extractors**: `graph/node_detail_extractors.py` implements `extract_node_details(node_name, state)` with a 12-node `_EXTRACTORS` dispatch (entities resolved, edges, bridges, hypotheses, etc.), already called at main.py:631.
+- `errors` (`graph/state.py:455`) is a flat `list[str]` accumulated via `operator.add` — **it carries no node field** (see Per-node rows for the attribution consequence).
+- The Brown eval harness (`backend/assessment_data/brown_c1_pilot_e2e.py`) hand-rolls a `node_timeline` + coverage counts — reinventing a slice of this report for one harness only.
+
+The missing piece is therefore **not a new accumulator but one shared, surface-agnostic reporter** that lifts the existing per-node aggregation (timing + tokens + cost + counts + errors) out of the WS handler, fixes the timing bug, adds cost + serialization + durable emission, and runs for *every* entry path — not just the WebSocket one.
+
+## Goal
+
+Auto-generate a per-node performance report at the end of **every** discovery pipeline run (prod WebSocket, LangGraph Studio, and eval harnesses alike). The report's job is **node-level bottleneck + cost + failure attribution** — not a raw timing dump.
+
+### Non-goals
+
+- Not replacing Langfuse tracing (LLM-call-level observability stays in Langfuse).
+- Not a real-time dashboard. This is an end-of-run artifact.
+- Not a billing system of record — the `$` figure is an estimate (see Cost below).
+
+## Scope decision (load-bearing)
+
+**Every pipeline run.** The aggregator lives in the streaming path (`stream_discovery()` in `graph/runner.py`) and fires once per run. Two consequences follow directly:
+
+1. **Fail-safe is mandatory — at two distinct points.** This sits on the prod request path, and aggregation now runs *during* the stream, not only at the end. So two guards are required: (a) **per-yield accumulation** must be individually wrapped — an exception draining a single delta (e.g. a non-serializable `node_output`) logs a warning and skips that delta but **never aborts the stream**; (b) **end-of-run emission** (serialization + disk write) must be wrapped so any failure (disk full, serialization error, missing field) logs a warning and is swallowed. Together these guarantee a reporting failure can **never** break or delay a user-facing run.
+2. **Auto-save by default.** Per the artifact-hygiene SOP, and because every run makes paid LLM calls (expensive to reproduce), the artifact is written by default. An `--out`/path override is allowed, but there is no flag that gates *whether* it saves.
+
+### v1 scope — disk-only (decided 2026-06-22)
+
+**v1 ships the disk artifact (JSON + Markdown) only.** The `performance_report` WebSocket event + frontend renderer are **deferred to v2**. Rationale: the disk artifact fully serves the stated dev/research audience, and the WS path carries a large UI-spec surface (loading/error/empty/no-event states, responsive layout for a wide node table, counts render contract, error-row treatment) that is not worth gating v1 on. Consequences:
+
+- The reporter is **surface-agnostic** and owns disk emission only. No `protocol.py` event type and no `client/src/` work in v1.
+- The browser-payload concerns (cost visibility to users, `git_sha` exposure) are **moot for v1** — nothing report-related is sent to the browser. They return as open decisions when v2 (the WS event) is scoped.
+- v2, when scoped, must specify the deferred UI states above and the cost-visibility decision (all authenticated users vs operator-only).
+
+## Key architectural constraint
+
+`stream_discovery()` uses `stream_mode="updates"`, so the runner does **not** retain full accumulated state — the underlying graph yields one node's delta per step, and the caller accumulates. Two implementation facts must be pinned (both verified against source):
+
+- **Yield shape.** `stream_discovery()` does not yield raw `{node_name: node_output}` — it wraps each as `{"type": "node_update", "node": node_name, "node_output": node_output}` (runner.py:85-89). A reporter placed *inside* the runner consumes the raw `event.items()` loop; one placed at the caller consumes the wrapped form. `main.py` also filters out `__start__` and non-status nodes (main.py:592) — the reporter must replicate that filtering or it will time/cost phantom nodes.
+- **Reuse the existing accumulator.** The reporter must **accumulate as it streams** by draining each node's delta into running `model_usages` / `errors` lists — which is what main.py already does. Prefer extracting that logic over rewriting it (see Open items: reuse-vs-rewrite decision).
+
+**Per-node timing — known bug + multi-yield rule.** The existing main.py timing (605-610) records `node_start_times[node]` only on first sighting but overwrites `node_timings[node]` on *every* sighting. Nodes with `operator.add` reducers (e.g. `resolved_entities`, `direct_findings`, `model_usages`) yield **multiple deltas** per run from parallel `asyncio.gather` batches, so for those nodes `duration = now − first_seen` grows monotonically and double-counts unrelated intervening wall-clock — not merely "approximate concurrent work." The plan MUST define an explicit accumulation rule for multi-yield nodes (e.g. sum per-delta intervals, or measure first-start→last-yield) and pick the per-node timing *source* (see Open items). Caveat to retain: with truly parallel branches, any inter-yield attribution is approximate; **total wall-clock is exact**.
+
+## Report contents
+
+### Run-level header (reproducibility — SOP)
+
+- `query` (and `mode`: classic vs discovery)
+- `timestamp` (run start, ISO 8601)
+- `git_sha` (current commit; pins code version). Capture as a **build/deploy-time constant** (e.g. baked into an env var at deploy), not a per-request `git rev-parse` subprocess — the every-run scope means this runs on the prod request path. Keep `git_sha` and `biomapper_env` in the **disk artifact only**; omit them from the browser-facing WS payload (no need to fingerprint the deployed commit to end users).
+- `biomapper_env` (production/dev toggle — affects entity resolution behavior)
+- Totals: wall-clock seconds, total tokens (in/out/cache), total estimated `$`
+- Derived headline: top bottleneck node (by duration) and top cost node (by `$`)
+
+### Per-node rows
+
+| Field | Source |
+|---|---|
+| `node` | stream key |
+| `status` (ok / error / skipped) | derived from `errors` + whether node ran |
+| `duration_s` + `pct_of_total` | populated `node_timings` |
+| `input_tokens` / `output_tokens` / `cache_read_tokens` / `cache_creation_tokens` | `model_usages` |
+| `model(s)` | `model_usages.model_name` |
+| `cost_usd` (estimate) | tokens × per-model pricing map |
+| `mcp_tool_calls` | `model_usages.mcp_tool_calls` |
+| `counts` (node-specific findings: entities resolved, edges, bridges, hypotheses, etc.) | **reuse `node_detail_extractors.extract_node_details`** (already exists, 12-node dispatch) — do not redesign |
+| `errors` | `errors` is a flat `list[str]` with **no node field** — attribute by the stream delta the error arrived in (see below) |
+
+> **Error attribution caveat.** Because `errors` carries no node tag, per-node attribution is only possible via *which streamed delta the error appeared in*. This works in the streaming path but is approximate under parallel branches and is **lost entirely in the non-streaming `run_discovery()` path** (no per-delta visibility). The plan must either accept delta-origin attribution (and document its limits) or change nodes to emit structured, node-tagged errors. Acceptance criteria are worded accordingly.
+
+## Output formats — JSON + Markdown
+
+Both emitted per run.
+
+- **JSON** — machine-readable; canonical artifact for diffing across runs and feeding eval tooling. Stable schema (versioned with a `report_version` field).
+- **Markdown** — human-readable; ranks nodes by time and cost so a bottleneck is visible at a glance. **Ultimate destination: the BioMapper collection in the Phenome Health wiki (Outline).** The markdown should therefore be Outline-publishable as-is (publishable via the `publish-wiki` skill — plain GFM tables, no exotic embeds). **Publication is a manual, curated step — never per-run auto-publish.** See Security for query-text handling in Outline-bound reports.
+
+## Delivery — disk only (v1)
+
+- **Disk:** timestamped artifact written by default. Proposed location: a dedicated run-reports directory (e.g. `backend/run_reports/<timestamp>_<run-id>.{json,md}`) rather than `assessment_data/` (which is eval-specific). Use a run-id/hash in the filename, **not** a query slug — a query slug leaks user query text into directory listings.
+  - **Retention is a v1 requirement, not an open item.** Because the writer is default-on for every prod run on a single shared Lightsail box, an unbounded writer can fill prod disk and take down the user-facing service the fail-safe was meant to protect. The writer and a retention bound MUST ship together — **do not merge the writer ahead of the pruner.** (Specific policy — e.g. keep last N pairs vs total-size cap — is a decision below.)
+  - **File permissions:** create `run_reports/` mode `700` and write each artifact mode `600` (owner `ubuntu` only). Artifacts contain the raw query and cost data; default umask would leave them group/world-readable.
+- **WebSocket: deferred to v2** (see *v1 scope* above). No `protocol.py` event type or `client/src/` renderer in v1.
+
+## Security — query-text handling (decided 2026-06-22)
+
+User queries are treated as **potentially sensitive** (may contain PII/PHI/proprietary hypotheses). Therefore:
+
+- **Disk artifact** stores the **full raw query** (needed for reproducibility), protected by `600` perms / `700` directory and the retention bound.
+- **Outline-bound reports** (the curated Markdown that may be published to the wiki) must **not** carry the raw prod query — replace it with the run-id / a hash. Prod-run reports are **never auto-published**; publishing is a deliberate, per-report human action.
+- **Eval-harness reports** (synthetic queries, e.g. Brown module) carry no sensitive data and may be published freely with the raw query intact.
+- Because the WS event is deferred to v2, no cost/token/query data crosses the browser trust boundary in v1; the cost-visibility (all users vs operator-only) and `git_sha`-exposure decisions return when v2 is scoped.
+
+## Cost estimation — tokens + `$` estimate
+
+Derive `cost_usd` from a per-model pricing map (input/output/cache rates per model id).
+
+- **Drift risk (must document):** the pricing table is maintained by hand and can diverge from actual billing. Mitigations: keep the map in one well-commented constant with a "last verified" date; label the figure "estimated"; include raw token counts so the reader can recompute. Unknown model id → cost `null` + a logged warning, never a crash.
+
+## Acceptance criteria
+
+1. Running any discovery query writes a JSON + Markdown report pair to disk by default, with no flag required.
+2. `node_timings` is populated for every node that ran, using the chosen timing source and multi-yield accumulation rule. Define a **concrete tolerance**: the sum of per-node durations is within a stated bound of total wall-clock (note that under multi-yield re-yields a naive sum can *exceed* wall-clock — the chosen rule must prevent that).
+3. Per-node tokens, MCP tool calls, model, and estimated cost all appear and match `model_usages`. Counts appear via `extract_node_details`. Errors that **can be attributed** (by stream-delta origin) appear on their node; the flat-list limitation is documented.
+4. Reporting failures never break a run — **proven by test**, not assumed: (a) a mid-stream accumulation error (mock a non-serializable delta) is logged and skipped without aborting the stream; (b) an end-of-run serialization/disk error is logged and swallowed while the run completes and streams its result normally.
+5. A retention bound is enforced (ships with the writer): old report pairs are pruned per the chosen policy; `run_reports/` is mode `700` and artifacts mode `600`.
+6. The disk artifact stores the full query; any Outline-bound report substitutes a run-id/hash for the raw prod query; prod-run reports are not auto-published.
+7. The Markdown renders cleanly when published to Outline (no broken tables/embeds).
+8. The Brown harness's bespoke `node_timeline` can be replaced by (or cross-checks against) the shared reporter.
+9. Report header pins `git_sha`, query, mode, `biomapper_env`, and timestamp for reproducibility (disk artifact).
+10. _(v2)_ When the WS `performance_report` event is added: it is emitted and rendered with loading/error/empty/no-event states; `git_sha`/`biomapper_env` excluded from the browser payload; cost-visibility decision (all users vs operator-only) made.
+
+## Open items / decisions for the plan
+
+Genuine forks (no single correct answer — to be resolved before/at planning):
+
+1. **Reporter placement / entry-path coverage.** Placing the reporter only in `stream_discovery()` does **not** cover LangGraph Studio (which invokes `build_discovery_graph` directly) or the non-streaming `run_discovery()` (`ainvoke`). The Goal claims "prod WebSocket, Studio, and eval harnesses alike." Decide: lift aggregation into a **graph-level mechanism** (e.g. a final reporting node / callback) that fires for all three paths, or **narrow the Goal** to drop Studio/`run_discovery`.
+2. **Reuse vs rewrite.** Extract main.py's existing accumulator + timing + `extract_node_details` usage into the shared reporter and have main.py *call* it (single source of truth), or build the reporter alongside (two accumulators on one stream — divergence risk). Recommended: extract.
+3. **Per-node timing source.** Use each node's **exact in-node `time.time()` self-timing** (already measured/logged per node) as the `node_timings` source — exact, immune to the parallel-branch/multi-yield problem — and use inter-yield timestamps only for total wall-clock; vs. fix the stream-delta inter-yield approach. Recommended: in-node self-timing.
+4. **Error attribution.** Accept stream-delta-origin attribution (approximate; lost in `run_discovery()`), or change nodes to emit structured node-tagged errors.
+5. **Retention policy specifics.** A bound is required (see Delivery); choose the mechanism — keep last N pairs, total-size cap, or time-based TTL — and who/what prunes.
+6. **Cost vs Langfuse + pricing-map.** Confirm Langfuse does not already attribute cost per pipeline node before maintaining a parallel hand-kept pricing map; pin pricing-map ownership, "last verified" date, and the model ids actually in use (note `ModelUsageRecord.model_name` is free-form, e.g. `anthropic/claude-sonnet-4-…`). Also decide whether to backfill the unused `cost_usd` DB column or keep cost disk-only.
+7. **JSON schema versioning** + where the schema is documented (`report_version` field).
+8. `ModelUsageRecord` is a **frozen** Pydantic model — the reporter must `model_dump()` it when serializing (a likely cause of the AC-4 serialization failure if missed).

--- a/docs/plans/2026-06-22-002-feat-pipeline-node-performance-report-plan.md
+++ b/docs/plans/2026-06-22-002-feat-pipeline-node-performance-report-plan.md
@@ -1,0 +1,384 @@
+---
+title: "feat: Per-node pipeline performance report (disk-only v1)"
+type: feat
+status: active
+date: 2026-06-22
+deepened: 2026-06-22
+origin: docs/brainstorms/2026-06-22-pipeline-node-performance-report-requirements.md
+---
+
+# feat: Per-node pipeline performance report (disk-only v1)
+
+## Overview
+
+Auto-generate a per-node performance report at the end of **every** discovery pipeline run, written to disk as a JSON artifact plus a human-readable Markdown summary. The report attributes **time, tokens, estimated cost, output counts, and errors** to individual nodes so that bottlenecks (e.g. `pathway_enrichment` ~307s, the synthesis-overflow wall) and cost are visible per run without instrumenting each harness by hand.
+
+The data is ~70% latent already: `main.py` accumulates `model_usages`/`errors`, `node_detail_extractors.py` extracts per-node counts, and `agent.py` already computes a token→$ estimate. The work is to lift that aggregation into a **shared, surface-agnostic reporter** that runs as a **graph-terminal node** (so it fires on the WebSocket path, `run_discovery`, and LangGraph Studio alike), add exact per-node timing, generalize cost to a per-model map, and emit durable artifacts fail-safely.
+
+v1 is **disk-only**. The `performance_report` WebSocket event + frontend renderer are deferred to v2 (see origin: scope decision).
+
+## Problem Frame
+
+When a discovery run is slow, expensive, or degrades, there is no single durable artifact attributing time/tokens/cost/failures to individual nodes (see origin: Problem). The Brown eval harness hand-rolls a `node_timeline` for one harness only. Operators currently SSH for logs or read Langfuse call-by-call. The report's real job is **node-level bottleneck + cost + failure attribution**, emitted automatically.
+
+This sits on the **prod request path** (Lightsail), so the reporter must be fail-safe (never break a user-facing run) and must not grow disk unbounded.
+
+## Requirements Trace
+
+- **R1.** Every discovery run writes a JSON + Markdown report pair to disk by default, no flag required (origin AC1; auto-save SOP).
+- **R2.** Per-node exact duration is captured for every node that ran, on all entry paths (origin AC2, Open item #1, #3).
+- **R3.** Per-node tokens (in/out/cache), model, MCP tool calls, and estimated cost appear and match `model_usages`; counts via `extract_node_details` (origin AC3).
+- **R4.** Reporting failures never break or delay a run — proven by test (origin AC4; fail-safe).
+- **R5.** A retention bound ships with the writer; `run_reports/` is mode 700, artifacts mode 600 (origin AC5, Delivery).
+- **R6.** Query text handling: the disk **JSON** carries the full query (600 perms) for reproducibility; the **Markdown** (the Outline-bound artifact) never prints the raw query — it shows an opaque random `run_id` generated at run start and stored only in the disk JSON (not derivable, never sent to Langfuse/DB). Prod-run reports never auto-published. Full keyed-token/two-destination redaction remains v2 (origin Security decision; AC6).
+- **R7.** Markdown renders cleanly as Outline-publishable GFM (origin AC7).
+- **R8.** The Brown harness's bespoke `node_timeline` can cross-check against / be replaced by the shared reporter (origin AC8).
+- **R9.** Report header pins `git_sha`, query, mode, `biomapper_env`, timestamp for reproducibility (origin AC9).
+
+## Scope Boundaries
+
+- Not replacing Langfuse tracing (LLM-call-level observability stays in Langfuse). The reporter derives cost from the **same** `model_usages` source so the two never diverge.
+- Not a real-time dashboard; end-of-run artifact only.
+- Not a billing system of record — `$` is an estimate.
+- v1 reports errors at **run-level** + per-node ran/skipped status. Per-node error *rows* require node-tagged structured errors — not available from final state without touching nodes — and are deferred (see below).
+
+### Deferred to Separate Tasks
+
+- **WebSocket `performance_report` event + React renderer** (origin: v1 scope decision): v2. Includes loading/error/empty/no-event states, responsive layout, counts render contract, error-row treatment, and the cost-visibility (all-users vs operator-only) + `git_sha`-in-browser decisions.
+- **Node-tagged structured per-node errors** (origin Open item #4): v2 — enables per-node error rows. v1 uses run-level errors.
+- **Full Outline-safe redaction pipeline** (keyed-token + two-destination builder selection): v2, shipped with Outline publishing. v1 already keeps the raw query out of the markdown (opaque `run_id`, R6); v2 generalizes this (e.g. keyed HMAC, redacting other free-text fields if any appear). Note: v1's `run_id` is a *random opaque* id — sufficient because it is never stored anywhere correlatable (not in Langfuse/DB); a keyed HMAC is only needed if the token must be deterministically derivable.
+- **Backfilling the unused `cost_usd` DB column** for pipeline turns (origin Open item #6): out of scope; cost is disk-only in v1.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `backend/src/kestrel_backend/graph/builder.py` — `build_discovery_graph`; full tail chain is `…→hypothesis_extraction→bridge_grounding→literature_grounding→synthesis→END` (literature_grounding runs *before* synthesis). `synthesis` is the terminal functional node — `add_edge("synthesis", END)` at **line 196** is the exact edge to replace with `synthesis→reporting→END`. Conditional branches: triage→`[direct_kg|cold_start]`→pathway_enrichment (both branches run in the **same superstep**); integration→`[temporal|hypothesis_extraction]`. A terminal `reporting` node runs last on every path.
+- `backend/src/kestrel_backend/graph/state.py` — `model_usages` (`Annotated[list, operator.add]`, ~451), `errors` (flat `list[str]`, ~455), `node_timings` (plain `dict[str,float]`, ~456, no reducer). `ModelUsageRecord` (~337) carries `node_name`, tokens, `mcp_tool_calls`; **frozen** (use `model_dump()`).
+- `backend/src/kestrel_backend/graph/node_detail_extractors.py` — `extract_node_details(node_name, state) -> (summary, details)`; 12-node `_EXTRACTORS` dispatch. Reuse for counts; do not redesign.
+- `backend/src/kestrel_backend/agent.py:340-348` — `TurnMetrics.cost_usd` hardcodes Sonnet 4.5 rates ($3/$15/$0.30/$3.75 per 1M). Generalize into a per-model map.
+- `backend/src/kestrel_backend/main.py` — WS path: accumulates state (`CONCAT_LIST_FIELDS`), computes a **buggy** inline `node_timings` (605-610: first-seen start, overwrite every yield), passes it to Langfuse (686) + DB `add_turn` (714, where it is **not persisted**). Langfuse handler attached via `pipeline_config = {"callbacks": [handler]}` (575) — WS path only.
+- `backend/src/kestrel_backend/graph/runner.py` — `run_discovery` (`ainvoke`, 46) and `stream_discovery` (`astream(stream_mode="updates")`, 83); both thread `config`; wrap yields as `{"type":"node_update","node":...,"node_output":...}` (85-89).
+- `backend/langgraph.json` — Studio entry `kestrel_backend.graph.builder:build_discovery_graph` (bypasses runner; **terminal-node approach required for Studio coverage**).
+- `backend/assessment_data/brown_c1_pilot_e2e.py` — artifact pattern: `Path(...)/f"...{datetime.now(timezone.utc):%Y%m%dT%H%M%SZ}.json"`, `json.dumps(artifact, indent=2, default=str)`, `git_sha()` via `subprocess git rev-parse` (56-60), `_meta` block with reproduce-inputs. No retention.
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/reliable-long-running-llm-batch-runs-2026-06-07.md` — persist-by-default; **cost via per-unit deltas, not cumulative counters** (a 150× double-count bug). `model_usages` records are per-call deltas appended via `operator.add`, so summing them is correct — verify no cumulative counter is summed. Atomic write (temp + rename) so a mid-write crash leaves no corrupt JSON.
+- `docs/solutions/best-practices/langfuse-sdk-v3-migration-2026-06-03.md` — exact **fail-safe-on-request-path** pattern: wrap instrumentation in try/except, degrade to no-op, never raise into the response. Langfuse already tracks per-node cost → derive from the same `model_usages` source to avoid divergence.
+- `docs/solutions/best-practices/langgraph-pipeline-production-formalization.md` — template for lifting per-node logic into shared utilities + formalizing state contracts; test aggregation **structure/math**, not non-deterministic LLM values.
+- `docs/solutions/best-practices/discovery-pipeline-one-graph-methods-within-nodes-2026-05-28.md` — report must distinguish "node did not run" (conditional branch skipped, e.g. cold_start/temporal) from "ran with zero".
+- `docs/solutions/developer-experience/pytest-venv-path-spaces-module-invocation-2026-06-01.md` — run `cd backend && uv run python -m pytest tests/ -v -m "not integration"`; full suite has ~16-18 pre-existing failures → validate new test files individually.
+
+### External References
+
+- Per-model token pricing values come from the `claude-api` reference at implementation time (current Opus/Sonnet/Haiku rates), seeded from the existing `agent.py` Sonnet rates. No other external research needed — strongly patterned in-repo.
+
+## Key Technical Decisions
+
+- **Graph-terminal reporting node** (resolves Open item #1): place the reporter as a node after `synthesis` (`synthesis → reporting → END`). Only this covers all three entry paths (WS, `run_discovery`, Studio). A runner/`main.py`-level reporter would miss Studio (`langgraph.json` bypasses the runner).
+- **`timed_node` wrapper + dict-merge reducer** (resolves Open items #2, #3): wrap each node at registration in `builder.py` with a timing wrapper that injects `{node_name: duration}` into the node's returned state; merge via a custom `node_timings` reducer. The reducer is **required, not just convenient**: `direct_kg` and `cold_start` write `node_timings` in the same superstep, and LangGraph raises `InvalidUpdateError` on concurrent writes to a non-reducer field. One duration per node execution (the wall-clock of that node's `await`); path-independent (baked into the compiled graph), concurrency-safe (per-run state, not a shared handler instance), and immune to the stream-delta multi-yield bug. Avoids editing all 12 node bodies. **Concurrency caveat (carried from origin):** for the parallel `direct_kg`/`cold_start` superstep, each node's `await` wall-clock overlaps the other, so summed per-node durations can exceed total wall-clock and `pct_of_total` can exceed 100%. Total wall-clock is exact; per-node durations are approximate under concurrency — surfaced as a caveat in the report. **Defensiveness (R4):** the wrapper and `merge_node_timings` run on *every* node, *outside* the reporting node's try/except — they must each be independently defensive (wrapper catches its own timing errors and still returns the node's result unchanged; reducer never raises on unexpected/None/non-dict values).
+- **Reuse, don't rewrite** (resolves Open item #2): the reporter consumes the same `model_usages`/`errors`/`extract_node_details` the WS path already uses. **The disk artifact reads `node_timings` from the graph's merged final state inside the terminal node — it does not depend on `main.py`.** Unit 6 is still required because Unit 1's reducer change *regresses* `main.py`'s WS-path `node_timings`: `_get_concat_fields()` (main.py:84) only detects `operator.add`, and the accumulator's merge branch (main.py:599) is list-only, so a `dict` reducer field falls to last-write-wins → Langfuse would receive only the last node's timing. Unit 6 must add an **explicit dict-merge branch** for `node_timings` in `main.py`'s accumulator (do **not** rely on `CONCAT_LIST_FIELDS`), which also kills the pre-existing first-seen/overwrite bug. `add_turn` does **not** persist `node_timings` (no such column, database.py:156), so this benefits **Langfuse only**, not the DB.
+- **Cost from `model_usages`, per-model map** (resolves Open item #6): generalize `agent.py` rates into `pricing.py` (model_name → rates, normalization, "last verified" date, unknown→`None` + warn). Same source as Langfuse → no divergence. Don't backfill the DB `cost_usd` column in v1.
+- **Errors at run-level in v1** (resolves Open item #4): a terminal node sees only the flat `errors` list (no stream-delta origin). Report run-level errors + per-node ran/skipped status. Per-node error rows (node-tagged errors) → v2.
+- **Retention = keep last N pairs, prune-on-write** (resolves Open item #5): default `N=200` (env-overridable), oldest pruned during the same fail-safe-wrapped write. No cron dependency. **Best-effort under concurrency**: `SDK_SEMAPHORE=4` allows concurrent runs, so two reporting nodes may prune simultaneously — prune must tolerate already-deleted files (swallow `FileNotFoundError`) and never count/delete an in-flight `*.tmp`; the cap is approximate, not exact, under concurrent writers. Keep prune cheap (stat+unlink only) since it runs on the request path.
+- **Fail-safe + atomic write**: the entire reporting node body is wrapped try/except (logs a warning, never raises); disk write is temp-file + rename; dir 700 / files 600.
+- **git_sha captured once** (resolves R9): memoized `get_git_sha()` (single `git rev-parse` at first call / startup), not a per-request subprocess; catch `CalledProcessError`/`FileNotFoundError` specifically and return `"unknown"` **without logging the exception detail** (avoid leaking the absolute repo path into logs). Correct on the deploy path (deploy does `git reset --hard` then `systemctl restart`, so the fresh process re-memoizes the new HEAD); the only stale case is manual prod branch-checkout *without* restart (documented testing flow) — acceptable.
+- **Schema versioned** (resolves Open item #7): JSON carries `report_version: 1`; schema documented in the module docstring.
+- **Serialization** (resolves Open item #8): `ModelUsageRecord.model_dump()`; `json.dumps(..., default=str)` backstop.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Entry-path coverage → graph-terminal node (Studio-safe).
+- Per-node timing source → `timed_node` wrapper + merge reducer (exact, path-independent).
+- Reuse vs rewrite → extract shared reporter; align `main.py` to authoritative timings.
+- Error attribution → run-level + ran/skipped status v1; node-tagged errors v2.
+- Retention → keep-last-N (200) prune-on-write.
+- Cost vs Langfuse → derive from `model_usages`; no DB backfill v1.
+- Schema versioning, frozen-model serialization → resolved above.
+
+### Deferred to Implementation
+
+- Verify the WS-accumulator dict-merge (Unit 6) against the installed `langgraph` version's `stream_mode="updates"` delta shape (the *design* is committed: an explicit dict branch; only the version-behavior confirmation is deferred).
+- Final per-model rate values (pull current rates from `claude-api` reference; seed from `agent.py:340-348`).
+- Exact module home for `pricing.py` / `run_reports_io.py` (`kestrel_backend/` vs `graph/`) — pick during implementation; keep surface-agnostic (no graph imports in pricing/io).
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart LR
+    subgraph graph["compiled discovery graph (all entry paths)"]
+      direction LR
+      I[intake] --> ER[entity_resolution] --> T[triage]
+      T --> S[...nodes...] --> SY[synthesis] --> R[reporting node NEW]
+      R --> E((END))
+    end
+    W["timed_node wrapper (builder.py)"] -. "injects {node: duration}" .-> graph
+    R --> RB["report builder (state -> report dict)"]
+    RB --> PR["pricing.py (model_usages -> cost)"]
+    RB --> ND["extract_node_details (counts)"]
+    RB --> JM["JSON + Markdown render"]
+    JM --> IO["run_reports_io: atomic write, 700/600, retention, git_sha"]
+    IO --> D[("backend/run_reports/&lt;ts&gt;_&lt;run-id&gt;.{json,md}")]
+```
+
+Per-node timing is captured by the wrapper into reducer-merged `node_timings`; everything else the reporter needs (`model_usages`, `errors`, counts via `extract_node_details`) is already in the accumulated `DiscoveryState` when the terminal `reporting` node runs. The reporter is pure-from-state → trivially testable without running the LLM pipeline.
+
+## Implementation Units
+
+- [ ] **Unit 1: Per-node timing — `timed_node` wrapper + `node_timings` merge reducer**
+
+**Goal:** Capture exact per-node duration on every entry path without editing node bodies.
+
+**Requirements:** R2
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `backend/src/kestrel_backend/graph/state.py` (custom dict-merge reducer for `node_timings`)
+- Create: `backend/src/kestrel_backend/graph/timing.py` (`timed_node(name, fn)` async wrapper)
+- Modify: `backend/src/kestrel_backend/graph/builder.py` (wrap each `add_node` registration)
+- Test: `backend/tests/test_timing_wrapper.py`
+
+**Approach:**
+- `timed_node` records `time.time()` before/after awaiting the wrapped node fn, shallow-copies the node's returned dict, and sets `node_timings={name: duration}`; returns the merged dict. One duration per node execution (the node's `await` wall-clock). Handles `None`/empty/non-dict returns. **Shallow-copy only** — pass reducer-bound values (lists of frozen `ModelUsageRecord`/`Finding`) through unchanged; never deep-copy or reconstruct frozen models.
+- **Defensive (R4):** the wrapper runs on every node, outside the reporting node's guard — if timing/merge logic raises, it must catch internally and return the node's original result unchanged, so a timing bug can never break the pipeline.
+- Replace `node_timings: dict[str, float]` with `Annotated[dict[str, float], merge_node_timings]`. The reducer is **required**: `direct_kg`+`cold_start` write `node_timings` in the same superstep, so LangGraph raises `InvalidUpdateError` without one. `merge_node_timings(a, b)` key-merges, treats `None`/missing as `{}`, and **never raises**.
+- Wrap all node registrations in `builder.py` uniformly (a helper applied at each `add_node`).
+
+**Patterns to follow:** existing `operator.add` reducer declarations in `state.py`; node registration block in `builder.py`.
+
+**Test scenarios:**
+- Happy path: wrapping a stub node that returns `{"errors": ["x"]}` yields a dict containing both `errors` and `node_timings={name: <float>}`.
+- Edge case: wrapped node returns `None` / `{}` / a non-dict → result still carries `node_timings` for that node; non-dict is handled without raising.
+- Edge case: `merge_node_timings` merges `{"a":1.0}` + `{"b":2.0}` → `{"a":1.0,"b":2.0}` (parallel branches); merging with `None`/`{}` does not raise.
+- Edge case (defensiveness, R4): a wrapper whose timing logic is forced to raise still returns the node's original result unchanged (pipeline unaffected).
+- Edge case: duration is non-negative and `>= sleep` for a stub that sleeps a known interval (not exact).
+- Integration: a compiled two-branch graph (direct_kg + cold_start) runs without `InvalidUpdateError` and final `node_timings` contains both branch keys.
+
+**Verification:** A full graph run leaves `state["node_timings"]` with one entry per executed node; skipped conditional nodes are absent (not zero); a forced timing error does not break the run.
+
+- [ ] **Unit 2: Per-model pricing module**
+
+**Goal:** Estimate $ cost from `model_usages`, generalized beyond hardcoded Sonnet rates.
+
+**Requirements:** R3
+
+**Dependencies:** None
+
+**Files:**
+- Create: `backend/src/kestrel_backend/pricing.py` (rate map + `estimate_cost(records)`)
+- Test: `backend/tests/test_pricing.py`
+
+**Approach:**
+- Rate map keyed by normalized model id (handle free-form names like `anthropic/claude-sonnet-4-…`), fields: input/output/cache_read/cache_create per 1M; module-level `LAST_VERIFIED = "YYYY-MM-DD"`.
+- Seed from `agent.py:340-348` Sonnet rates; add current Opus/Haiku rates from the `claude-api` reference.
+- `estimate_cost` sums per-record cost (records are per-call deltas — safe to sum; do **not** sum a cumulative counter). Unknown model → cost `None` + `logger.warning`, never raise.
+- Provide per-record and grouped-by-node helpers for the reporter.
+
+**Patterns to follow:** `TurnMetrics.cost_usd` math in `agent.py`.
+
+**Test scenarios:**
+- Happy path: known model + known tokens → expected $ (assert against hand-computed value).
+- Edge case: cache_read/cache_create tokens included in the total.
+- Error path: unknown model id → returns `None`, logs warning, does not raise.
+- Edge case: empty record list → `0.0` (not `None`).
+- Edge case: free-form `anthropic/...` name normalizes to a known rate key.
+
+**Verification:** `estimate_cost` reproduces the legacy Sonnet number for a Sonnet-only record set within rounding.
+
+- [ ] **Unit 3: Artifact I/O — atomic write, perms, retention, git_sha**
+
+**Goal:** Surface-agnostic durable writer that can never corrupt or unbounded-grow the prod disk.
+
+**Requirements:** R1, R5, R6, R9
+
+**Dependencies:** None
+
+**Files:**
+- Create: `backend/src/kestrel_backend/run_reports_io.py` (`write_report`, `prune`, `get_git_sha`, path helpers)
+- Modify: `backend/.gitignore` (add `run_reports/` — **must ship in this unit** so the first prod run can't commit 600-perm PII artifacts)
+- Test: `backend/tests/test_run_reports_io.py`
+
+**Approach:**
+- Output dir `backend/run_reports/` created without a world-readable window: `old=os.umask(0o077); os.makedirs(path, mode=0o700, exist_ok=True); os.umask(old)` (plus an explicit `os.chmod(0o700)`) — a bare `os.makedirs` leaves the dir at umask-default (e.g. 755) until a later chmod.
+- Filename `<%Y%m%dT%H%M%SZ>_<run-id>.{json,md}` — run-id, **never** a query slug.
+- Atomic write that is never world-readable even transiently: create the temp file with `os.open(tmp, O_WRONLY|O_CREAT|O_EXCL, 0o600)` (mode set at creation, not after), write, then `os.replace` to final. Do not `open()`-then-`chmod` (leaves a pre-chmod window on the PII-bearing file).
+- `prune(max_pairs=env REPORT_RETENTION_MAX default 200)`: list completed report pairs (ignore `*.tmp`) by mtime, delete oldest beyond the cap; swallow `FileNotFoundError` (concurrent pruner already deleted it).
+- `get_git_sha()`: memoized single `git rev-parse HEAD`; catch `CalledProcessError`/`FileNotFoundError` only, return `"unknown"` without logging the path.
+- All functions are independently callable and raise normally here (the fail-safe wrapper lives in the node, Unit 5) — but `prune` failures must not block the write.
+
+**Patterns to follow:** artifact/timestamp/`git_sha` conventions in `brown_c1_pilot_e2e.py`.
+
+**Test scenarios:**
+- Happy path: `write_report` produces both `.json` and `.md`; file mode is `600`, dir mode `700`.
+- Edge case: the temp file is `600` at creation (assert mode before rename, not just after) — no world-readable window.
+- Edge case: atomic write — no `.tmp` remains after success; a crash before rename leaves no partial final file.
+- Edge case: `prune` with 205 existing pairs and cap 200 deletes the 5 oldest by mtime, keeps newest 200; ignores any `*.tmp`.
+- Error/concurrency path: two `prune` calls targeting the same oldest file → the second's `FileNotFoundError` is swallowed; the just-written report persists.
+- Happy path: `get_git_sha` returns a 40-char hex in a git repo; `"unknown"` when `git` unavailable (monkeypatch), with no path in logs.
+
+**Verification:** Repeated writes keep the directory roughly bounded at the cap (approximate under concurrency); artifacts and dir are owner-only at every moment; `run_reports/` is git-ignored.
+
+- [ ] **Unit 4: Report builder — state → report dict → JSON + Markdown**
+
+**Goal:** Pure function turning final `DiscoveryState` + run metadata into the versioned report structure and an Outline-publishable Markdown rendering.
+
+**Requirements:** R3, R6, R7, R9
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Create: `backend/src/kestrel_backend/graph/performance_report.py` (`build_report(state, meta) -> dict`, `render_markdown(report) -> str`)
+- Test: `backend/tests/test_performance_report.py`
+
+**Approach:**
+- Run header carries `report_version=1`, `run_id` (opaque random id from meta), mode, `biomapper_env`, timestamp, `git_sha`, totals (wall-clock, tokens, est. cost), derived headline (top bottleneck by duration, top cost node). The **full `query` is in the JSON header only**; the **Markdown header shows `run_id`, never the raw query** (R6 — markdown is the Outline-bound artifact).
+- `render_markdown(report)` MUST NOT emit the `query` field — assert this in tests. `build_report` returns one dict containing both `query` (full) and `run_id`; the JSON serializer keeps `query`, the markdown renderer reads only `run_id`.
+- Per-node rows: status (`ran` if in `node_timings`, else `skipped`), `duration_s` + `pct_of_total`, tokens (in/out/cache) + model + `mcp_tool_calls` (group `model_usages` by `node_name`, `model_dump()` frozen records), cost (Unit 2), counts (`extract_node_details`). Run-level `errors` list in the header.
+- **Concurrency caveat in output:** `pct_of_total` is `duration_s / total_wall_clock`; for the parallel `direct_kg`/`cold_start` superstep these overlap, so per-node sums can exceed 100%. Render a one-line note that concurrent branches overlap; total wall-clock is the exact denominator.
+- Markdown: plain GFM tables, nodes ranked by duration then cost; no exotic embeds (R7).
+
+**Patterns to follow:** brown harness `_meta`/`node_timeline` shape; `extract_node_details` return contract.
+
+**Test scenarios:**
+- Happy path: a synthetic serial-node state (2 sequential nodes + one skipped) → report dict with correct per-node tokens, summed totals, `pct_of_total` summing ~100% within tolerance, correct headline node.
+- Edge case (concurrency): a state where two nodes' durations overlap the same wall-clock window → builder does **not** crash or clamp incorrectly; summed `pct_of_total` may exceed 100% and the overlap note is present.
+- Edge case: a node in `node_timings` with no `model_usages` → tokens/cost `0`/`None`, status `ran`.
+- Edge case: conditional node absent from `node_timings` → status `skipped`, excluded from the wall-clock denominator? (No — denominator is total wall-clock, not sum of durations; assert skipped nodes simply have no row contribution.)
+- Edge case: unknown model → cost `None` rendered as `est. n/a`, never crashes the render.
+- Security (R6): the rendered Markdown contains `run_id` and does **not** contain the raw query string (assert the query text is absent); the JSON does contain the full query.
+- Happy path (R7): rendered Markdown is valid GFM (pipe tables, no raw HTML/embeds) — assert table header/separator rows present.
+- Integration: feed a real recorded `DiscoveryState` fixture (or the brown harness's accumulated state) → totals reconcile with the harness's own `node_timeline` ordering (R8).
+
+**Verification:** `build_report` is pure (no I/O); `render_markdown` output round-trips through a GFM parser without errors.
+
+- [ ] **Unit 5: Reporting terminal node + graph wiring (fail-safe)**
+
+**Goal:** Wire the reporter into the graph so it fires last on every path and can never break a run.
+
+**Requirements:** R1, R4, R5
+
+**Dependencies:** Unit 3, Unit 4
+
+**Files:**
+- Create: `backend/src/kestrel_backend/graph/nodes/reporting.py` (`run(state) -> dict`)
+- Modify: `backend/src/kestrel_backend/graph/builder.py` (`add_node("reporting", ...)`; replace `add_edge("synthesis", END)` at line 196)
+- Test: `backend/tests/test_reporting_node.py`
+
+**Approach:**
+- `reporting.run`: generate an opaque random `run_id` (e.g. `uuid4().hex` or `secrets.token_hex`), build report (Unit 4) passing `run_id` in meta, write JSON (full query) + MD (run_id only) via Unit 3 using `run_id` in the filename, prune. **Entire body wrapped in try/except** — log a warning and return `{}` on any failure; never raise (R4). Returns a minimal `{"report_path": ...}` for observability (optional). The `run_id` is stored only in the JSON artifact — never emitted to Langfuse/DB — so it cannot be correlated back to the query.
+- Wiring: replace `add_edge("synthesis", END)` (builder.py:196) with `add_edge("synthesis", "reporting")` + `add_edge("reporting", END)`.
+- **Do NOT add `reporting` to `NODE_STATUS_MESSAGES`** (protocol.py): the WS loop skips nodes not in that set (main.py:592), so `reporting` is intentionally invisible to the WS stream/accumulator in v1 (it writes its own disk artifact). Decide whether to exclude `reporting` from its own report (its duration is dominated by disk I/O) — recommended: exclude.
+
+**Execution note:** Start with a failing test that mocks `write_report` to raise and asserts the run completes (fail-safe contract) before wiring real I/O.
+
+**Patterns to follow:** existing node `run(state)` signatures in `graph/nodes/`; builder edge wiring.
+
+**Test scenarios:**
+- Happy path: invoking `reporting.run` on a synthetic terminal state writes a JSON+MD pair to a temp dir.
+- Error path (R4): `write_report` raises → `reporting.run` logs a warning, returns without raising, run is unaffected.
+- Error path (R4): `build_report` raises (mock a malformed state) → swallowed, no partial artifact, no raise.
+- Integration: compiled graph reaches `reporting` after `synthesis` on both the direct_kg branch and the cold_start branch (assert node executed via a write side effect).
+
+**Verification:** `END` is reached after `reporting` on every conditional path; a forced reporting failure leaves the pipeline result intact.
+
+- [ ] **Unit 6: Prevent WS-path `node_timings` regression + WS integration test**
+
+**Goal:** Unit 1's reducer change would regress `main.py`'s WS-path `node_timings` to last-write-wins; fix `main.py` to merge the dict, kill the pre-existing timing bug, and prove the report lands on the prod WebSocket path. (Required-for-v1: not an accuracy nice-to-have — without it, Langfuse receives only the last node's timing.)
+
+**Requirements:** R2, R4, R8
+
+**Dependencies:** Unit 1, Unit 5
+
+**Files:**
+- Modify: `backend/src/kestrel_backend/main.py` (explicit dict-merge branch for `node_timings` in the accumulator; source `node_timings` from accumulated state)
+- Test: `backend/tests/test_pipeline_report_integration.py`
+
+**Approach:**
+- **Add an explicit dict-merge branch** for `node_timings` in the accumulation loop (main.py:595-602), *before* the list-concat check: `_get_concat_fields()` (main.py:84) only detects `operator.add`, and the concat branch (main.py:599) is list-only, so a `dict` reducer field otherwise falls to last-write-wins. Do **not** rely on `CONCAT_LIST_FIELDS`.
+- Replace the first-seen/overwrite `node_start_times` logic (main.py:605-610) by reading the authoritative merged `node_timings` from accumulated state; pass that to Langfuse (main.py:686).
+- **Scope note:** `add_turn` (database.py:154-156) has no `node_timings` column, so this benefits **Langfuse only** — node_timings is not persisted to the DB in v1 (consistent with Scope Boundaries). Do not claim DB persistence.
+- Confirm no behavior change to the user-facing stream.
+
+**Execution note:** Characterization-first — capture the current Langfuse metrics shape before changing the inline timing, so the refactor preserves the contract.
+
+**Patterns to follow:** the accumulation block in `main.py` (add a dict branch alongside the existing list-concat branch).
+
+**Test scenarios:**
+- Integration: a mocked end-to-end discovery run over the WS handler writes exactly one report pair and streams its result normally.
+- Happy path (regression guard): with the dict-merge branch, accumulated `node_timings` after a multi-node stream contains **all** nodes — assert it does NOT collapse to the last node only (the bug this unit prevents).
+- Error path (R4): reporting node failure during a WS run → user still receives the full streamed response; warning logged.
+- Happy path: `node_timings` passed to Langfuse equals the authoritative per-node durations (no monotonic overcount from the old first-seen/overwrite bug).
+- Edge case (R8): a recorded multi-node run's report node ordering/coverage cross-checks against the brown harness `node_timeline` for the same inputs.
+
+**Verification:** `main.py` accumulates `node_timings` for all nodes (not last-write-wins) and no longer uses the first-seen/overwrite logic; Langfuse receives accurate durations; a prod-shaped run produces a disk report.
+
+- [ ] **Unit 7: Synthesis fallback marker (surface the silent overflow)**
+
+**Goal:** Make the report able to flag the synthesis-overflow degradation that otherwise reads as `status=complete, errors=0`.
+
+**Requirements:** R3 (failure attribution for the motivating case)
+
+**Dependencies:** None (independent of Units 1-6; report picks it up via run-level `errors`)
+
+**Files:**
+- Modify: `backend/src/kestrel_backend/graph/nodes/synthesis.py` (emit a marker on the fallback paths)
+- Test: `backend/tests/test_synthesis_fallback_marker.py`
+
+**Approach:**
+- At the fallback convergence points (synthesis.py:1009 empty-LLM-text, 1010-1012 SDK exception), append a distinct run-level marker to the node's returned `errors` (the `operator.add` reducer carries it), e.g. `"synthesis: fell back to deterministic report (LLM returned empty)"` and `"synthesis: fell back to deterministic report (SDK error: <type>)"`. Add `"errors"` to synthesis's return dict only on these degraded paths.
+- The no-SDK path (1014-1015) is an environment condition, not a degradation — use a distinct, clearly-labeled marker (or omit) so it isn't confused with the overflow case.
+- Keep the marker a short string (no raw report dump). The report's run-level errors list (Unit 4) surfaces it automatically; no reporter change needed.
+
+**Execution note:** Test-first — assert the marker is emitted on each degraded path before touching the node.
+
+**Patterns to follow:** existing `errors` returns in other nodes (e.g. `direct_kg.run` returning `{"errors": [...]}`); the SDK/fallback convergence comment block at synthesis.py:1021-1026.
+
+**Test scenarios:**
+- Happy path: LLM returns non-empty text → no fallback marker in `errors`.
+- Degraded (the motivating case): LLM returns empty/whitespace text → `errors` contains the empty-fallback marker; `synthesis_report` is the deterministic fallback.
+- Degraded: `query_with_usage` raises → `errors` contains the SDK-error marker; run still completes.
+- Edge case: no-SDK environment → distinct marker (or none), not the overflow marker.
+
+**Verification:** A synthesis run forced down each fallback path emits its marker; a normal run emits none; the marker appears in the report's run-level errors.
+
+## System-Wide Impact
+
+- **Interaction graph:** New terminal `reporting` node on the compiled graph affects all three entry paths (WS, `run_discovery`, Studio). The `timed_node` wrapper touches every node registration in `builder.py` (uniform, behavior-preserving).
+- **Error propagation:** **Two new failure surfaces, not one.** (1) The reporting node is fully isolated by a try/except that never raises (R4). (2) The `timed_node` wrapper + `merge_node_timings` reducer run on *every* node, *outside* that guard — so they must be independently defensive (Unit 1): a timing/merge bug must never propagate into the pipeline. Pricing/IO functions raise normally but are only called inside the reporting guard.
+- **State lifecycle risks:** `node_timings` becomes a reducer field (required — parallel branches write it). Confirmed readers are `main.py` only (Langfuse 686, the dropped `add_turn` pass 714); Unit 6 fixes the WS accumulator. Atomic temp+rename prevents partial-write corruption. Retention prune is best-effort under concurrency (tolerates already-deleted files), not exact.
+- **API surface parity:** WS protocol unchanged in v1 (no `performance_report` event; `reporting` deliberately absent from `NODE_STATUS_MESSAGES`). Langfuse `node_timings` values get more accurate; `add_turn` payload shape unchanged (node_timings still not persisted).
+- **Integration coverage:** Unit 5/6 integration tests prove the report lands on the real WS path and survives both conditional branches. **Studio path is not unit-testable** — verify manually (see Documentation/Operational Notes) since Studio adds a checkpointer that could in principle replay/interrupt the terminal node.
+- **Failure-attribution in v1:** Unit 7 makes synthesis emit a run-level marker on its fallback paths, so the **synthesis-overflow silent fallback** (the motivating degradation, which otherwise reads as `status=complete, errors=0` — see memory `brown-c1-48-run-synthesis-overflow-wall`) is surfaced in the report's run-level errors. General per-node error *rows* (attributing arbitrary errors to their node) still need node-tagged errors (v2); v1 covers the one high-value case explicitly.
+- **Unchanged invariants:** User-facing streaming output, classic mode, the WS protocol, and the synthesis report content are unchanged. The reporter is read-only over state plus disk I/O.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Reporting failure breaks a prod run | Reporting node try/except never raises; **and** `timed_node`/reducer are independently defensive (run outside that guard); proven by Unit 1 + Unit 5/6 error-path tests (R4). |
+| Unbounded disk growth on single Lightsail box | Retention cap (keep last N=200) prunes on every write (R5); best-effort under concurrent runs; no prior art, so it ships *with* the writer — never the writer first. |
+| Corrupt JSON if process dies mid-write | Atomic temp-file (`O_EXCL`, mode `600` at creation) + `os.replace`. |
+| User query (PII/PHI) leaks via filenames / disk / git | Run-id (not query slug) in filenames; 600 files / 700 dir created without a world-readable window; `run_reports/` git-ignored in the same unit (Unit 3). Outline-redaction variant deferred to v2 (built with publishing). |
+| Cost number diverges from Langfuse | Both derive from the same `model_usages`; pricing map carries a "last verified" date; unknown model → `None` not a guess. |
+| `node_timings` reducer change regresses Langfuse timings | `_get_concat_fields()` only detects `operator.add`; Unit 6 adds an explicit dict-merge branch (does not rely on `CONCAT_LIST_FIELDS`); regression-guard test asserts all nodes present. Confirmed only `main.py` reads the field. |
+| Touching every node registration introduces regressions | Wrapper is behavior-preserving (only adds `node_timings`); covered by Unit 1 + the existing pipeline test suite (run new test files individually given ~16-18 pre-existing suite failures). |
+
+## Documentation / Operational Notes
+
+- Document the JSON schema (`report_version: 1`) in the `performance_report.py` module docstring.
+- Note `REPORT_RETENTION_MAX` env var in `backend/.env.example` and deploy docs; default 200.
+- `run_reports/` git-ignore entry ships in Unit 3 (not as a later cleanup) so the first prod run can't commit PII artifacts.
+- **Manual Studio verification** (not unit-testable): run one query in LangGraph Studio (`uv run langgraph dev`) and confirm exactly one report pair is written and `reporting` runs to `END` once (no checkpointer replay/duplicate). Record the result when implementing Unit 5.
+- Testing: `cd backend && uv run python -m pytest tests/test_*report* tests/test_pricing.py tests/test_timing_wrapper.py tests/test_reporting_node.py tests/test_run_reports_io.py tests/test_synthesis_fallback_marker.py -v` (module invocation; validate these files individually given ~16-18 pre-existing full-suite failures).
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-06-22-pipeline-node-performance-report-requirements.md](docs/brainstorms/2026-06-22-pipeline-node-performance-report-requirements.md)
+- Related code: `graph/builder.py`, `graph/state.py`, `graph/node_detail_extractors.py`, `agent.py`, `main.py`, `assessment_data/brown_c1_pilot_e2e.py`
+- Learnings: `docs/solutions/best-practices/reliable-long-running-llm-batch-runs-2026-06-07.md`, `docs/solutions/best-practices/langfuse-sdk-v3-migration-2026-06-03.md`, `docs/solutions/best-practices/langgraph-pipeline-production-formalization.md`, `docs/solutions/developer-experience/pytest-venv-path-spaces-module-invocation-2026-06-01.md`

--- a/docs/plans/2026-06-22-002-feat-pipeline-node-performance-report-plan.md
+++ b/docs/plans/2026-06-22-002-feat-pipeline-node-performance-report-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Per-node pipeline performance report (disk-only v1)"
 type: feat
-status: active
+status: completed
 date: 2026-06-22
 deepened: 2026-06-22
 origin: docs/brainstorms/2026-06-22-pipeline-node-performance-report-requirements.md


### PR DESCRIPTION
## Summary

Auto-generates a per-node performance report at the end of **every** discovery pipeline run, written to disk as JSON + Markdown. Attributes time, tokens, estimated cost, output counts, and errors to individual nodes so bottlenecks (e.g. `pathway_enrichment` ~307s, the synthesis-overflow wall) and cost are visible per run.

Origin: `docs/brainstorms/2026-06-22-pipeline-node-performance-report-requirements.md` → plan `docs/plans/2026-06-22-002-feat-pipeline-node-performance-report-plan.md` (both via ce:brainstorm → ce:plan, 7/5-persona document-reviewed).

## What's in it (7 units)

- **Timing** — `timed_node` wrapper (builder.py) + `node_timings` dict-merge reducer (state.py). Reducer is *required*: parallel branches (`direct_kg`+`cold_start`) write it in the same superstep (LangGraph `InvalidUpdateError` otherwise).
- **Pricing** — `pricing.py` per-model rate map (Opus/Sonnet/Haiku/Fable), generalizing `agent.py`'s hardcoded Sonnet cost.
- **Artifact I/O** — `run_reports_io.py`: atomic temp+rename, owner-only perms (700 dir / 600 files), keep-last-N retention (`REPORT_RETENTION_MAX`, default 200), memoized `git_sha` (5s timeout). `run_reports/` git-ignored.
- **Report builder** — `performance_report.py`: pure state→JSON+Markdown. Markdown shows an opaque `run_id` (Outline-safe); JSON retains the full query.
- **Reporting node** — terminal `synthesis → reporting → END` (covers WS, `run_discovery`, and Studio, which bypasses the runner). Entirely fail-safe: a reporting failure can never break a user-facing run.
- **WS accumulator fix** — `main.py` dict-merges `node_timings` (prevents a Langfuse regression the reducer change would otherwise cause) and sources per-node duration from the wrapper, killing the old first-seen/overwrite bug.
- **Synthesis fallback marker** — surfaces the silent context-overflow degradation (empty LLM output) that otherwise reads as `status=complete, errors=0`.

## Scope (v1)

Disk-only. The `performance_report` WebSocket event + frontend renderer are **deferred to v2**. Queries treated as sensitive: full query on disk (600 perms), `run_id` (not query) in filenames and Markdown, prod reports never auto-published.

## Testing

- 64 new feature tests pass (timing, pricing, I/O, report builder, reporting node, WS integration incl. the node_timings regression guard, synthesis marker).
- 3 graph-topology tests updated for the new terminal node.
- Full suite: 36 pre-existing failures (unrelated `biomapper_env` mock drift etc.), **0 new regressions**. Graph compiles.
- Code-reviewed by 8 ce:review personas; 9 findings auto-fixed (event-loop offload, git timeout, umask removal, atomic pair, honest wall-clock labeling, etc.).
- Run: `cd backend && uv run python -m pytest tests/test_timing_wrapper.py tests/test_pricing.py tests/test_run_reports_io.py tests/test_performance_report.py tests/test_reporting_node.py tests/test_pipeline_report_integration.py tests/test_synthesis_fallback_marker.py -v`

## Deferred (advisory)

- `agent.py` classic-mode cost still hardcodes Sonnet rates (out of scope; different path).
- `hypothesis_extraction`/`bridge_grounding` lack dedicated detail-extractors (pre-existing) → generic findings for those 2 nodes.
- Measured wall-clock (vs the honestly-labeled summed estimate) needs intake start-time plumbing → v2.

## Post-Deploy Monitoring & Validation

- **Where:** reports land in `backend/run_reports/<ts>_<run-id>.{json,md}` on the dev host (`dev-kraken`); git-ignored, 600 perms.
- **Healthy signals:** after a discovery run, a new JSON+MD pair appears; `journalctl -u kraken-backend-dev` shows `Performance report written: run_id=…`; the pipeline streams its result normally (no added latency — disk write is offloaded to a thread).
- **Failure signals:** `Performance report failed; pipeline result unaffected` warnings (report skipped but run OK — acceptable, investigate cause); disk growth in `run_reports/` beyond ~200 pairs (retention not pruning); any user-facing run breakage (should be impossible — fail-safe).
- **Rollback trigger:** any user-facing discovery run failing/hanging that correlates with the reporting node → revert this branch on dev. The disk writer is the only new prod-path side effect and is fully guarded.
- **Validation window/owner:** verify on dev-kraken after first deploy (trent); confirm a report pair is written and a normal run is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)