### PR TITLE
feat(synthesis): module-aware context — fix silent synthesis-overflow at module scale

### DIFF
--- a/backend/assessment_data/brown_c1_pilot_e2e.py
+++ b/backend/assessment_data/brown_c1_pilot_e2e.py
@@ -1,0 +1,312 @@
+"""Brown-module C1 PILOT: instrumented full-pipeline E2E run, biomapper-ON (dev).
+
+Runs a ~24-analyte slice of the Brown WGCNA module through the REAL 12-node discovery
+pipeline (intake -> resolution -> triage -> ... -> hypothesis_extraction -> bridge_grounding
+-> literature_grounding -> synthesis), with biomapper resolution enabled against the dev
+endpoint (the fixed resolver). Purpose: confirm synthesis survives the volume, measure
+cost/latency (incl. the rate-limited literature_grounding), and produce honest per-node
+coverage accounting + the actual synthesis report.
+
+Guards (per the requirements-doc review):
+  - biomapper is force-ENABLED (flag is default-off and NOT env-sourced) by mutating the
+    get_pipeline_config() singleton; asserted before the run.
+  - biomapper_env="dev" so it hits the FIXED resolver (prod/main is the legacy ablation baseline).
+  - POST-RUN assert biomapper actually fired (resolved_entities method=="biomapper" count > 0),
+    else a silent ValueError fallback would let a biomapper-OFF run masquerade as ON.
+  - 20-min wall-clock ceiling: on breach, abort and SAVE the partial accumulated state.
+  - Saves a timestamped artifact by default (expensive-run SOP), pinning inputs.
+
+Paid: SDK calls (entity_resolution Tier-2, hypothesis_extraction, synthesis) + external
+literature APIs (PubMed/OpenAlex/Exa/S2; S2 serialized ~10s/req). Scratch tooling.
+Run: cd backend && uv run python -m assessment_data.brown_c1_pilot_e2e [--n-proteins 12 --n-metabolites 12]
+"""
+
+import argparse
+import asyncio
+import csv
+import json
+import operator
+import os
+import re
+import subprocess
+import time
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Annotated, get_args, get_origin, get_type_hints
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# --- biomapper creds: dev endpoint + key (key from the biomapper2 repo .env; never hardcode) ---
+if not os.environ.get("BIOMAPPER_API_KEY"):
+    _bm_env = Path("../../biomapper2/.env")
+    if _bm_env.exists():
+        for _line in _bm_env.read_text().splitlines():
+            if _line.startswith("BIOMAPPER2_API_KEY="):
+                os.environ["BIOMAPPER_API_KEY"] = _line.split("=", 1)[1].strip()
+                break
+os.environ.setdefault("BIOMAPPER_DEV_BASE_URL", "https://dev-biomapper.expertintheloop.io/api/v1")
+
+from kestrel_backend.graph.nodes.synthesis import assemble_synthesis_context  # noqa: E402
+from kestrel_backend.graph.pipeline_config import get_pipeline_config  # noqa: E402
+from kestrel_backend.graph.runner import stream_discovery  # noqa: E402
+from kestrel_backend.graph.state import DiscoveryState  # noqa: E402
+
+TSV = Path("../docs/data/Frailty_Multiomic_WGCNA-modules.tsv")
+OUT_DIR = Path("assessment_data/brown_diagnostic_runs")
+
+# Chars/token ratio measured on the 48-analyte CURIE-dense context (Diagnostic Evidence, 2026-06-22).
+CHARS_PER_TOKEN = 3.5
+TOKEN_BUDGET = 100_000  # assembled-context target, well under the ~200K-token model window
+
+
+def _additive_list_keys() -> set[str]:
+    """Keys declared ``Annotated[list[...], operator.add]`` in DiscoveryState.
+
+    These accumulate across streamed node deltas (stream_mode="updates"), so a reducer-blind
+    ``merged.update(out)`` clobbers all but the last node's slice — the ~110x coverage under-count
+    (R6). Derived from the annotations so a future reducer field can't silently reintroduce the bug.
+    """
+    keys: set[str] = set()
+    for name, ann in get_type_hints(DiscoveryState, include_extras=True).items():
+        if get_origin(ann) is Annotated:
+            base, *meta = get_args(ann)
+            if operator.add in meta and get_origin(base) is list:
+                keys.add(name)
+    return keys
+
+
+_ADDITIVE_KEYS = _additive_list_keys()
+
+
+def merge_delta(merged: dict, out: dict) -> None:
+    """Reducer-aware merge mirroring LangGraph semantics: concatenate operator.add list keys across
+    deltas; overwrite plain last-write-wins keys. Replaces the under-counting ``merged.update(out)``."""
+    for k, v in out.items():
+        if k in _ADDITIVE_KEYS and isinstance(v, list):
+            merged[k] = merged.get(k, []) + v
+        else:
+            merged[k] = v
+
+
+def git_sha():
+    try:
+        return subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+    except Exception:  # noqa: BLE001
+        return "unknown"
+
+
+def pick_pilot(n_prot, n_met):
+    """A mix that exercises both the analyzable path (proteins, now well-characterized ON)
+    and the cap-drop path (sparse metabolites). Clean names to survive intake parsing."""
+    prot, met = [], []
+    with open(TSV, newline="") as f:
+        for r in csv.DictReader(f, delimiter="\t"):
+            if r["ModuleID"] != "Brown":
+                continue
+            if r["Dataset"] == "Protein" and r["GeneSymbol"] not in ("", "NA"):
+                # gene symbols are clean (no parentheticals intake would strip)
+                if "(" not in r["GeneSymbol"]:
+                    prot.append(r["GeneSymbol"])
+            elif r["Dataset"] in ("Metabolite", "Chemistry") and r["ChemName"] not in ("", "NA"):
+                # avoid parentheticals (intake strips them -> isomer dedup) AND internal commas
+                # (the comma-joined query list would split e.g. "12,13-DiHOME" into two entities)
+                if "(" not in r["ChemName"] and "," not in r["ChemName"]:
+                    met.append(r["ChemName"])
+    return prot[:n_prot], met[:n_met]
+
+
+def build_query(proteins, metabolites):
+    return (
+        "Analyze the biological relationships among these co-expressed analytes "
+        "from the Brown WGCNA module.\n\n"
+        "Proteins:\n" + ", ".join(proteins) + "\n\n"
+        "Metabolites:\n" + ", ".join(metabolites) + "\n"
+    )
+
+
+def coverage(state):
+    """Per-node analyzed-vs-dropped accounting from the (merged) final state."""
+    re_ = state.get("resolved_entities", []) or []
+    methods = Counter(getattr(e, "method", None) or (e.get("method") if isinstance(e, dict) else None)
+                      for e in re_)
+    bm = sum(v for k, v in methods.items() if k and str(k).startswith("biomapper"))
+    hyps = state.get("hypotheses", []) or []
+    lit_total = sum(len(getattr(h, "literature_support", None) or
+                        (h.get("literature_support") if isinstance(h, dict) else []) or []) for h in hyps)
+    report = state.get("synthesis_report", "") or ""
+    return {
+        "resolved_by_method": {str(k): v for k, v in methods.items()},
+        "biomapper_confirmed": bm,
+        "triage_buckets": {
+            "well_characterized": len(state.get("well_characterized_curies", []) or []),
+            "moderate": len(state.get("moderate_curies", []) or []),
+            "sparse": len(state.get("sparse_curies", []) or []),
+            "cold_start": len(state.get("cold_start_curies", []) or []),
+        },
+        "direct_findings": len(state.get("direct_findings", []) or []),
+        "cold_start_findings": len(state.get("cold_start_findings", []) or []),
+        "cold_start_skipped_count": state.get("cold_start_skipped_count"),
+        "biological_themes": len(state.get("biological_themes", []) or []),
+        "bridges": len(state.get("bridges", []) or []),
+        "grounded_bridges": len(state.get("grounded_bridges", []) or []),
+        "hypotheses": len(hyps),
+        "literature_support_total": lit_total,
+        "synthesis_report_chars": len(report),
+        "errors": len(state.get("errors", []) or []),
+        "literature_errors": len(state.get("literature_errors", []) or []),
+        "bridge_grounding_errors": len(state.get("bridge_grounding_errors", []) or []),
+    }
+
+
+def synthesis_duration(node_order):
+    """Wall-seconds spent in the synthesis node (its completion minus the prior node's)."""
+    for i, n in enumerate(node_order):
+        if n["node"] == "synthesis":
+            prev = node_order[i - 1]["t"] if i > 0 else 0.0
+            return round(n["t"] - prev, 1)
+    return None
+
+
+def acceptance_checks(merged, cov, synth_dur):
+    """U7 machine-checkable acceptance — reproducible despite LLM non-determinism.
+
+    Reconstructs the assembled synthesis context from the final merged state to measure the real
+    size that overflowed (it is internal to the node, not stored in the artifact). The
+    signal-preservation diff vs the 24-analyte pilot is a SEPARATE human gate, not checked here.
+    """
+    report = merged.get("synthesis_report", "") or ""
+    errors = merged.get("errors", []) or []
+    degraded = [e for e in errors if "synthesis_degraded" in str(e)]
+    try:
+        ctx_chars = len(assemble_synthesis_context(merged))
+    except Exception as e:  # noqa: BLE001
+        ctx_chars = -1
+        print(f"  (acceptance: could not reassemble context: {type(e).__name__}: {e})", flush=True)
+    est_tokens = round(ctx_chars / CHARS_PER_TOKEN) if ctx_chars >= 0 else -1
+    # A module narrative should have few/no raw per-entity "### CURIE" dump sections.
+    raw_curie_sections = len(re.findall(r"(?m)^###\s+[A-Za-z][\w.]*:\S", report))
+    total_findings = cov["direct_findings"] + cov["cold_start_findings"]
+    return {
+        "no_synthesis_degraded": (len(degraded) == 0, f"{len(degraded)} degraded entries"),
+        "synthesis_ran_real_llm": (
+            synth_dur is not None and synth_dur > 30,
+            f"synthesis_duration={synth_dur}s (want >30s, not the ~3.5s fallback)",
+        ),
+        "context_under_token_budget": (
+            0 <= est_tokens < TOKEN_BUDGET,
+            f"~{est_tokens} est tokens / {ctx_chars} chars (budget {TOKEN_BUDGET} tokens)",
+        ),
+        "report_not_raw_dump": (
+            raw_curie_sections < 10,
+            f"{raw_curie_sections} raw '### CURIE' sections (want <10)",
+        ),
+        "findings_counted_plausibly": (
+            total_findings > 37,
+            f"{total_findings} findings (R6: ≫37 expected at module scale post-merge-fix)",
+        ),
+    }
+
+
+async def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--n-proteins", type=int, default=12)
+    ap.add_argument("--n-metabolites", type=int, default=12)
+    ap.add_argument("--ceiling-min", type=int, default=20,
+                    help="wall-clock ceiling in minutes; on breach abort and save partial")
+    ap.add_argument("--output", default=None)
+    args = ap.parse_args()
+    ceiling_seconds = args.ceiling_min * 60
+
+    if not os.environ.get("BIOMAPPER_API_KEY"):
+        raise SystemExit("BIOMAPPER_API_KEY not set / not found in ../../biomapper2/.env — cannot run biomapper-ON.")
+
+    # Force-enable biomapper (default-off, not env-sourced) on the config singleton; assert it took.
+    cfg = get_pipeline_config()
+    cfg.entity_resolution.biomapper.enabled = True
+    assert cfg.entity_resolution.biomapper.enabled is True, "failed to enable biomapper on the config singleton"
+
+    proteins, metabolites = pick_pilot(args.n_proteins, args.n_metabolites)
+    query = build_query(proteins, metabolites)
+    submitted = proteins + metabolites
+
+    # Intake-parse check: how many of the submitted names survive extract_entities (denominator honesty).
+    from kestrel_backend.graph.nodes.intake import extract_entities  # noqa: PLC0415
+    parsed = extract_entities(query)
+    print(f"PILOT: {len(proteins)} proteins + {len(metabolites)} metabolites = {len(submitted)} submitted; "
+          f"intake parsed {len(parsed)}; biomapper=dev enabled; ceiling={ceiling_seconds//60}min", flush=True)
+
+    merged: dict = {}
+    node_order = []
+    t0 = time.monotonic()
+
+    async def consume():
+        async for ev in stream_discovery(query, biomapper_env="dev"):
+            node, out = ev["node"], ev["node_output"]
+            if isinstance(out, dict):
+                merge_delta(merged, out)  # reducer-aware: concatenate additive keys (R6 fix)
+            node_order.append({"node": node, "t": round(time.monotonic() - t0, 1)})
+            print(f"  [{time.monotonic() - t0:6.1f}s] {node}", flush=True)
+
+    status = "complete"
+    try:
+        await asyncio.wait_for(consume(), timeout=ceiling_seconds)
+    except asyncio.TimeoutError:
+        status = "timeout_aborted"
+        print(f"  !! exceeded {ceiling_seconds}s ceiling — aborting, saving partial", flush=True)
+    except Exception as e:  # noqa: BLE001
+        status = f"error:{type(e).__name__}"
+        print(f"  !! run error: {type(e).__name__}: {e} — saving partial", flush=True)
+
+    wall = round(time.monotonic() - t0, 1)
+    cov = coverage(merged)
+    synth_dur = synthesis_duration(node_order)
+    checks = acceptance_checks(merged, cov, synth_dur)
+
+    artifact = {
+        "_meta": {
+            "generated": datetime.now(timezone.utc).isoformat(),
+            "phase": "C1-pilot", "module": "Brown", "status": status, "wall_seconds": wall,
+            "ceiling_seconds": ceiling_seconds, "biomapper_env": "dev",
+            "biomapper_enabled": True, "git_sha": git_sha(),
+            "submitted": submitted, "n_submitted": len(submitted), "n_parsed": len(parsed),
+            "nodes_reached": [n["node"] for n in node_order],
+            "synthesis_duration_s": synth_dur,
+        },
+        "coverage": cov,
+        "acceptance": {k: {"passed": p, "detail": d} for k, (p, d) in checks.items()},
+        "node_timeline": node_order,
+        "synthesis_report": merged.get("synthesis_report", ""),
+    }
+    out = Path(args.output) if args.output else OUT_DIR / f"brown_c1_pilot_{datetime.now(timezone.utc):%Y%m%dT%H%M%SZ}.json"
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(artifact, indent=2, default=str))
+
+    # Post-run guard: did biomapper actually fire? (only meaningful if resolution completed)
+    if cov["resolved_by_method"]:
+        bm_ok = cov["biomapper_confirmed"] > 0
+        print(f"\n  biomapper fired: {bm_ok} (confirmed={cov['biomapper_confirmed']}, "
+              f"methods={cov['resolved_by_method']})", flush=True)
+        if not bm_ok:
+            print("  !! WARNING: biomapper-ON requested but 0 entities resolved via biomapper — "
+                  "run is effectively biomapper-OFF (check type-hint assignment / dev endpoint).", flush=True)
+
+    print("\n=== U7 ACCEPTANCE (machine checks) ===")
+    all_pass = all(p for p, _ in checks.values())
+    for name, (p, d) in checks.items():
+        print(f"  [{'PASS' if p else 'FAIL'}] {name}: {d}")
+    print(f"  OVERALL: {'PASS' if all_pass else 'FAIL'} "
+          f"(+ signal-preservation diff vs the 24-analyte pilot is a separate human gate)")
+
+    print(f"\n=== C1 PILOT [{status}] {wall}s ===")
+    print(json.dumps({"_meta": artifact["_meta"], "coverage": cov,
+                      "acceptance": artifact["acceptance"]}, indent=2, default=str))
+    print(f"\n--- SYNTHESIS REPORT ({cov['synthesis_report_chars']} chars) ---\n")
+    print(merged.get("synthesis_report", "(none — run did not reach synthesis)")[:6000])
+    print(f"\nArtifact: {out}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/assessment_data/brown_c1_pilot_e2e.py
+++ b/backend/assessment_data/brown_c1_pilot_e2e.py
@@ -179,7 +179,11 @@ def acceptance_checks(merged, cov, synth_dur):
     """
     report = merged.get("synthesis_report", "") or ""
     errors = merged.get("errors", []) or []
-    degraded = [e for e in errors if "synthesis_degraded" in str(e)]
+    # Match the fallback marker that synthesis.run() actually emits: both the empty-output and the
+    # exception cases end with "... fell back to deterministic report" (the exception case also says
+    # "LLM call failed"). The earlier "synthesis_degraded" string never matched any real marker, so
+    # this gate was permanently green. The marker text is owned by synthesis.run(); keep in sync.
+    degraded = [e for e in errors if "fell back to deterministic" in str(e) or "LLM call failed" in str(e)]
     try:
         ctx_chars = len(assemble_synthesis_context(merged))
     except Exception as e:  # noqa: BLE001

--- a/backend/src/kestrel_backend/graph/nodes/synthesis.py
+++ b/backend/src/kestrel_backend/graph/nodes/synthesis.py
@@ -1210,6 +1210,7 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
 
     # Phase C: LLM synthesis or fallback
     usage_record = None
+    degraded_error: str | None = None
     if HAS_SDK:
         try:
             options = ClaudeAgentOptions(
@@ -1227,12 +1228,25 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
             # NOTE: query_with_usage joins text blocks with "", not "\n" (previous behavior).
             # All other nodes use "".join(); synthesis now matches them.
 
-            report = text if text.strip() else fallback_report(state)
+            if text.strip():
+                report = text
+            else:
+                # Expected in some runs (e.g. tests / empty completion) — NOT a degradation, so
+                # do not pollute state["errors"] with a false positive. Log at INFO for visibility.
+                logger.info("synthesis SDK returned empty text; using fallback report")
+                report = fallback_report(state)
         except Exception as e:
-            # Fallback on any SDK error
+            # R3: a genuine SDK synthesis failure must be VISIBLE, never silent. Log with the
+            # traceback and record it in the additive state["errors"] channel (so coverage/monitoring
+            # see the degradation) instead of silently emitting a deterministic dump as if all was well.
+            logger.warning(
+                "synthesis LLM call failed, using fallback report: %s", e, exc_info=True
+            )
             report = fallback_report(state)
-            # Could log error here if needed
+            degraded_error = f"synthesis_degraded: {type(e).__name__}: {e}"
     else:
+        # No SDK (test/offline path) — fallback is expected, not a degradation.
+        logger.debug("synthesis running without SDK; using fallback report")
         report = fallback_report(state)
 
     # Hypotheses are produced upstream (hypothesis_extraction) and grounded by
@@ -1255,7 +1269,11 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
     # Report-only return (R4/R12): hypotheses and bridges are produced/owned upstream now, so
     # synthesis must NOT re-emit them. extra='ignore' on SynthesisOutput would silently let a
     # stray `bridges` return through, so it is removed deliberately, not relied on to be dropped.
-    return {
+    result: dict[str, Any] = {
         "synthesis_report": report,
         "model_usages": [usage_record] if usage_record else [],
     }
+    # R3: surface a real SDK-synthesis failure in the additive errors channel (visible degradation).
+    if degraded_error:
+        result["errors"] = [degraded_error]
+    return result

--- a/backend/src/kestrel_backend/graph/nodes/synthesis.py
+++ b/backend/src/kestrel_backend/graph/nodes/synthesis.py
@@ -24,6 +24,7 @@ from ..state import (
     Hypothesis,
 )
 from ...literature_utils import format_pmid_link
+from ..pipeline_config import get_pipeline_config
 from ..sdk_utils import HAS_SDK, ClaudeAgentOptions, query_with_usage
 from ..state_contracts import validate_state, SynthesisInput, SynthesisOutput
 # References-table assembly lives with grounding's module but is OWNED by synthesis now (R6):
@@ -107,6 +108,17 @@ hypothesis, NOT that the claim is verified — calibrate confidence on the evide
 If a section has no KG-backed findings, state this explicitly: "No direct KG evidence was found for this connection. The following is based on [Model Knowledge]."
 
 Do NOT present model knowledge as if it were KG-derived or literature-backed. Scientific integrity requires honest attribution.
+
+## Module-Level Reasoning (multi-entity input)
+
+If the input is a module (many entities analyzed together — you will see "Module-Level Disease
+Recurrence", "Module-Level Pathway Recurrence", and a "Member Prioritization Table" instead of
+per-entity dumps), treat the entities as a coordinated group, not a list:
+- LEAD with the unifying biological theme that explains why these entities co-vary as a module.
+- Build the Key Findings from the Module-Level Recurrence sections (diseases/pathways shared across
+  members) and use the Member Prioritization Table to call out the highest-leverage individual members.
+- Do not enumerate every member; synthesize the module's story, then highlight outliers.
+For a single entity (per-entity sections present, no module sections), report as usual.
 
 Generate a clear, scientific report in markdown format.
 """
@@ -520,19 +532,27 @@ def format_inferred_associations(
     return "\n".join(lines)
 
 
+# Within-tier confidence ranking (high first) for capping the findings section.
+_CONFIDENCE_RANK = {"high": 0, "moderate": 1, "low": 2}
+
+
 def format_findings_summary(
     direct_findings: list[Finding],
-    cold_start_findings: list[Finding]
+    cold_start_findings: list[Finding],
+    max_per_tier: int | None = None,
 ) -> str:
-    """Format analysis findings into a summary report."""
+    """Format analysis findings into a summary report.
+
+    When ``max_per_tier`` is set, each tier is ranked by confidence (high->moderate->low) and capped to
+    that many findings, with a "… and N more (tier T)" elision line for the remainder. Findings are the
+    dominant synthesis-context section at module scale (58% of the 882K overflow), so this cap is the
+    load-bearing reduction. ``max_per_tier=None`` keeps the historical unbounded behavior.
+    """
     all_findings = direct_findings + cold_start_findings
     if not all_findings:
         return ""
 
     lines = ["## Analysis Findings Summary\n"]
-
-    # Sort by tier (1 = high confidence first)
-    sorted_findings = sorted(all_findings, key=lambda f: f.tier)
 
     # Group by tier
     tier_labels = {
@@ -542,19 +562,26 @@ def format_findings_summary(
     }
 
     for tier in [1, 2, 3]:
-        tier_findings = [f for f in sorted_findings if f.tier == tier]
-        if tier_findings:
-            lines.append(f"### {tier_labels[tier]}")
-            for f in tier_findings:
-                source_tag = f"[{f.source}]" if f.source else ""
-                confidence_marker = {"high": "[HIGH]", "moderate": "[MOD]", "low": "[LOW]"}.get(f.confidence, "")
-                lines.append(f"- {confidence_marker} **{f.entity}**: {f.claim} {source_tag}")
-                if f.pmids:
-                    pmid_links = [format_pmid_link(pmid) for pmid in f.pmids[:5]]
-                    lines.append(f"  - PMIDs: {', '.join(pmid_links)}")
-                if f.logic_chain:
-                    lines.append(f"  - _Logic: {f.logic_chain}_")
-            lines.append("")
+        tier_findings = [f for f in all_findings if f.tier == tier]
+        if not tier_findings:
+            continue
+        # Strongest-confidence first so the cap keeps the most reliable findings, not an arbitrary slice.
+        tier_findings.sort(key=lambda f: _CONFIDENCE_RANK.get(f.confidence, 3))
+        shown = tier_findings if max_per_tier is None else tier_findings[:max_per_tier]
+        elided = len(tier_findings) - len(shown)
+        lines.append(f"### {tier_labels[tier]}")
+        for f in shown:
+            source_tag = f"[{f.source}]" if f.source else ""
+            confidence_marker = {"high": "[HIGH]", "moderate": "[MOD]", "low": "[LOW]"}.get(f.confidence, "")
+            lines.append(f"- {confidence_marker} **{f.entity}**: {f.claim} {source_tag}")
+            if f.pmids:
+                pmid_links = [format_pmid_link(pmid) for pmid in f.pmids[:5]]
+                lines.append(f"  - PMIDs: {', '.join(pmid_links)}")
+            if f.logic_chain:
+                lines.append(f"  - _Logic: {f.logic_chain}_")
+        if elided > 0:
+            lines.append(f"- … and {elided} more (tier {tier})")
+        lines.append("")
 
     return "\n".join(lines)
 
@@ -855,6 +882,46 @@ def format_literature_evidence(hypotheses: list[Hypothesis]) -> str:
     return "\n".join(lines)
 
 
+def _disease_pathway_sections(state: DiscoveryState) -> list[str]:
+    """Disease + pathway sections, module-aware.
+
+    For module queries (>= ``module_mode_min_entities`` distinct resolved entities) emit cross-entity
+    recurrence aggregation + the per-member table in place of the unbounded per-entity dumps (which
+    were 21% + 17% of the module-scale overflow). Below that threshold (single/pair/triple queries)
+    keep the existing per-entity sections verbatim (R5). The threshold is the *module-mode* switch,
+    distinct from ``min_members_for_recurrence`` (which gates the recurrence lists).
+    """
+    cfg = get_pipeline_config().synthesis
+    disease_associations = state.get("disease_associations", [])
+    pathway_memberships = state.get("pathway_memberships", [])
+    resolved = state.get("resolved_entities", [])
+    novelty_scores = state.get("novelty_scores", [])
+    distinct_entities = len({e.curie for e in resolved if e.curie})
+
+    out: list[str] = []
+    if distinct_entities >= cfg.module_mode_min_entities:
+        candidates = [
+            aggregate_shared_diseases(
+                disease_associations, cfg.min_members_for_recurrence, cfg.max_aggregated_diseases
+            ),
+            aggregate_shared_pathways(
+                pathway_memberships, cfg.min_members_for_recurrence, cfg.max_aggregated_pathways
+            ),
+            format_member_table(
+                resolved, novelty_scores, disease_associations, cfg.max_member_table_rows
+            ),
+        ]
+    else:
+        candidates = [
+            format_disease_associations(disease_associations),
+            format_pathway_memberships(pathway_memberships),
+        ]
+    for section in candidates:
+        if section:
+            out.append(section)
+    return out
+
+
 def assemble_synthesis_context(state: DiscoveryState) -> str:
     """
     Assemble all accumulated state into a context block for LLM synthesis.
@@ -862,6 +929,7 @@ def assemble_synthesis_context(state: DiscoveryState) -> str:
     This function gathers data from all previous nodes and formats it into
     a comprehensive context that the LLM can use to generate a discovery report.
     """
+    cfg = get_pipeline_config().synthesis
     sections = []
     
     # Query context
@@ -892,18 +960,10 @@ def assemble_synthesis_context(state: DiscoveryState) -> str:
     if hub_section:
         sections.append(hub_section)
     
-    # Disease associations
-    disease_associations = state.get("disease_associations", [])
-    disease_section = format_disease_associations(disease_associations)
-    if disease_section:
-        sections.append(disease_section)
-    
-    # Pathway memberships
-    pathway_memberships = state.get("pathway_memberships", [])
-    pathway_section = format_pathway_memberships(pathway_memberships)
-    if pathway_section:
-        sections.append(pathway_section)
-    
+    # Disease associations + pathway memberships (module-aware: aggregation + member table at
+    # module scale, per-entity dumps for small queries — these two sections were 38% of the overflow)
+    sections.extend(_disease_pathway_sections(state))
+
     # Pathway enrichment (shared neighbors and themes)
     shared_neighbors = state.get("shared_neighbors", [])
     biological_themes = state.get("biological_themes", [])
@@ -936,10 +996,12 @@ def assemble_synthesis_context(state: DiscoveryState) -> str:
     if inference_section:
         sections.append(inference_section)
     
-    # All findings
+    # All findings (capped per tier — the dominant section, 58% of the module-scale overflow)
     direct_findings = state.get("direct_findings", [])
     cold_start_findings = state.get("cold_start_findings", [])
-    findings_section = format_findings_summary(direct_findings, cold_start_findings)
+    findings_section = format_findings_summary(
+        direct_findings, cold_start_findings, max_per_tier=cfg.max_findings_per_tier
+    )
     if findings_section:
         sections.append(findings_section)
 
@@ -951,7 +1013,20 @@ def assemble_synthesis_context(state: DiscoveryState) -> str:
     if literature_section:
         sections.append(literature_section)
 
-    return "\n".join(sections)
+    context = "\n".join(sections)
+
+    # Backstop tripwire (not a truncator): the per-section caps should keep us well under budget.
+    # The real ceiling is the model's ~200K-token input window; max_context_chars is a char proxy,
+    # so log an estimated token count (~3.5 chars/token for this CURIE-dense content) to make the
+    # warning interpretable. Reaching here means a cap is mis-set — surface it loudly.
+    if len(context) > cfg.max_context_chars:
+        logger.warning(
+            "synthesis context %d chars (~%dK est. tokens) exceeds max_context_chars=%d "
+            "(~200K-token window) — a per-section cap is likely mis-set",
+            len(context), round(len(context) / 3.5 / 1000), cfg.max_context_chars,
+        )
+
+    return context
 
 
 def fallback_report(state: DiscoveryState) -> str:
@@ -959,8 +1034,11 @@ def fallback_report(state: DiscoveryState) -> str:
     Generate a structured markdown report without LLM synthesis.
     
     This is the fallback used when the Claude Agent SDK is not available
-    or when running tests. It preserves the existing report format.
+    or when running tests. It preserves the existing report format, and — like
+    assemble_synthesis_context — is module-aware (aggregation + member table at module scale)
+    so the degraded path is also bounded, not an 882KB raw dump.
     """
+    cfg = get_pipeline_config().synthesis
     resolved = state.get("resolved_entities", [])
     query_type = state.get("query_type", "unknown")
     raw_query = state.get("raw_query", "")
@@ -1029,23 +1107,19 @@ def fallback_report(state: DiscoveryState) -> str:
     if temporal_section:
         report_lines.append(temporal_section)
 
-    # Disease associations (structured data)
-    disease_section = format_disease_associations(disease_associations)
-    if disease_section:
-        report_lines.append(disease_section)
-
-    # Pathway memberships (structured data)
-    pathway_section = format_pathway_memberships(pathway_memberships)
-    if pathway_section:
-        report_lines.append(pathway_section)
+    # Disease + pathway (module-aware: aggregation + member table at module scale, per-entity
+    # dumps for small queries — keeps the fallback path bounded too)
+    report_lines.extend(_disease_pathway_sections(state))
 
     # Inferred associations from cold-start (structured data)
     inference_section = format_inferred_associations(inferred_associations, analogues_found)
     if inference_section:
         report_lines.append(inference_section)
 
-    # Analysis findings (summary from both branches)
-    findings_section = format_findings_summary(direct_findings, cold_start_findings)
+    # Analysis findings (summary from both branches) — capped per tier (dominant section)
+    findings_section = format_findings_summary(
+        direct_findings, cold_start_findings, max_per_tier=cfg.max_findings_per_tier
+    )
     if findings_section:
         report_lines.append(findings_section)
 

--- a/backend/src/kestrel_backend/graph/nodes/synthesis.py
+++ b/backend/src/kestrel_backend/graph/nodes/synthesis.py
@@ -270,6 +270,153 @@ def format_pathway_memberships(pathways: list[PathwayMembership]) -> str:
     return "\n".join(lines)
 
 
+# Disease evidence strength, strongest first (matches format_disease_associations' evidence_order).
+_EVIDENCE_STRENGTH = {"gwas": 0, "curated": 1, "text_mined": 2, "predicted": 3}
+_EVIDENCE_LABEL = {0: "gwas", 1: "curated", 2: "text_mined", 3: "predicted"}
+
+
+def aggregate_shared_diseases(
+    disease_associations: list[DiseaseAssociation],
+    min_members: int,
+    max_items: int,
+) -> str:
+    """Module-level disease recurrence: diseases shared across ≥ min_members distinct members.
+
+    Dedupes ``(entity_curie, disease_curie)`` before counting *distinct* member entities (the
+    additive reducers can carry duplicates from parallel branches), keeping the **strongest**
+    ``evidence_type`` per (entity, disease) so evidence strength is not silently dropped. Ranks by
+    distinct-member count, then evidence strength; caps to ``max_items``. Returns ``""`` when nothing
+    qualifies (so single-entity / small queries emit nothing — R5).
+    """
+    if not disease_associations:
+        return ""
+
+    # disease_curie -> {entity_curie: strongest_evidence_rank}
+    by_disease: dict[str, dict[str, int]] = {}
+    names: dict[str, str] = {}
+    for d in disease_associations:
+        members = by_disease.setdefault(d.disease_curie, {})
+        rank = _EVIDENCE_STRENGTH.get(d.evidence_type, 99)
+        if d.entity_curie not in members or rank < members[d.entity_curie]:
+            members[d.entity_curie] = rank
+        names.setdefault(d.disease_curie, d.disease_name)
+
+    qualifying = [
+        (curie, members) for curie, members in by_disease.items() if len(members) >= min_members
+    ]
+    if not qualifying:
+        return ""
+
+    # member count desc, then strongest evidence (lowest rank) asc
+    qualifying.sort(key=lambda cm: (-len(cm[1]), min(cm[1].values())))
+    qualifying = qualifying[:max_items]
+
+    lines = ["## Module-Level Disease Recurrence\n"]
+    lines.append(f"*Diseases associated with multiple module members (shared by ≥{min_members}).*\n")
+    for curie, members in qualifying:
+        strongest = _EVIDENCE_LABEL.get(min(members.values()), "—")
+        lines.append(
+            f"- **{names[curie]}** (`{curie}`) — {len(members)} members [strongest: {strongest}]"
+        )
+        lines.append(f"  - Members: {', '.join(sorted(members))}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def aggregate_shared_pathways(
+    pathway_memberships: list[PathwayMembership],
+    min_members: int,
+    max_items: int,
+) -> str:
+    """Module-level pathway recurrence: pathways/processes shared across ≥ min_members members.
+
+    Dedupes ``(entity_curie, pathway_curie)`` (set of distinct members), filters by threshold, ranks
+    by member count, caps to ``max_items``. Returns ``""`` when nothing qualifies (R5).
+    """
+    if not pathway_memberships:
+        return ""
+
+    by_pathway: dict[str, set[str]] = {}
+    names: dict[str, str] = {}
+    for p in pathway_memberships:
+        by_pathway.setdefault(p.pathway_curie, set()).add(p.entity_curie)
+        names.setdefault(p.pathway_curie, p.pathway_name)
+
+    qualifying = [(c, m) for c, m in by_pathway.items() if len(m) >= min_members]
+    if not qualifying:
+        return ""
+
+    qualifying.sort(key=lambda cm: -len(cm[1]))
+    qualifying = qualifying[:max_items]
+
+    lines = ["## Module-Level Pathway Recurrence\n"]
+    lines.append(
+        f"*Pathways/processes shared across multiple module members (shared by ≥{min_members}).*\n"
+    )
+    for curie, members in qualifying:
+        lines.append(f"- **{names[curie]}** (`{curie}`) — {len(members)} members")
+        lines.append(f"  - Members: {', '.join(sorted(members))}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def format_member_table(
+    resolved_entities: list[EntityResolution],
+    novelty_scores: list[NoveltyScore],
+    disease_associations: list[DiseaseAssociation],
+    max_rows: int,
+) -> str:
+    """Compact one-row-per-member prioritization table (the per-member axis of a module report).
+
+    Joins ``novelty_scores`` (edge_count + classification bucket) with ``resolved_entities``
+    (name/category) by curie — over the **union** of curies so a curie present in only one source
+    still renders (graceful join, no KeyError). "Top disease" is the member's strongest-evidence
+    ``DiseaseAssociation`` (or "—"). Sorted by edge_count desc; capped to ``max_rows`` (top-N) with a
+    "… and N more members" elision so a 217-member table cannot itself become a dump.
+    """
+    name_by_curie = {e.curie: (e.resolved_name or e.raw_name) for e in resolved_entities if e.curie}
+    cat_by_curie = {e.curie: e.category for e in resolved_entities if e.curie}
+    novelty_by_curie = {n.curie: n for n in novelty_scores}
+
+    # strongest-evidence disease name per entity
+    top_disease: dict[str, tuple[int, str]] = {}
+    for d in disease_associations:
+        rank = _EVIDENCE_STRENGTH.get(d.evidence_type, 99)
+        cur = top_disease.get(d.entity_curie)
+        if cur is None or rank < cur[0]:
+            top_disease[d.entity_curie] = (rank, d.disease_name)
+
+    curies = list(dict.fromkeys(list(name_by_curie) + list(novelty_by_curie)))
+    if not curies:
+        return ""
+
+    def _edges(curie: str) -> int:
+        n = novelty_by_curie.get(curie)
+        return n.edge_count if n is not None else -1
+
+    curies.sort(key=_edges, reverse=True)
+    shown = curies[:max_rows]
+    hidden = len(curies) - len(shown)
+
+    lines = ["## Member Prioritization Table\n"]
+    lines.append("| Member | Category | Bucket | Edges | Top Disease |")
+    lines.append("|---|---|---|---|---|")
+    for curie in shown:
+        name = name_by_curie.get(curie, curie)
+        category = (cat_by_curie.get(curie) or "—")
+        if category != "—":
+            category = category.replace("biolink:", "")
+        n = novelty_by_curie.get(curie)
+        bucket = n.classification if n is not None else "—"
+        edges = str(n.edge_count) if n is not None else "—"
+        disease = top_disease.get(curie, (0, "—"))[1]
+        lines.append(f"| {name} (`{curie}`) | {category} | {bucket} | {edges} | {disease} |")
+    if hidden > 0:
+        lines.append(f"\n*… and {hidden} more members*")
+    lines.append("")
+    return "\n".join(lines)
+
+
 def format_shared_neighbors(
     shared_neighbors: list[SharedNeighbor],
     themes: list[BiologicalTheme]

--- a/backend/src/kestrel_backend/graph/pipeline_config.py
+++ b/backend/src/kestrel_backend/graph/pipeline_config.py
@@ -330,12 +330,12 @@ class SynthesisConfig(BaseModel):
     )
     module_mode_min_entities: int = Field(
         default=5,
-        ge=3,
+        ge=2,
         description="Resolved-entity count at/above which assembly switches to module-aware mode "
-        "(aggregation + member table) instead of per-entity sections. >2 by construction so genuine "
-        "single/pair/triple queries keep the per-entity report shape (R5). Distinct from "
-        "min_members_for_recurrence: this gates *whether* module mode engages, not *which* "
-        "diseases/pathways qualify for the recurrence lists.",
+        "(aggregation + member table) instead of per-entity sections. Defaults to 5 (>2) so genuine "
+        "single/pair/triple queries keep the per-entity report shape (R5); operators may lower it to 2 "
+        "to treat pairs as modules. Distinct from min_members_for_recurrence: this gates *whether* "
+        "module mode engages, not *which* diseases/pathways qualify for the recurrence lists.",
     )
     min_members_for_recurrence: int = Field(
         default=2,

--- a/backend/src/kestrel_backend/graph/pipeline_config.py
+++ b/backend/src/kestrel_backend/graph/pipeline_config.py
@@ -295,6 +295,75 @@ class BridgeGroundingConfig(BaseModel):
     )
 
 
+class SynthesisConfig(BaseModel):
+    """Configuration for the synthesis node's context-assembly caps.
+
+    At module scale the assembled LLM context overflowed the model's ~200K-token input
+    window (48-analyte Brown run, 2026-06-22: ~882K chars ~= 230K tokens; findings 58%,
+    disease 21%, pathway 17% of the dump). These caps bound the context against a
+    token-derived budget and switch multi-entity ("module") queries to cross-entity
+    aggregation + a per-member table instead of per-entity dumps. See
+    docs/plans/2026-06-22-001-feat-module-aware-synthesis-context-plan.md.
+    """
+
+    max_findings_per_tier: int = Field(
+        default=50,
+        ge=1,
+        description="Max findings rendered per tier (1/2/3), ranked by confidence "
+        "high->moderate->low; the rest are elided as '... and N more (tier T)'. Findings are "
+        "the dominant context section (58% of the 882K dump, 4,099 entries), so this is the "
+        "load-bearing cut. 50/tier (<=150 total) is ample for a narrative and ~27x below 4,099; "
+        "tune against the R7 run.",
+    )
+    max_aggregated_diseases: int = Field(
+        default=30,
+        ge=1,
+        description="Max diseases in the Module-Level Disease Recurrence section (ranked by "
+        "distinct-member count, then evidence strength). Replaces the per-entity disease dump "
+        "(21% of the overflow) for module queries.",
+    )
+    max_aggregated_pathways: int = Field(
+        default=30,
+        ge=1,
+        description="Max pathways in the Module-Level Pathway Recurrence section. Replaces the "
+        "per-entity pathway dump (17% of the overflow) for module queries.",
+    )
+    module_mode_min_entities: int = Field(
+        default=5,
+        ge=3,
+        description="Resolved-entity count at/above which assembly switches to module-aware mode "
+        "(aggregation + member table) instead of per-entity sections. >2 by construction so genuine "
+        "single/pair/triple queries keep the per-entity report shape (R5). Distinct from "
+        "min_members_for_recurrence: this gates *whether* module mode engages, not *which* "
+        "diseases/pathways qualify for the recurrence lists.",
+    )
+    min_members_for_recurrence: int = Field(
+        default=2,
+        ge=2,
+        description="Minimum distinct member entities sharing a disease/pathway for it to appear in "
+        "the Module-Level Recurrence sections. Inclusive (2 = shared by any pair). Distinct from "
+        "module_mode_min_entities: a low value keeps recurrence inclusive without forcing small "
+        "queries into module mode.",
+    )
+    max_member_table_rows: int = Field(
+        default=50,
+        ge=1,
+        description="Max rows in the per-member prioritization table (top-N by edge_count, rest "
+        "elided). A no-op at 48 analytes; bounds the table at the 217-analyte target where a full "
+        "table (~217 rows) would itself become a dump.",
+    )
+    max_context_chars: int = Field(
+        default=350_000,
+        ge=1,
+        description="Char budget for the assembled synthesis context — a PROXY for the model's "
+        "~200K-token input window (the real ceiling). ~350K chars ~= 100K tokens at the measured "
+        "3.5-3.8 chars/token for this CURIE-dense content, leaving ~100K-token headroom for the "
+        "system prompt + output. ~2.5x below the 882K/230K that crashed. A backstop logs a WARNING "
+        "(with an estimated token count) if assembly exceeds this; the per-section caps should "
+        "prevent reaching it. Tune downward if R7 shows headroom is tight.",
+    )
+
+
 class PipelineConfig(BaseModel):
     """Top-level pipeline configuration with per-node sub-models.
 
@@ -312,6 +381,7 @@ class PipelineConfig(BaseModel):
     hypothesis_extraction: HypothesisExtractionConfig = Field(default_factory=HypothesisExtractionConfig)
     integration: IntegrationConfig = Field(default_factory=IntegrationConfig)
     bridge_grounding: BridgeGroundingConfig = Field(default_factory=BridgeGroundingConfig)
+    synthesis: SynthesisConfig = Field(default_factory=SynthesisConfig)
 
 
 @lru_cache(maxsize=1)

--- a/backend/tests/test_pipeline_config.py
+++ b/backend/tests/test_pipeline_config.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+import pydantic
+
 from kestrel_backend.graph.pipeline_config import (
     BiomapperConfig,
     ColdStartConfig,
@@ -10,6 +12,7 @@ from kestrel_backend.graph.pipeline_config import (
     LiteratureGroundingConfig,
     PathwayEnrichmentConfig,
     PipelineConfig,
+    SynthesisConfig,
     TriageConfig,
     get_pipeline_config,
     get_semaphore,
@@ -73,6 +76,31 @@ class TestPipelineConfig:
         assert config.max_hypotheses == 15
         assert config.parallel_fetch_limit == 6
         assert config.use_llm_classifier is False
+
+    def test_synthesis_defaults(self):
+        """SynthesisConfig exposes the cap surface with token-derived defaults (Diagnostic Evidence)."""
+        config = get_pipeline_config().synthesis
+        assert config.max_findings_per_tier > 0
+        assert config.max_aggregated_diseases > 0
+        assert config.max_aggregated_pathways > 0
+        assert config.max_member_table_rows > 0
+        # max_context_chars is a char proxy for the ~200K-token window: ~350K chars ~= 100K tokens.
+        assert config.max_context_chars == 350_000
+
+    def test_synthesis_thresholds_are_decoupled(self):
+        """Module-mode switch and recurrence threshold are separate fields (not one conflated knob)."""
+        config = get_pipeline_config().synthesis
+        # Module mode engages only above pair size, so 2-entity queries keep the per-entity shape (R5).
+        assert config.module_mode_min_entities > 2
+        # Recurrence is inclusive (a disease shared by 2 members qualifies).
+        assert config.min_members_for_recurrence == 2
+
+    def test_synthesis_field_bounds_reject_invalid(self):
+        """ge= bounds reject nonsensical caps so a misconfig fails loudly, not silently."""
+        with pytest.raises(pydantic.ValidationError):
+            SynthesisConfig(max_findings_per_tier=-1)
+        with pytest.raises(pydantic.ValidationError):
+            SynthesisConfig(max_context_chars=0)
 
     def test_hub_thresholds_intentionally_different(self):
         """Direct KG and pathway enrichment have different hub thresholds by design."""

--- a/backend/tests/test_synthesis_node.py
+++ b/backend/tests/test_synthesis_node.py
@@ -4,17 +4,42 @@ cap, module-vs-per-entity assembly switch, and visible SDK-fallback degradation.
 Plan: docs/plans/2026-06-22-001-feat-module-aware-synthesis-context-plan.md
 """
 
+import logging
+
+from kestrel_backend.graph.nodes import synthesis
 from kestrel_backend.graph.nodes.synthesis import (
     aggregate_shared_diseases,
     aggregate_shared_pathways,
+    format_findings_summary,
     format_member_table,
 )
+from kestrel_backend.graph.pipeline_config import PipelineConfig, SynthesisConfig
 from kestrel_backend.graph.state import (
     DiseaseAssociation,
     EntityResolution,
+    Finding,
     NoveltyScore,
     PathwayMembership,
 )
+
+
+def _finding(entity, tier=1, confidence="high", claim="claimX"):
+    return Finding(
+        entity=entity,
+        claim=claim,
+        tier=tier,
+        predicate=None,
+        source="direct_kg",
+        pmids=[],
+        confidence=confidence,
+        logic_chain=None,
+    )
+
+
+def _use_cfg(monkeypatch, **synthesis_kwargs):
+    cfg = PipelineConfig(synthesis=SynthesisConfig(**synthesis_kwargs))
+    monkeypatch.setattr(synthesis, "get_pipeline_config", lambda: cfg)
+    return cfg
 
 
 def _entity(curie, name="GeneX", category="biolink:Gene"):
@@ -223,3 +248,108 @@ def test_member_table_caps_rows():
     assert "E6" in out and "E5" in out and "E4" in out
     assert "E0" not in out and "E1" not in out
     assert "more members" in out
+
+
+# --- Unit 4: findings cap + module-aware assembly + backstop ---------------------------
+
+
+def test_findings_cap_per_tier_keeps_highest_confidence():
+    """Cap per tier, ranked by confidence high->low; the rest are elided."""
+    findings = [
+        _finding("E_hi1", tier=1, confidence="high"),
+        _finding("E_hi2", tier=1, confidence="high"),
+        _finding("E_lo1", tier=1, confidence="low"),
+        _finding("E_lo2", tier=1, confidence="low"),
+        _finding("E_lo3", tier=1, confidence="low"),
+    ]
+    out = format_findings_summary(findings, [], max_per_tier=2)
+    assert "E_hi1" in out and "E_hi2" in out
+    assert "E_lo1" not in out
+    assert "more (tier 1)" in out  # elision line names the remainder
+
+
+def test_findings_unbounded_when_no_cap():
+    """Backward-compatible: no cap renders every finding (existing callers unaffected)."""
+    findings = [_finding(f"E{i}", tier=1, confidence="low") for i in range(40)]
+    out = format_findings_summary(findings, [], max_per_tier=None)
+    assert "E39" in out
+    assert "more (tier 1)" not in out
+
+
+def test_module_assembly_uses_aggregation_not_per_entity(monkeypatch):
+    """At module scale, assembly emits aggregation + member table, NOT per-entity dumps."""
+    _use_cfg(monkeypatch, module_mode_min_entities=3, min_members_for_recurrence=2)
+    state = {
+        "resolved_entities": [_entity("g1"), _entity("g2"), _entity("g3")],
+        "disease_associations": [_disease("g1", "MONDO:9", "Cancer"), _disease("g2", "MONDO:9", "Cancer")],
+        "pathway_memberships": [_pathway("g1", "GO:1"), _pathway("g2", "GO:1")],
+        "novelty_scores": [_novelty("g1", 100), _novelty("g2", 200), _novelty("g3", 5)],
+    }
+    out = synthesis.assemble_synthesis_context(state)
+    assert "Module-Level Disease Recurrence" in out
+    assert "Member Prioritization Table" in out
+    assert "## Disease Associations" not in out  # per-entity header omitted
+    assert "## Pathway & Biological Process Memberships" not in out
+
+
+def test_single_entity_keeps_per_entity_sections(monkeypatch):
+    """A single-entity query keeps the per-entity report shape (R5)."""
+    _use_cfg(monkeypatch, module_mode_min_entities=5)
+    state = {
+        "resolved_entities": [_entity("g1")],
+        "disease_associations": [_disease("g1", "MONDO:9", "Cancer")],
+        "pathway_memberships": [_pathway("g1", "GO:1")],
+        "novelty_scores": [_novelty("g1", 100)],
+    }
+    out = synthesis.assemble_synthesis_context(state)
+    assert "## Disease Associations" in out
+    assert "Module-Level Disease Recurrence" not in out
+
+
+def test_two_entity_boundary_respects_threshold(monkeypatch):
+    """A 2-entity (pair) query keeps per-entity shape unless module_mode_min_entities<=2 (R5)."""
+    state = {
+        "resolved_entities": [_entity("g1"), _entity("g2")],
+        "disease_associations": [_disease("g1", "MONDO:9", "Cancer"), _disease("g2", "MONDO:9", "Cancer")],
+        "pathway_memberships": [],
+        "novelty_scores": [_novelty("g1", 100), _novelty("g2", 200)],
+    }
+    _use_cfg(monkeypatch, module_mode_min_entities=5)
+    assert "## Disease Associations" in synthesis.assemble_synthesis_context(state)
+    _use_cfg(monkeypatch, module_mode_min_entities=2, min_members_for_recurrence=2)
+    assert "Module-Level Disease Recurrence" in synthesis.assemble_synthesis_context(state)
+
+
+def test_module_context_stays_under_token_budget(monkeypatch):
+    """Core R1 guard: 50 well-char entities x inflated data stay under char + token budget."""
+    cfg = _use_cfg(monkeypatch, module_mode_min_entities=5)
+    entities = [_entity(f"g{i}", f"E{i}") for i in range(50)]
+    novelty = [_novelty(f"g{i}", 500) for i in range(50)]
+    diseases = [_disease(f"g{i}", f"MONDO:{j}", f"Disease{j}") for i in range(50) for j in range(40)]
+    pathways = [_pathway(f"g{i}", f"GO:{j}", f"Pathway{j}") for i in range(50) for j in range(40)]
+    findings = [_finding(f"E{i}-{k}", tier=((k % 3) + 1)) for i in range(50) for k in range(40)]
+    state = {
+        "resolved_entities": entities,
+        "novelty_scores": novelty,
+        "disease_associations": diseases,
+        "pathway_memberships": pathways,
+        "direct_findings": findings,
+        "cold_start_findings": [],
+    }
+    out = synthesis.assemble_synthesis_context(state)
+    assert len(out) < cfg.synthesis.max_context_chars
+    assert len(out) / 3.5 < 100_000  # estimated tokens under budget
+
+
+def test_context_backstop_logs_warning(monkeypatch, caplog):
+    """If assembled context exceeds max_context_chars, a WARNING (with token estimate) is logged."""
+    _use_cfg(monkeypatch, module_mode_min_entities=5, max_context_chars=50)
+    state = {
+        "resolved_entities": [_entity("g1")],
+        "disease_associations": [_disease("g1", "MONDO:9", "Cancer")],
+        "novelty_scores": [_novelty("g1", 100)],
+    }
+    with caplog.at_level(logging.WARNING):
+        synthesis.assemble_synthesis_context(state)
+    msgs = " ".join(r.getMessage().lower() for r in caplog.records)
+    assert "token" in msgs or "max_context_chars" in msgs or "exceeds" in msgs

--- a/backend/tests/test_synthesis_node.py
+++ b/backend/tests/test_synthesis_node.py
@@ -1,0 +1,225 @@
+"""Module-aware synthesis context: cross-entity aggregation, per-member table, findings
+cap, module-vs-per-entity assembly switch, and visible SDK-fallback degradation.
+
+Plan: docs/plans/2026-06-22-001-feat-module-aware-synthesis-context-plan.md
+"""
+
+from kestrel_backend.graph.nodes.synthesis import (
+    aggregate_shared_diseases,
+    aggregate_shared_pathways,
+    format_member_table,
+)
+from kestrel_backend.graph.state import (
+    DiseaseAssociation,
+    EntityResolution,
+    NoveltyScore,
+    PathwayMembership,
+)
+
+
+def _entity(curie, name="GeneX", category="biolink:Gene"):
+    return EntityResolution(
+        raw_name=name,
+        curie=curie,
+        resolved_name=name,
+        category=category,
+        confidence=0.9,
+        method="exact",
+    )
+
+
+def _novelty(curie, edge_count, classification="well_characterized"):
+    return NoveltyScore(
+        curie=curie,
+        raw_name="x",
+        edge_count=edge_count,
+        classification=classification,
+    )
+
+
+def _disease(entity, disease_curie, disease_name="DiseaseX", evidence_type="curated"):
+    return DiseaseAssociation(
+        entity_curie=entity,
+        disease_curie=disease_curie,
+        disease_name=disease_name,
+        predicate="biolink:associated_with",
+        source="test",
+        pmids=[],
+        evidence_type=evidence_type,
+        discovery_preset="default",
+    )
+
+
+def _pathway(entity, pathway_curie, pathway_name="PathwayX"):
+    return PathwayMembership(
+        entity_curie=entity,
+        pathway_curie=pathway_curie,
+        pathway_name=pathway_name,
+        predicate="biolink:participates_in",
+        source="test",
+        discovery_preset="default",
+    )
+
+
+# --- Unit 2: aggregate_shared_diseases -------------------------------------------------
+
+
+def test_shared_disease_lists_all_members():
+    """A disease shared by 3 members is rendered with member count 3 and every member."""
+    diseases = [
+        _disease("NCBIGene:1", "MONDO:9", "Cancer"),
+        _disease("NCBIGene:2", "MONDO:9", "Cancer"),
+        _disease("NCBIGene:3", "MONDO:9", "Cancer"),
+    ]
+    out = aggregate_shared_diseases(diseases, min_members=2, max_items=30)
+    assert "Cancer" in out
+    assert "MONDO:9" in out
+    assert "3" in out  # member count
+    for curie in ("NCBIGene:1", "NCBIGene:2", "NCBIGene:3"):
+        assert curie in out
+
+
+def test_shared_disease_dedupes_duplicate_member():
+    """An additive-reducer duplicate (same entity+disease twice) counts the member ONCE."""
+    diseases = [
+        _disease("NCBIGene:1", "MONDO:9", "Cancer"),
+        _disease("NCBIGene:1", "MONDO:9", "Cancer"),  # duplicate from a parallel branch
+        _disease("NCBIGene:2", "MONDO:9", "Cancer"),
+    ]
+    out = aggregate_shared_diseases(diseases, min_members=2, max_items=30)
+    # 2 distinct members, not 3.
+    assert "2" in out
+    assert "3" not in out.split("Cancer")[1].split("\n")[0]
+
+
+def test_shared_disease_dedupe_keeps_strongest_evidence():
+    """Duplicate (entity, disease) differing in evidence_type keeps the STRONGER one."""
+    diseases = [
+        _disease("NCBIGene:1", "MONDO:9", "Cancer", evidence_type="predicted"),
+        _disease("NCBIGene:1", "MONDO:9", "Cancer", evidence_type="gwas"),  # stronger
+        _disease("NCBIGene:2", "MONDO:9", "Cancer", evidence_type="predicted"),
+    ]
+    out = aggregate_shared_diseases(diseases, min_members=2, max_items=30)
+    assert "gwas" in out  # strongest evidence surfaced, not silently dropped
+    # member counted once despite two rows for NCBIGene:1
+    assert "2" in out
+
+
+def test_disease_below_threshold_excluded():
+    """A disease in only 1 member is excluded when min_members=2."""
+    diseases = [
+        _disease("NCBIGene:1", "MONDO:solo", "Lonely"),
+        _disease("NCBIGene:1", "MONDO:shared", "Shared"),
+        _disease("NCBIGene:2", "MONDO:shared", "Shared"),
+    ]
+    out = aggregate_shared_diseases(diseases, min_members=2, max_items=30)
+    assert "Shared" in out
+    assert "Lonely" not in out
+
+
+def test_disease_cap_keeps_highest_member_count():
+    """With max_items=N and N+ qualifying diseases, exactly N render, highest member-count kept."""
+    diseases = []
+    # disease A: 4 members; B: 3; C: 2; D: 2
+    for e in ("g1", "g2", "g3", "g4"):
+        diseases.append(_disease(e, "MONDO:A", "AAA"))
+    for e in ("g1", "g2", "g3"):
+        diseases.append(_disease(e, "MONDO:B", "BBB"))
+    for e in ("g1", "g2"):
+        diseases.append(_disease(e, "MONDO:C", "CCC"))
+    out = aggregate_shared_diseases(diseases, min_members=2, max_items=2)
+    assert "AAA" in out and "BBB" in out  # top 2 by member count
+    assert "CCC" not in out
+
+
+def test_disease_empty_and_single_entity_return_empty():
+    """Empty input and single-entity input (nothing shared by >=2) both render nothing."""
+    assert aggregate_shared_diseases([], min_members=2, max_items=30) == ""
+    single = [
+        _disease("NCBIGene:1", "MONDO:9", "Cancer"),
+        _disease("NCBIGene:1", "MONDO:8", "Other"),
+    ]
+    assert aggregate_shared_diseases(single, min_members=2, max_items=30) == ""
+
+
+# --- Unit 2: aggregate_shared_pathways -------------------------------------------------
+
+
+def test_shared_pathway_distinct_member_count():
+    """Pathway aggregation counts distinct members, dedupes, respects threshold."""
+    pathways = [
+        _pathway("NCBIGene:1", "GO:1", "Inflammation"),
+        _pathway("NCBIGene:1", "GO:1", "Inflammation"),  # duplicate
+        _pathway("NCBIGene:2", "GO:1", "Inflammation"),
+        _pathway("NCBIGene:1", "GO:solo", "Solo"),  # 1 member only
+    ]
+    out = aggregate_shared_pathways(pathways, min_members=2, max_items=30)
+    assert "Inflammation" in out
+    assert "GO:1" in out
+    assert "2" in out
+    assert "Solo" not in out
+
+
+# --- Unit 3: format_member_table -------------------------------------------------------
+
+
+def test_member_table_rows_sorted_by_edge_count_desc():
+    """One row per member, sorted by edge_count desc, showing bucket + edge_count."""
+    entities = [_entity("g1", "Alpha"), _entity("g2", "Beta"), _entity("g3", "Gamma")]
+    novelty = [
+        _novelty("g1", 50, "moderate"),
+        _novelty("g2", 900, "well_characterized"),
+        _novelty("g3", 5, "sparse"),
+    ]
+    out = format_member_table(entities, novelty, [], max_rows=50)
+    # rows present with bucket + edge_count
+    assert "Beta" in out and "900" in out and "well_characterized" in out
+    assert "Alpha" in out and "Gamma" in out
+    # sorted desc: Beta (900) before Alpha (50) before Gamma (5)
+    assert out.index("Beta") < out.index("Alpha") < out.index("Gamma")
+
+
+def test_member_table_no_disease_shows_dash():
+    """A member with no disease associations renders '—' for top disease."""
+    entities = [_entity("g1", "Alpha")]
+    novelty = [_novelty("g1", 50)]
+    out = format_member_table(entities, novelty, [], max_rows=50)
+    assert "Alpha" in out
+    assert "—" in out
+
+
+def test_member_table_top_disease_is_strongest_evidence():
+    """'Top disease' is the entity's strongest-evidence association."""
+    entities = [_entity("g1", "Alpha")]
+    novelty = [_novelty("g1", 50)]
+    diseases = [
+        _disease("g1", "MONDO:weak", "WeakLink", evidence_type="predicted"),
+        _disease("g1", "MONDO:strong", "StrongLink", evidence_type="gwas"),
+    ]
+    out = format_member_table(entities, novelty, diseases, max_rows=50)
+    assert "StrongLink" in out
+    assert "WeakLink" not in out
+
+
+def test_member_table_graceful_join_both_directions():
+    """A novelty curie with no resolved entity (and vice versa) renders without KeyError."""
+    entities = [_entity("g1", "Alpha")]  # has no novelty
+    novelty = [_novelty("g2", 100)]  # has no resolved entity
+    out = format_member_table(entities, novelty, [], max_rows=50)
+    assert "Alpha" in out  # resolved-only row
+    assert "g2" in out  # novelty-only row
+
+
+def test_member_table_empty_returns_empty():
+    assert format_member_table([], [], [], max_rows=50) == ""
+
+
+def test_member_table_caps_rows():
+    """With max_rows=N and N+ members, exactly N rows (highest edge_count) + an elision line."""
+    entities = [_entity(f"g{i}", f"E{i}") for i in range(7)]
+    novelty = [_novelty(f"g{i}", i * 10) for i in range(7)]
+    out = format_member_table(entities, novelty, [], max_rows=3)
+    # top 3 by edge_count: g6(60), g5(50), g4(40)
+    assert "E6" in out and "E5" in out and "E4" in out
+    assert "E0" not in out and "E1" not in out
+    assert "more members" in out

--- a/backend/tests/test_synthesis_node.py
+++ b/backend/tests/test_synthesis_node.py
@@ -353,3 +353,54 @@ def test_context_backstop_logs_warning(monkeypatch, caplog):
         synthesis.assemble_synthesis_context(state)
     msgs = " ".join(r.getMessage().lower() for r in caplog.records)
     assert "token" in msgs or "max_context_chars" in msgs or "exceeds" in msgs
+
+
+# --- Unit 5: visible SDK-fallback degradation ------------------------------------------
+
+
+def _findings_state():
+    """Minimal state that passes SynthesisInput (needs a non-empty findings branch)."""
+    return {
+        "raw_query": "q",
+        "query_type": "discovery",
+        "resolved_entities": [_entity("g1")],
+        "direct_findings": [_finding("g1")],
+    }
+
+
+async def test_run_records_synthesis_degraded_on_sdk_failure(monkeypatch, caplog):
+    """An SDK synthesis crash returns the fallback report AND records a visible errors entry."""
+    monkeypatch.setattr(synthesis, "HAS_SDK", True)
+    monkeypatch.setattr(synthesis, "ClaudeAgentOptions", lambda **kw: object())
+
+    async def boom(**kw):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(synthesis, "query_with_usage", boom)
+    with caplog.at_level(logging.WARNING):
+        result = await synthesis.run(_findings_state())
+    assert result["synthesis_report"]  # fallback report still produced
+    assert any("synthesis_degraded" in e for e in result.get("errors", []))
+    assert any("kaboom" in r.getMessage() or "fail" in r.getMessage().lower() for r in caplog.records)
+
+
+async def test_run_no_sdk_is_not_recorded_as_degradation(monkeypatch):
+    """The no-SDK/test path uses the fallback but must NOT record a degradation (no false positives)."""
+    monkeypatch.setattr(synthesis, "HAS_SDK", False)
+    result = await synthesis.run(_findings_state())
+    assert result["synthesis_report"]
+    assert not any("synthesis_degraded" in e for e in result.get("errors", []))
+
+
+async def test_run_empty_sdk_text_uses_fallback_without_error(monkeypatch):
+    """Empty SDK text falls back but is not a degradation error (expected, e.g. in tests)."""
+    monkeypatch.setattr(synthesis, "HAS_SDK", True)
+    monkeypatch.setattr(synthesis, "ClaudeAgentOptions", lambda **kw: object())
+
+    async def empty(**kw):
+        return "   ", None
+
+    monkeypatch.setattr(synthesis, "query_with_usage", empty)
+    result = await synthesis.run(_findings_state())
+    assert result["synthesis_report"]
+    assert not any("synthesis_degraded" in e for e in result.get("errors", []))

--- a/docs/plans/2026-06-22-001-feat-module-aware-synthesis-context-plan.md
+++ b/docs/plans/2026-06-22-001-feat-module-aware-synthesis-context-plan.md
@@ -1,0 +1,617 @@
+---
+title: "feat: Module-aware synthesis context (fix synthesis-overflow at module scale)"
+type: feat
+status: active
+date: 2026-06-22
+origin: docs/brainstorms/2026-06-18-run-brown-module-through-pipeline-requirements.md
+---
+
+# feat: Module-aware synthesis context (fix synthesis-overflow at module scale)
+
+## Overview
+
+The discovery pipeline's `synthesis` node assembles its LLM context from accumulated state via
+**uncapped per-entity formatters**. At module scale (the 48-analyte Brown C1 run, 2026-06-22, git
+`09b0f61`: 44 well-characterized entities, 4,099 findings) the assembled context **exceeds the model's
+input-token window** (~882K chars ≈ **230K tokens** vs sonnet-4's ~200K-token limit — see Diagnostic
+Evidence) and the Claude Agent SDK synthesis call fails (observed on console as `Fatal error in
+message reader: Command failed with exit code 1`). The `except` at
+`backend/src/kestrel_backend/graph/nodes/synthesis.py:1010` **silently** falls back to
+`fallback_report()`, producing an 882KB raw per-entity dump with **no module-level narrative** — while
+the run reports `status=complete, errors=0` (synthesis took 3.5s vs the 24-analyte pilot's real 150s
+LLM call). The actual deliverable was not produced, and nothing surfaced it.
+
+This plan **redesigns what synthesis sees**: replace the per-entity raw dumps with (a) cross-entity
+aggregation (diseases/pathways recurring across ≥N module members) and (b) a compact per-member
+prioritization table, cap the findings section, make every cap configurable against a **token-derived
+budget**, and make the SDK-failure degradation **visible and recorded** instead of silent. The result
+is a bounded context that produces a genuine module-level report and — once the cap value is proven by
+the R7 run — never crashes; until then it never *silently* collapses to a raw dump.
+
+## Problem Frame
+
+The pipeline was built for a handful of entities per query; synthesis context assembly was never
+bounded for module-scale input. The 24-analyte C1 pilot (12 well-char entities) fit and produced a
+strong module narrative ("Brown WGCNA Module — Inflammatory-Metabolic Stress Axis"); doubling to 48
+(44 well-char) broke it. This is the synthesis half of Phase B of the Brown-module effort
+(see origin: `docs/brainstorms/2026-06-18-run-brown-module-through-pipeline-requirements.md`). It
+removes the **synthesis-overflow** blocker, which is the first thing that breaks at module scale; it
+is **not** sufficient on its own to make a full-217 run practical — that remains gated on
+`pathway_enrichment` latency (~307s now; origin C1 measured ~47s/analyte ⇒ a single full-217 run is
+~1–2h) and the `cold_start` cap-of-8 silent drop (origin: ~97/105 sparse metabolites dropped at full
+scale). bridge_grounding, the prior dominant cost, is already fixed (~400s → ~35s, PR #83). Two design
+questions were resolved during brainstorming with the user:
+- **Scope:** module-aware redesign (not just minimal caps).
+- **Per-member data:** aggregate **and** keep a cheap per-member prioritization table (the "hybrid"
+  the origin doc flagged as the highest-leverage open question — answered here in favor of capturing
+  both the module-theme and per-member axes).
+
+### Diagnostic Evidence (measured 2026-06-22 from the failure artifact)
+
+Offline analysis of the failing run's deterministic dump
+(`brown_diagnostic_runs/brown_c1_pilot_20260622T070237Z.json`, the 881,749-char `fallback_report`,
+which shares synthesis's section formatters and underlying data) establishes the root cause and sizes
+the fix — **no paid re-run required**:
+
+- **Root cause = input-token-window overflow.** 881,749 chars ≈ **230K tokens** (regex BPE-proxy;
+  **3.80 chars/token** for this CURIE/predicate-dense content — *below* the 4.0 rule of thumb, so a
+  char cap chosen via 4.0 would under-protect). Every estimate (220K–294K tokens across 4.0–3.0
+  chars/token) **exceeds sonnet-4's ~200K-token input window**. The failure is a deterministic
+  over-window rejection, not transient flakiness. *(Caveat: the literal SDK error string is
+  console-only and absent from the artifact; the size math is dispositive independently.)*
+- **The plan caps the right sections.** Per-section char contribution of the dump:
+  **Analysis Findings 514,537 (58%)**, **Disease Associations 184,067 (21%)**, **Pathway/Process
+  Memberships 151,043 (17%)** — together **96%**. Everything else combined is ~4%. Capping findings +
+  aggregating disease/pathway therefore targets essentially all of the bloat.
+- **Finding count: 4,099** (not 37). Confirms the harness ~110× under-count (R6) and that "~4,000" was
+  a correct estimate, not an artifact of the broken counter. ≈125 chars/finding.
+- **Derived budget (pre-committed, not "tune later").** Target assembled context ≤ ~100K tokens
+  (≈ **350,000 chars** at 3.5 chars/token), leaving ~100K-token headroom under the 200K window for the
+  system prompt + model output. That is ~2.5× below the 882K/230K that crashed — conservative by
+  construction. This becomes the initial `max_context_chars` (R7 confirms; tune only downward if
+  needed).
+
+## Requirements Trace
+
+- **R1.** Synthesis LLM call must **succeed** at module scale (≥44 well-characterized entities) —
+  i.e., the assembled context stays within a configurable budget **derived from the model's ~200K-token
+  input window** (the real ceiling; `max_context_chars` is a char *proxy* for it, see Diagnostic
+  Evidence) so the SDK call does not exceed the window.
+- **R2.** The synthesis report at module scale is a coherent **module-level narrative**, not a raw
+  per-entity dump (cross-entity theme + per-member prioritization).
+- **R3.** When the synthesis LLM call fails for any reason, the degradation is **visible**: logged at
+  WARNING with the exception and recorded in `state["errors"]` (so coverage/monitoring sees it). No
+  silent fallback.
+- **R4.** All new bounds are **configurable** via the existing `pipeline_config` pattern, with
+  `Field(description=...)` documenting why each default exists.
+- **R5.** **Single-entity** queries are **unaffected** (the per-entity report shape is preserved
+  verbatim). Module-aware assembly engages only at `module_mode_min_entities` resolved entities
+  (default >2, so genuine *pair* queries also keep the per-entity shape — see Key Technical Decisions);
+  above that threshold the report shape changes by design.
+- **R6.** The assessment harness `coverage()` must report **accurate** finding/association counts
+  (it currently under-reports ~110× — verified: 4,099 actual findings vs 37 reported) so the fix can
+  be honestly verified. *(Sizing for this plan no longer depends on it — the Diagnostic Evidence below
+  measured the failing context directly — so Unit 6 is a harness-honesty cleanup that can ship
+  independently, not a gate for Units 1–5.)*
+- **R7.** End-to-end: re-running the 48-analyte Brown pass produces an LLM narrative (not the
+  deterministic fallback), under the token-derived budget, with a human-sized report, **verified by
+  machine-checkable assertions** (not only a human read — see Unit 7).
+
+## Scope Boundaries
+
+- Not changing `pathway_enrichment` / `integration` node logic; aggregation reuses their state output.
+- Not addressing the new `pathway_enrichment` ~307s latency (separate perf task).
+- Not addressing resolution data-quality quirks (GH1→somatropin, alpha-ketoglutarate→cyanohydrin,
+  proline category=Protein) — those belong to biomapper/resolution.
+- Not implementing the Semantic Scholar circuit-breaker (separate, tracked).
+- Not changing reducer semantics in `state.py` (the additive reducers are correct; only the harness
+  that *reads* streamed deltas is wrong).
+
+### Deferred to Separate Tasks
+
+- **Bounded SDK retry-then-raise** for transient synthesis failures: the learnings
+  (`docs/solutions/best-practices/reliable-long-running-llm-batch-runs-2026-06-07.md`) recommend
+  bounded retry for the intermittently-flaky SDK subprocess. This plan's caps address the
+  *deterministic* context-size failure; a general retry wrapper is a broader SDK-reliability change —
+  future iteration.
+- **Tuning cap values for the full-217 scale**: ship with the token-derived defaults above (pinned
+  from the 200K window, validated at 48 analytes by R7); the headline 217-analyte scale (~79 well-char
+  per origin C0) is never exercised here, so re-confirm/tune the budget before a full-217 run. This is
+  re-validation at a larger scale, **not** shipping unvalidated values now.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `backend/src/kestrel_backend/graph/nodes/synthesis.py` — the node. Key functions:
+  `assemble_synthesis_context` (line 711), `fallback_report` (line 810), `run` (line 960),
+  `SYNTHESIS_PROMPT` (line 41), and formatters `format_disease_associations` (199),
+  `format_pathway_memberships` (248), `format_findings_summary` (376), `format_entity_summary` (119).
+  Existing caps are module constants (`MAX_LIT_PAPERS_PER_HYPOTHESIS=4`, `MAX_LIT_ABSTRACT_CHARS=1500`,
+  lines 634–635) + inline slices. **synthesis.py does not currently import `get_pipeline_config`** —
+  wiring it is net-new.
+- `backend/src/kestrel_backend/graph/pipeline_config.py` — config pattern to mirror:
+  `class XConfig(BaseModel)` with `Field(default=, description=)`; register on `PipelineConfig`
+  (lines 298–314) via `name: XConfig = Field(default_factory=XConfig)`; access via
+  `@lru_cache get_pipeline_config()` (lines 317–325). Closest example: `BridgeGroundingConfig`
+  (lines 270–295). Nested-config precedent: `EntityResolutionConfig` embeds `BiomapperConfig`.
+- `backend/src/kestrel_backend/graph/state.py` — `DiscoveryState` (TypedDict, line 378). Additive
+  reducer fields (accumulate, may contain duplicates across branches): `resolved_entities` (410,
+  `Annotated[list[EntityResolution], operator.add]`), `novelty_scores` (414), `direct_findings` (423),
+  `cold_start_findings` (424), `disease_associations` (427), `pathway_memberships` (428). Additional
+  additive list keys (also accumulate; relevant to Unit 6's count fix): `inferred_associations` (429),
+  `analogues_found` (430), `hub_flags` (431), `shared_neighbors` (434), `gap_entities` (447),
+  `temporal_classifications` (450), `model_usages` (471), `literature_errors` (461),
+  `bridge_grounding_errors` (467). Plain last-write-wins: `bridges` (446), `hypotheses` (458),
+  `biological_themes` (435). `errors` (475) is additive and read by coverage. Models: `DiseaseAssociation` (entity_curie, disease_curie, disease_name,
+  evidence_type), `PathwayMembership` (entity_curie, pathway_curie, pathway_name), `NoveltyScore`
+  (curie, edge_count, classification), `Finding` (entity, claim, tier, confidence).
+- `backend/tests/test_bridge_grounding_node.py` — **template** for the new synthesis tests: tests
+  synthesis `format_*` helpers directly, config gating via
+  `monkeypatch.setattr(<node>, "get_pipeline_config", lambda: cfg)`, and `run()`.
+- `backend/tests/test_pathway_enrichment.py` — `HAS_SDK` monkeypatch + lightweight
+  dict/`SimpleNamespace` state construction.
+- `backend/assessment_data/brown_c1_pilot_e2e.py` — the E2E harness; `coverage()` (line ~93) does
+  `merged.update(out)` over streamed deltas, clobbering additive keys (the R6 bug).
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/sdk-stdio-mcp-unavailable-migrate-to-http-data-in-prompt-2026-06-02.md`
+  — "Drop with a visible `degraded` flag, never silently"; stage non-SDK results before the `try`;
+  emit a result on every exit path. Directly shapes R3.
+- `docs/solutions/best-practices/reliable-long-running-llm-batch-runs-2026-06-07.md` — SDK subprocess
+  fails intermittently; never swallow failures (anti-pattern = silent shrink / fabricated result).
+- `docs/solutions/best-practices/discovery-pipeline-one-graph-methods-within-nodes-2026-05-28.md` —
+  a blanket merge over LangGraph state mishandles `operator.add` keys (the R6 root cause); mirror the
+  reducer map when merging streamed deltas.
+- `docs/solutions/best-practices/langgraph-pipeline-production-formalization.md` — ship new behavior
+  behind config with `Field(description=...)` recording why each default exists; cassette replay does
+  not remove LLM non-determinism. Notes issue #47 as the same silent-truncation family as R6.
+- `docs/solutions/developer-experience/pytest-venv-path-spaces-module-invocation-2026-06-01.md` —
+  run tests as `cd backend && uv run python -m pytest ...`.
+
+### External References
+
+- None used — internal pipeline code with strong local patterns.
+
+## Key Technical Decisions
+
+- **Aggregate, don't dump (module queries only).** For queries with ≥ `module_mode_min_entities`
+  resolved entities, replace the per-entity `format_disease_associations` /
+  `format_pathway_memberships` output in the synthesis context with cross-entity aggregation + a
+  per-member table. Below that threshold (single-entity **and** small pair/triple queries) keep the
+  existing per-entity sections verbatim (R5). Gate on resolved-entity count, not a config flag, so
+  behavior matches intent automatically.
+- **Two distinct thresholds, two config fields (do not conflate).** `module_mode_min_entities`
+  (default >2, e.g. 5) gates *whether* assembly switches to module-aware mode; `min_members_for_recurrence`
+  (default 2) gates *which* diseases/pathways qualify for the shared-recurrence lists. These pull in
+  opposite directions (inclusive recurrence wants a low value; not-reshaping-small-queries wants a
+  higher mode threshold), so a single field would couple two independent decisions — a latent bug.
+- **Dedupe before counting members; keep strongest evidence.** Because
+  `disease_associations`/`pathway_memberships` use additive reducers and may carry duplicates from
+  multiple branches, aggregation must dedupe by `(entity_curie, disease_curie)` /
+  `(entity_curie, pathway_curie)` before counting *distinct* member entities. When duplicate
+  `(entity, key)` rows differ only in `evidence_type`, **retain the strongest** (don't silently drop
+  evidence strength that the member table's "top disease" selection relies on). Otherwise recurrence
+  counts inflate.
+- **Caps default-ON with token-derived values (this fixes a live crash).** The bounds fix a
+  deterministic over-window crash, so they ship enabled. `max_context_chars` defaults to a value
+  **derived from the ~200K-token window** (≈350K chars ≈ ≤100K tokens at 3.5 chars/token, ~2.5× under
+  the failing 882K — see Diagnostic Evidence), not a guessed-then-tuned number. R7 confirms; tune only
+  downward, and re-validate before the full-217 scale.
+- **`max_context_chars` is a char proxy for a token ceiling.** The real limit is tokens, not chars
+  (3.80 chars/token measured for this CURIE-dense content). The cap is expressed in chars for cheap
+  in-process checking, sized conservatively against the token budget; Unit 7 asserts the *token*
+  estimate stays under budget, closing the proxy gap.
+- **Visible degradation, not retry.** The primary fix (caps) prevents the deterministic overflow; the
+  `except` is fixed to log + record in `state["errors"]` + set a degraded marker. This makes a future
+  over-budget case **observable**, not impossible — "always produces a narrative" holds only once the
+  R7 run proves the cap value. Bounded retry for transient SDK flakiness is deferred (see Scope).
+- **Config over constants.** New caps live in a `SynthesisConfig` Pydantic sub-model (mirroring
+  `BridgeGroundingConfig`), read via `get_pipeline_config()` newly imported into synthesis.py.
+  (Module constants like `MAX_LIT_PAPERS_PER_HYPOTHESIS` would also satisfy R4; the sub-model is chosen
+  for consistency with the established config pattern and runtime overridability.)
+- **Harness reads reducers correctly.** Fix `coverage()` to mirror `state.py` reducer semantics
+  (concatenate additive list keys across streamed deltas; overwrite plain keys) rather than a blanket
+  `merged.update()`.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Scope of fix → module-aware redesign (user decision).
+- Per-member data treatment → aggregate **and** keep a compact per-member table (user decision).
+- Config vs constants → config sub-model, mirroring existing pattern (research-confirmed).
+- Are source fields additive? → yes, all six (research-confirmed) → aggregation must dedupe.
+- Root cause → **input-token-window overflow** (~230K tokens vs ~200K window), measured offline from
+  the failure artifact (Diagnostic Evidence, 2026-06-22). Not transient flakiness.
+- Which sections dominate → findings 58%, disease 21%, pathway 17% (96% combined) → the planned cuts
+  are correctly targeted (measured, not assumed).
+- Module-mode threshold vs recurrence threshold → **two separate config fields** (decoupled) —
+  `module_mode_min_entities` (>2) and `min_members_for_recurrence` (2).
+- Initial `max_context_chars` → **pre-committed at ≈350K chars** (token-derived), not deferred.
+- Degraded handling → log + record in `state["errors"]` (+ marker); retry deferred (learnings).
+- Caps enablement → **default-ON** (user sign-off 2026-06-22): fixes a live crash, not an
+  experiment; only cap *values* tuned later post-measurement. No enable flag.
+- SDK-failure handling → **visible-degraded only** (user sign-off 2026-06-22): log WARNING +
+  record in `state["errors"]`; bounded SDK retry stays a separate reliability task (see Deferred).
+
+### Deferred to Implementation
+
+- `max_context_chars` initial value is **pre-committed at ≈350,000 chars** (token-derived; see
+  Diagnostic Evidence). The remaining cap values (`max_findings_per_tier`, `max_aggregated_diseases`,
+  `max_aggregated_pathways`, `module_mode_min_entities`, `min_members_for_recurrence`,
+  `max_member_table_rows`) get conservative starting values; R7 confirms context stays under the token
+  budget and the report is coherent. Re-validate at the full-217 scale.
+- Exact helper/function names for the new aggregation + member-table functions.
+- Whether to add a dedicated `synthesis_degraded: bool` state key vs recording only in `errors` —
+  decide during implementation based on whether the frontend/report needs to display it (recording in
+  `errors` satisfies R3 with no schema change; a bool is additive polish). The *baseline* return shape
+  is already fixed by Unit 5's Approach — a `synthesis_degraded: <type>: <msg>` string appended to the
+  node's returned `errors` list (merged into state via the additive reducer); the deferred decision is
+  only whether to *additionally* surface a typed bool.
+- The precise "top disease per member" selection rule for the member table (highest evidence tier,
+  then by source) — settle when writing `format_member_table` against real data.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation
+> specification. The implementing agent should treat it as context, not code to reproduce.*
+
+Synthesis context assembly, before vs after, for a multi-entity (module) query:
+
+```
+BEFORE (unbounded):                      AFTER (bounded, module-aware):
+  Entity Resolution Summary                Entity Resolution Summary
+  Disease Associations   ── per entity     Module-Level Disease Recurrence  ── diseases shared by ≥N members
+    ### CURIE: [all diseases] × 44         Module-Level Pathway Recurrence  ── pathways shared by ≥N members
+  Pathway Memberships    ── per entity     Member Prioritization Table      ── 1 line/member: bucket|edges|top disease
+    ### CURIE: [all pathways]  × 44        Shared Neighbors / Themes        (unchanged, already capped)
+  Shared Neighbors / Themes                Cross-Type Bridges               (unchanged)
+  Cross-Type Bridges                       Gap Analysis                     (unchanged)
+  Gap Analysis                             Analysis Findings (top-K / tier) ── capped, "… and N more"
+  Analysis Findings  ── ALL ~4,000 ✗       Literature Evidence              (unchanged)
+  → 882KB → SDK crash → silent fallback    → bounded → SDK succeeds → module narrative
+
+                                         [context-char backstop: if assembled > max_context_chars,
+                                          log WARNING (caps should prevent reaching here)]
+```
+
+`run()` failure path, before vs after:
+
+```
+BEFORE: except Exception: report = fallback_report(state)   # silent, errors stays 0
+AFTER:  except Exception as e:
+            logger.warning("synthesis LLM failed, using fallback: %s", e, exc_info=True)
+            report = fallback_report(state)
+            return {..., "errors": [f"synthesis_degraded: {type(e).__name__}: {e}"]}  # additive → visible
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: `SynthesisConfig` + wire config into synthesis.py**
+
+**Goal:** Introduce a configurable cap surface for synthesis and make the node read it.
+
+**Requirements:** R4 (supports R1, R2).
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `backend/src/kestrel_backend/graph/pipeline_config.py`
+- Modify: `backend/src/kestrel_backend/graph/nodes/synthesis.py`
+- Test: `backend/tests/test_pipeline_config.py` (extend), `backend/tests/test_synthesis_node.py` (new)
+
+**Approach:**
+- Add `class SynthesisConfig(BaseModel)` mirroring `BridgeGroundingConfig`: fields
+  `max_findings_per_tier`, `max_aggregated_diseases`, `max_aggregated_pathways`,
+  `module_mode_min_entities` (default >2, e.g. 5), `min_members_for_recurrence` (default 2),
+  `max_member_table_rows`, `max_context_chars` (default **350_000**, token-derived — see Diagnostic
+  Evidence), each `Field(default=…, ge=…, description="why")`. The two threshold fields are
+  intentionally separate (see Key Technical Decisions).
+- Register `synthesis: SynthesisConfig = Field(default_factory=SynthesisConfig)` on `PipelineConfig`.
+- Import `get_pipeline_config` into synthesis.py; read `get_pipeline_config().synthesis` where caps
+  are applied (Units 2–4). Do **not** add to `get_semaphore()`'s map (synthesis has no per-node
+  semaphore).
+
+**Patterns to follow:** `BridgeGroundingConfig` + its registration; config override idiom
+`monkeypatch.setattr(synthesis, "get_pipeline_config", lambda: cfg)`.
+
+**Test scenarios:**
+- Happy path: `PipelineConfig().synthesis` exposes all cap fields with documented defaults.
+- Edge case: field bounds reject invalid values (e.g. negative `max_findings_per_tier` raises
+  `ValidationError` via `ge=`).
+- Happy path: `get_pipeline_config().synthesis` is reachable and overridable in a node test via
+  monkeypatch.
+
+**Verification:** `PipelineConfig` carries a `synthesis` sub-config; synthesis.py imports and reads it;
+config tests green.
+
+- [ ] **Unit 2: Cross-entity aggregation helpers**
+
+**Goal:** Compute module-level disease/pathway recurrence across members.
+
+**Requirements:** R2 (supports R1).
+
+**Dependencies:** Unit 1 (caps).
+
+**Files:**
+- Modify: `backend/src/kestrel_backend/graph/nodes/synthesis.py`
+- Test: `backend/tests/test_synthesis_node.py`
+
+**Approach:**
+- Add `aggregate_shared_diseases(disease_associations, min_members, max_items)` → diseases grouped by
+  `disease_curie`, counting **distinct** `entity_curie` after deduping `(entity_curie, disease_curie)`
+  (on duplicate `(entity, disease)` rows differing only in `evidence_type`, keep the strongest);
+  keep those with ≥ `min_members` members (caller passes `min_members_for_recurrence`); rank by member
+  count then evidence strength; cap to `max_items`; render markdown (disease name, member count, member
+  list, strongest evidence type).
+- Add `aggregate_shared_pathways(pathway_memberships, min_members, max_items)` — same over
+  `pathway_curie`.
+- Both return `""` when nothing qualifies (so single-entity queries emit nothing — R5).
+
+**Execution note:** Implement test-first — pure functions over Pydantic models, ideal for TDD.
+
+**Technical design:** *(directional)* group → dedupe `(entity, key)` → `Counter` over distinct
+entities → filter `≥ min_members` → sort desc → slice `max_items` → format.
+
+**Patterns to follow:** existing `format_*` helpers in synthesis.py (markdown section + `### ` shape);
+`format_bridges` test style in `test_bridge_grounding_node.py`.
+
+**Test scenarios:**
+- Happy path: 3 entities sharing disease D → D listed with member count 3 and all three members.
+- Edge case (dedupe): same `(entity_curie, disease_curie)` appearing twice (additive-reducer
+  duplicate) counts the member **once**, not twice.
+- Edge case (dedupe keeps strongest evidence): same `(entity_curie, disease_curie)` with two different
+  `evidence_type` values → member counted once **and** the rendered "strongest evidence type" reflects
+  the stronger of the two (evidence not silently dropped).
+- Edge case (threshold): a disease in only 1 member with `min_members=2` is excluded.
+- Edge case (cap): with `max_aggregated_diseases=N` and N+5 qualifying diseases, exactly N rendered,
+  highest member-count retained.
+- Edge case (empty): empty input → `""`; single-entity input → `""` (nothing shared by ≥2).
+- Happy path (pathways): analogous distinct-member counting for `aggregate_shared_pathways`.
+
+**Verification:** helpers produce correct distinct-member counts with dedupe, respect threshold + cap,
+and return empty for single-entity input.
+
+- [ ] **Unit 3: Per-member prioritization table**
+
+**Goal:** A compact one-line-per-member table capturing the per-member axis.
+
+**Requirements:** R2 (supports R5).
+
+**Dependencies:** Unit 1.
+
+**Files:**
+- Modify: `backend/src/kestrel_backend/graph/nodes/synthesis.py`
+- Test: `backend/tests/test_synthesis_node.py`
+
+**Approach:**
+- Add `format_member_table(resolved_entities, novelty_scores, disease_associations, max_rows)` →
+  one row per resolved entity: `name (curie) | category | bucket | edge_count | top disease`. Join
+  `novelty_scores` (edge_count + classification) with `resolved_entities` (name/category) by curie;
+  "top disease" = the entity's highest-evidence-tier `DiseaseAssociation` (or "—"). Sort by
+  `edge_count` desc. Each row ≈50 chars, but at the 217-analyte target a full table is ~217 rows (~11KB)
+  and itself becomes a dump — so cap to `max_member_table_rows` (top-N by edge_count) with a
+  "… and N more members" elision line. At 48 analytes this is a no-op; it protects the headline scale.
+
+**Execution note:** Test-first (pure function).
+
+**Patterns to follow:** synthesis `format_*` helpers; markdown table rendering.
+
+**Test scenarios:**
+- Happy path: 3 members with differing edge counts → 3 rows sorted by edge_count desc, each showing
+  bucket + edge_count.
+- Edge case: a member with no disease associations → "top disease" shows "—".
+- Edge case: a `novelty_score` curie with no matching `resolved_entity` (and vice versa) → row still
+  renders without KeyError (graceful join).
+- Edge case: empty resolved set → `""`.
+- Edge case (cap): with `max_member_table_rows=N` and N+5 members → exactly N rows (highest edge_count)
+  + a "… and N more members" line.
+
+**Verification:** table renders one bounded row per member with correct bucket/edges/top-disease and
+graceful joins, and never exceeds `max_member_table_rows`.
+
+- [ ] **Unit 4: Cap findings + rewire module-aware assembly + prompt framing**
+
+**Goal:** Bound the findings section and assemble the module-aware context (and fallback report),
+plus orient the prompt.
+
+**Requirements:** R1, R2, R5 (supports R7).
+
+**Dependencies:** Units 1–3.
+
+**Files:**
+- Modify: `backend/src/kestrel_backend/graph/nodes/synthesis.py`
+- Test: `backend/tests/test_synthesis_node.py`
+
+**Approach:**
+- Cap `format_findings_summary` to `max_findings_per_tier` per tier, appending "… and N more (tier T)"
+  elision lines. **Note:** the current helper groups by `Finding.tier` (1/2/3) and sorts by tier only;
+  it does **not** rank within a tier. This unit adds within-tier ranking by `Finding.confidence`
+  (map `high`→0, `moderate`→1, `low`→2 as the sort key) so the cap keeps the strongest findings, not
+  an arbitrary slice. (Findings are the 58% dominant section per Diagnostic Evidence, so this is the
+  load-bearing cut.)
+- In `assemble_synthesis_context` **and** `fallback_report`: when resolved-entity count
+  ≥ `module_mode_min_entities` (the module-mode switch — NOT the recurrence threshold), emit
+  `aggregate_shared_diseases` + `aggregate_shared_pathways` (each passed `min_members_for_recurrence`)
+  + `format_member_table` **in place of** the per-entity `format_disease_associations` /
+  `format_pathway_memberships`; otherwise keep the existing per-entity sections (R5). Always apply the
+  capped findings section. Keep shared-neighbors, themes, bridges, gaps, literature sections unchanged.
+- Add a **context-char backstop**: after assembling, if `len(context) > max_context_chars`, log a
+  WARNING (the caps should prevent reaching this — it is a tripwire, not a truncator). Because the real
+  limit is tokens, the backstop should also log an **estimated token count** (`len(context) / 3.5`) so
+  the warning is interpretable against the ~200K window.
+- `SYNTHESIS_PROMPT`: add a conditional instruction — *if the input is a module (≥ module_mode_min_entities
+  entities), treat them as a group/module; lead with the unifying theme; use the Module-Level Recurrence
+  + Member Prioritization sections.* Keep single/small-query behavior intact.
+
+**Patterns to follow:** existing section-assembly order in `assemble_synthesis_context` (711) and
+`fallback_report` (810); the `[:N]` slice + "… and N more" elision idiom already in the file.
+
+**Test scenarios:**
+- Happy path (cap): 200 findings in tier 1 with `max_findings_per_tier=20` → 20 rendered + an
+  elision line stating the remainder.
+- Happy path (module assembly): a state with 44 well-char entities and shared diseases →
+  `assemble_synthesis_context` contains the aggregation + member-table sections and **omits** the
+  per-entity `### CURIE` disease/pathway dumps.
+- Edge case (single entity): 1 resolved entity → per-entity sections retained, no aggregation
+  sections, prompt-agnostic (R5).
+- Edge case (2-entity boundary, R5): 2 resolved entities with `module_mode_min_entities=5` → per-entity
+  sections **retained** (small pair query unaffected); separately, 2 entities with
+  `module_mode_min_entities=2` → module-aware sections engage. Pins the decoupled-threshold behavior.
+- Bound test: `assemble_synthesis_context` and `fallback_report` with 50 well-char entities ×
+  inflated disease/pathway/findings stay **under `max_context_chars`** AND under the token budget
+  (`len/3.5 < ~100K`) — the core R1 guard (note the unit char bound is necessary but only R7 proves
+  real SDK success).
+- Edge case (backstop): force an over-budget context (tiny `max_context_chars`) → WARNING logged with
+  the estimated token count.
+
+**Verification:** module-scale assembled context is bounded and module-shaped; small queries unchanged.
+
+- [ ] **Unit 5: Make synthesis fallback visible (no silent degradation)**
+
+**Goal:** Fix the silent `except`; surface SDK-synthesis failures.
+
+**Requirements:** R3.
+
+**Dependencies:** None (independent of 1–4, but verified together).
+
+**Files:**
+- Modify: `backend/src/kestrel_backend/graph/nodes/synthesis.py`
+- Test: `backend/tests/test_synthesis_node.py`
+
+**Approach:**
+- In `run()` (line ~1010): on SDK exception, `logger.warning(... exc_info=True)`, build the fallback
+  report, and **append a `synthesis_degraded: <type>: <msg>` string to the returned `errors`** (the
+  `errors` reducer is additive, so it surfaces in final state and coverage). Same for the
+  `not HAS_SDK` and empty-text paths (the latter is expected in tests — log at INFO/DEBUG, not an
+  error, to avoid false positives). Optionally set a `synthesis_degraded` marker (deferred decision).
+
+**Execution note:** Test-first — assert on the returned dict and captured logs.
+
+**Patterns to follow:** other nodes' error recording into `state["errors"]`; `caplog` usage in
+existing tests.
+
+**Test scenarios:**
+- Error path: `HAS_SDK=True`, `query_with_usage` raises → returns the fallback report **and**
+  `errors` contains a `synthesis_degraded:` entry; WARNING logged.
+- Edge case: `HAS_SDK=False` → fallback report returned; this is the test/no-SDK path and must **not**
+  be recorded as a degradation error (avoid false positives in the suite).
+- Edge case: SDK returns empty text → fallback used, logged at non-error level.
+
+**Verification:** an SDK synthesis crash is logged and recorded in `errors`; the no-SDK path stays
+clean.
+
+- [ ] **Unit 6: Fix assessment harness `coverage()` under-count (reducer-aware merge)**
+
+**Goal:** Accurate finding/association counts so the fix is verifiable.
+
+**Requirements:** R6 (supports R7).
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `backend/assessment_data/brown_c1_pilot_e2e.py`
+- Test: none (scratch assessment harness) — see Test expectation note.
+
+**Approach:**
+- In the stream-consume loop, stop using a blanket `merged.update(out)` for additive list keys.
+  Mirror `state.py` reducer semantics: for **every** `operator.add` list key — `resolved_entities`,
+  `novelty_scores`, `direct_findings`, `cold_start_findings`, `disease_associations`,
+  `pathway_memberships`, `inferred_associations`, `analogues_found`, `hub_flags`, `shared_neighbors`,
+  `gap_entities`, `temporal_classifications`, `model_usages`, `literature_errors`,
+  `bridge_grounding_errors`, `errors` — **concatenate** across deltas; for plain last-write-wins keys
+  (`bridges`, `hypotheses`, `biological_themes`, `synthesis_report`, etc.), overwrite. (Prefer
+  deriving the additive-key set programmatically from `DiscoveryState`'s annotations so a future
+  reducer field cannot silently reintroduce the under-count.) Then `coverage()` counts reflect reality
+  (the run that reported 37 findings under-counted findings/associations — see the "measure actual
+  per-section contribution" item below for the real magnitude).
+
+**Test expectation:** none — this is scratch assessment tooling, not shipped library code; correctness
+is validated by the R7 run reporting plausible counts. (If kept long-term, a small unit test over a
+synthetic delta stream would be worthwhile — noted, not required.)
+
+**Verification:** re-running the harness reports finding/association counts consistent with the
+rendered report (no ~100× under-count).
+
+- [ ] **Unit 7: End-to-end verification — re-run the 48-analyte Brown pass**
+
+**Goal:** Prove the fix at the scale that broke it.
+
+**Requirements:** R7 (closes R1, R2).
+
+**Dependencies:** Units 1–6.
+
+**Files:**
+- Run: `backend/assessment_data/brown_c1_pilot_e2e.py` (`--n-proteins 24 --n-metabolites 24
+  --ceiling-min 45`); artifact auto-saved to `backend/assessment_data/brown_diagnostic_runs/`.
+
+**Approach:**
+- Re-run, then assert **machine-checkable** acceptance (not only a human read) — add these checks to
+  the harness so pass/fail is reproducible despite LLM non-determinism:
+  1. `synthesis_degraded` **absent** from `errors` (no fallback path taken).
+  2. `synthesis_duration > 30s` (a real LLM call happened, not the ~3.5s deterministic fallback).
+  3. assembled-context **estimated tokens** (`chars/3.5`) **< budget** (~100K) and chars < `max_context_chars`.
+  4. `synthesis_report` is human-sized (regex: **< 10** `### CURIE`-style raw per-entity sections;
+     total size ~tens of KB, not ~882KB).
+  5. `coverage()` counts are now plausible (findings ≫ the old 37; consistent with the rendered report).
+- **Signal-preservation check (guards information loss):** diff the 48-analyte narrative against the
+  known-good 24-analyte pilot narrative — confirm no high-value finding present at 24 disappeared at
+  48 purely due to aggregation. This is a **human/domain** gate on top of the machine assertions; name
+  who signs off (the researcher/owner). A bounded, crash-free-but-degraded report must not pass
+  silently.
+
+**Test expectation:** the machine assertions above ARE the automated acceptance; the signal-preservation
+diff is a human gate. (Paid ~12-min biomapper-ON SDK run; auto-saves its artifact.)
+
+**Verification:** R1, R2, R7 satisfied on the real module-scale input — proven by the machine assertions
+*and* the signal-preservation sign-off, not "looks like a narrative" alone.
+
+## System-Wide Impact
+
+- **Interaction graph:** synthesis is the terminal node; changes affect only the final report and the
+  `errors` channel. No upstream node is touched. The `errors` additions are read by coverage and any
+  monitoring of `state["errors"]`.
+- **Error propagation:** SDK synthesis failure now propagates as a recorded `errors` entry + log,
+  instead of vanishing. Downstream consumers that treat `errors == []` as "fully clean" will now
+  correctly see synthesis degradations.
+- **State lifecycle risks:** none new — no schema changes required (recording in existing additive
+  `errors`); a `synthesis_degraded` bool, if added, is additive and backward-compatible.
+- **API surface parity:** the WebSocket/report payload (`synthesis_report`) shape is unchanged; only
+  its *content* at module scale changes (narrative vs raw dump). Frontend rendering already handles
+  arbitrary markdown.
+- **Integration coverage:** the bound test (Unit 4) and the E2E run (Unit 7) together prove what unit
+  mocks cannot — that the real assembled context stays under the SDK's effective limit.
+- **Unchanged invariants:** single-entity / small-query report shape (R5); reducer semantics in
+  `state.py`; all non-synthesis nodes; the literature/bridges/themes/gaps sections.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Caps too tight → narrative loses signal; **or** aggregation drops a high-value single-member finding | Aggregation preserves cross-entity signal; member table preserves per-member coverage; the Unit 7 signal-preservation diff vs the 24-analyte pilot is the explicit guard, with a named human sign-off. A 1-member strong link still surfaces via the member table's "top disease". |
+| `max_context_chars` set above the real **token** ceiling → still over-window | Initial value is **token-derived** (≈350K chars ≈ ≤100K tokens, ~2.5× under the failing 882K/230K); Unit 4 asserts both char and estimated-token bounds; R7 asserts est-tokens < budget on real data. The true gate is R7, not the unit char bound. |
+| Caps slightly loose → first module run re-crashes | Conservative token-derived default + the visible-degraded path makes it observable (recorded in `errors`), not silent; R7 is engineered to pass, not hoped to. |
+| Aggregation double-counts, or drops evidence strength, due to additive-reducer duplicates | Explicit dedupe by `(entity, key)` before counting distinct members, retaining the strongest `evidence_type` (Unit 2 tests cover both). |
+| Recording every empty-text fallback as an error → false positives in test suite | Only the genuine SDK-exception path records `synthesis_degraded`; no-SDK / empty-text paths log at non-error level (Unit 5 tests cover both). |
+| Harness `coverage()` fix incomplete (misses a reducer key) | Mirror the exact additive-key list from `state.py` (enumerated in this plan); R7 sanity-checks counts against the rendered report. |
+
+## Documentation / Operational Notes
+
+- After R7 passes, document the module-scale synthesis pattern via `ce:compound` (the learnings
+  researcher flagged this as net-new territory worth capturing).
+- Update the origin requirements doc's Phase B section with the synthesis-overflow resolution and the
+  chosen cap defaults.
+- No deployment/rollout concerns: caps are default-on bug fixes; no migration; no env vars.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-06-18-run-brown-module-through-pipeline-requirements.md](docs/brainstorms/2026-06-18-run-brown-module-through-pipeline-requirements.md)
+- Run artifact (the failure): `backend/assessment_data/brown_diagnostic_runs/brown_c1_pilot_20260622T070237Z.json`
+- Related code: `backend/src/kestrel_backend/graph/nodes/synthesis.py`,
+  `backend/src/kestrel_backend/graph/pipeline_config.py`, `backend/src/kestrel_backend/graph/state.py`
+- Related learnings: `docs/solutions/best-practices/sdk-stdio-mcp-unavailable-migrate-to-http-data-in-prompt-2026-06-02.md`,
+  `docs/solutions/best-practices/discovery-pipeline-one-graph-methods-within-nodes-2026-05-28.md`,
+  `docs/solutions/best-practices/reliable-long-running-llm-batch-runs-2026-06-07.md`
+- Memory: `brown-c1-48-run-synthesis-overflow-wall`


### PR DESCRIPTION
## Summary

Fixes the **silent synthesis-overflow** at module scale. At 48 analytes (44 well-characterized entities) the assembled synthesis context exceeded the model's input-token window, the SDK call failed, and the `except` silently fell back to an **882 KB raw per-entity dump** — while the run reported `status=complete, errors=0`. The module-level narrative (the actual deliverable) was never produced and nothing surfaced it.

This PR redesigns *what synthesis sees* so the context stays bounded and the report is a genuine module narrative.

## Root cause (measured, not assumed)

Offline analysis of the failing run's artifact (no paid re-run needed):

- Context was **~882 K chars ≈ 230 K tokens**, exceeding sonnet-4's **~200 K-token input window**. Measured **3.80 chars/token** for this CURIE-dense content (below the 4.0 rule of thumb).
- Per-section contribution: **findings 58 % · disease 21 % · pathway 17 %** (96 % combined).
- The artifact's "37 findings" was a **~110× under-count** (real = 4,099) from the assessment harness's reducer-blind merge.

## What changed

- **`SynthesisConfig`** (new `pipeline_config` sub-model): token-derived caps. `max_context_chars=350_000` is an explicit **char proxy for the ~200 K-token window** (≈100 K-token target with headroom). Two **decoupled** thresholds — `module_mode_min_entities` (default 5) vs `min_members_for_recurrence` (default 2) — so they tune independently.
- **Module-aware assembly**: for queries with ≥ `module_mode_min_entities` distinct entities, `assemble_synthesis_context` **and** `fallback_report` emit cross-entity **disease/pathway recurrence aggregation** + a **per-member prioritization table** in place of the unbounded per-entity dumps. Single/small queries keep the per-entity shape unchanged.
- **Capped findings**: `format_findings_summary` ranks within tier by confidence and caps per tier with a "… and N more" elision (the dominant 58 % section).
- **Token backstop**: a tripwire WARNING (with an estimated token count) if assembly ever exceeds budget.
- **Prompt**: conditional module-level reasoning guidance for multi-entity input.
- **Assessment harness**: reducer-aware `coverage()` merge (concatenates the 16 `operator.add` list keys derived from `DiscoveryState`, overwrites last-write-wins keys) — fixes the ~110× under-count — plus **machine-checkable U7 acceptance** assertions.

## Verification

- **23 new unit tests** (`test_pipeline_config.py`, `test_synthesis_node.py`) — aggregation dedupe/threshold/cap, member-table joins/cap, module-vs-per-entity switch, the 2-entity boundary, the under-budget bound test, and the backstop.
- **U7 end-to-end on the exact 48-analyte input that broke** — all 5 machine checks **PASS**: no degraded fallback, **real 156.7 s synthesis** (vs the prior 3.5 s silent fallback), context **97.6 K chars ≈ 27.9 K tokens** (under budget), **0** raw `### CURIE` sections, **2,735** findings counted. The report is a coherent 24 KB module narrative ("TRAIL-driven inflammatory-metabolic stress axis"), not the 882 KB dump.
- **Zero regressions**: `test_langgraph_prototype.py` is 31 fail / 85 pass on both this branch and `origin/dev` (pre-existing stale-prototype failures).

## Notes for review

- The visible-fallback marker in `run()` (this PR's original "Unit 5") **overlapped with the perf-report feature merged to dev (PR #84)**, which shipped an equivalent — and slightly broader (also marks empty-output) — marker. On merge I **took dev's marker** and dropped the duplicate tests; `test_synthesis_fallback_marker.py` (from dev) is the canonical coverage. My commit `bfae979` is retained in history but its `run()` change is superseded by the merge.
- Cap **values** are deliberately conservative starting points (token-derived); re-validate before a full-217-analyte run.
- Out of scope (separate tasks): `pathway_enrichment` ~307 s latency (the next scaling wall), the `cold_start` cap-of-8 drop, the Semantic Scholar circuit-breaker.
- Plan: `docs/plans/2026-06-22-001-feat-module-aware-synthesis-context-plan.md` (diagnosis-backed, reviewed via document-review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
