### PR TITLE
fix: triage edge-count reliability at module scale

### DIFF
--- a/backend/assessment_data/brown_c1_pilot_e2e.py
+++ b/backend/assessment_data/brown_c1_pilot_e2e.py
@@ -151,6 +151,11 @@ def coverage(state):
         "resolved_entities_count": len(re_),
         "distinct_curies": distinct_curies,
         "curie_collisions": len(curies) - distinct_curies,
+        # plan 2026-06-23-001: how many entities had their triage edge-count fail and were rerouted
+        # to direct-KG (moderate) with a marker — should be ~0 once concurrency is bounded.
+        "triage_measurement_failures": sum(
+            1 for e in (state.get("errors", []) or []) if "edge-count failed" in str(e)
+        ),
         "triage_buckets": {
             "well_characterized": len(state.get("well_characterized_curies", []) or []),
             "moderate": len(state.get("moderate_curies", []) or []),
@@ -222,7 +227,31 @@ def acceptance_checks(merged, cov, synth_dur):
             total_findings > 37,
             f"{total_findings} findings (R6: ≫37 expected at module scale post-merge-fix)",
         ),
+        # plan 2026-06-23-001: guard against the triage-at-scale false-cold-start regression.
+        "triage_coldstart_not_mass_failure": (
+            cov["triage_buckets"]["cold_start"] < 45,
+            f"cold_start={cov['triage_buckets']['cold_start']} (want <45; pre-fix was 69 from "
+            f"edge-count query failures); triage_measurement_failures={cov.get('triage_measurement_failures', 0)}",
+        ),
+        "triage_hubs_well_characterized": _hubs_well_characterized(merged),
     }
+
+
+def _hubs_well_characterized(merged):
+    """Definitive post-fix check: well-characterized hub genes that are present in the module must
+    land in well_characterized, not cold_start. IL6=NCBIGene:3569, HMOX1=NCBIGene:3162 each carry
+    thousands of KG edges (verified live), so cold-starting them signals the triage-failure bug."""
+    hubs = {"IL6": "NCBIGene:3569", "HMOX1": "NCBIGene:3162"}
+    resolved = {
+        getattr(e, "curie", None) or (e.get("curie") if isinstance(e, dict) else None)
+        for e in (merged.get("resolved_entities") or [])
+    }
+    well = set(merged.get("well_characterized_curies", []) or [])
+    present = {sym: cur for sym, cur in hubs.items() if cur in resolved}
+    if not present:
+        return (True, "no curated hubs present in this run (check skipped)")
+    misbucketed = {sym: cur for sym, cur in present.items() if cur not in well}
+    return (not misbucketed, f"present={present}; not in well_characterized={misbucketed or 'none'}")
 
 
 async def main():

--- a/backend/src/kestrel_backend/graph/nodes/triage.py
+++ b/backend/src/kestrel_backend/graph/nodes/triage.py
@@ -28,6 +28,7 @@ import time
 from typing import Any
 
 from ...kestrel_client import call_kestrel_tool
+from ..pipeline_config import get_pipeline_config
 from ..state import DiscoveryState, NoveltyScore, EntityResolution
 from ..state_contracts import validate_state, TriageInput, TriageOutput
 
@@ -39,8 +40,13 @@ THRESHOLD_WELL_CHARACTERIZED = 200
 THRESHOLD_MODERATE = 20
 THRESHOLD_SPARSE = 1
 
+# Edge-count retry: a couple of attempts with a short backoff cover transient Kestrel hiccups
+# (server isError / timeout) without re-firing instantly into the same load (plan 2026-06-23-001).
+_MAX_ATTEMPTS = 3
+_RETRY_BACKOFF_S = 0.5
 
-async def count_edges_via_api(entity: EntityResolution) -> NoveltyScore | None:
+
+async def count_edges_via_api(entity: EntityResolution, sem: asyncio.Semaphore) -> NoveltyScore | None:
     """
     Tier 1: Count edges via direct Kestrel API call.
 
@@ -66,25 +72,30 @@ async def count_edges_via_api(entity: EntityResolution) -> NoveltyScore | None:
             classification="cold_start",
         )
 
-    max_attempts = 2  # one retry, for transient failures only
+    max_attempts = _MAX_ATTEMPTS
     for attempt in range(max_attempts):
         try:
-            # Call one_hop_query with preview mode - returns counts instead of full data
-            result = await call_kestrel_tool("one_hop_query", {
-                "start_node_ids": curie,
-                "mode": "preview",
-                "limit": 10000,  # High limit to get accurate count
-            })
+            # Call one_hop_query with preview mode - returns counts instead of full data.
+            # The semaphore bounds in-flight Kestrel calls; it wraps only the call (not the retry
+            # backoff) so a sleeping retry releases its slot to other entities.
+            async with sem:
+                result = await call_kestrel_tool("one_hop_query", {
+                    "start_node_ids": curie,
+                    "mode": "preview",
+                    "limit": 10000,  # High limit to get accurate count
+                })
 
             is_error = result.get("isError", False)
             content = result.get("content", [])
 
             if is_error:
-                # Transient server-side error — retry once, then give up.
+                # Transient server-side error — back off, retry, then give up.
                 logger.debug(
                     "Tier 1 triage '%s': API isError (attempt %d/%d)",
                     curie, attempt + 1, max_attempts,
                 )
+                if attempt < max_attempts - 1:
+                    await asyncio.sleep(_RETRY_BACKOFF_S)
                 continue
 
             if not content:
@@ -119,11 +130,13 @@ async def count_edges_via_api(entity: EntityResolution) -> NoveltyScore | None:
             )
 
         except Exception as e:
-            # Transient (timeout / connection) — retry once, then give up.
+            # Transient (timeout / connection) — back off, retry, then give up.
             logger.warning(
                 "Tier 1 triage '%s': Exception (attempt %d/%d) - %s",
                 curie, attempt + 1, max_attempts, str(e),
             )
+            if attempt < max_attempts - 1:
+                await asyncio.sleep(_RETRY_BACKOFF_S)
             continue
 
     # All attempts exhausted on transient failures → cold_start default (None).
@@ -187,9 +200,11 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
     tier1_start = time.time()
     logger.info("Tier 1 (API): Counting edges for %d entities", len(valid_entities))
 
-    # Run all API calls in parallel
+    # Run API calls concurrently but BOUNDED — an unbounded fan-out over hundreds of entities
+    # thundering-herds Kestrel into timeouts (plan 2026-06-23-001). Per-invocation semaphore.
+    sem = asyncio.Semaphore(get_pipeline_config().triage.kestrel_concurrency)
     tier1_results = await asyncio.gather(
-        *[count_edges_via_api(e) for e in valid_entities],
+        *[count_edges_via_api(e, sem) for e in valid_entities],
         return_exceptions=True,
     )
 
@@ -212,40 +227,40 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
         tier1_success, len(valid_entities), tier1_duration
     )
 
-    # ========== Tier 2 removed — failed counts default to cold_start (#61) ==========
-    # The Tier-2 LLM edge-counting fallback configured the broken stdio MCP, so with
-    # no working tools it could only guess a number. count_edges_via_api now retries
-    # once on *transient* failures (server isError / exception); any entity that still
-    # failed (None) is left unset here and backfilled to cold_start by the no-None
-    # block below — never an SDK-guessed count.
-    #
-    # NOTE (honest reroute): classify_by_edge_count has no 'unknown' bucket, so a count
-    # that fails even after the retry → edge_count=0 → cold_start, and route_after_triage
-    # sends it to the cold-start analogue branch instead of direct_kg. A genuinely
-    # well-characterized entity whose count failed is therefore downgraded. This is
-    # PRE-EXISTING behavior (the prior default was already cold_start); the migration
-    # does not worsen it, it just reaches the same default without a fabricated number.
+    # ========== Measurement failures reroute to direct-KG, never silent cold_start ==========
+    # count_edges_via_api retries transient failures (server isError / exception) with backoff;
+    # an entity whose count still cannot be MEASURED (None) is NOT a genuine 0-edge entity. A real
+    # 0 returns a NoveltyScore (edge_count=0 -> cold_start); only a measurement failure is None.
+    # Routing a measurement failure to cold_start would make a Kestrel overload read as "no KG
+    # presence" (the silent-degradation anti-pattern, cf. synthesis overflow, PR #85). Instead we
+    # route it to the direct-KG path via the `moderate` bucket and emit a visible marker.
     model_usages: list = []
     if tier1_failed_indices:
         for idx in tier1_failed_indices:
             entity = valid_entities[idx]
             logger.info(
                 "FALLBACK_EVENT node=triage entity=%s curie=%s "
-                "reason=tier1_edge_count_failed action=default_cold_start tier=2_dropped",
+                "reason=tier1_edge_count_failed action=reroute_direct_kg_moderate",
                 getattr(entity, "raw_name", str(entity)),
                 getattr(entity, "curie", "unknown"),
             )
 
-    # Ensure no None values
+    # Ensure no None values; a None means the count FAILED (not measured 0) -> moderate + marker.
     final_scores = []
     for i, s in enumerate(all_scores):
         if s is None:
+            ent = valid_entities[i]
+            cur = ent.curie or ent.raw_name
             final_scores.append(NoveltyScore(
-                curie=valid_entities[i].curie or valid_entities[i].raw_name,
-                raw_name=valid_entities[i].raw_name,
+                curie=cur,
+                raw_name=ent.raw_name,
                 edge_count=0,
-                classification="cold_start",
+                classification="moderate",
             ))
+            errors.append(
+                f"triage: edge-count failed for {cur} ({ent.raw_name}); "
+                "routed to direct-KG (moderate)"
+            )
         else:
             final_scores.append(s)
 

--- a/backend/src/kestrel_backend/graph/nodes/triage.py
+++ b/backend/src/kestrel_backend/graph/nodes/triage.py
@@ -51,14 +51,16 @@ async def count_edges_via_api(entity: EntityResolution, sem: asyncio.Semaphore) 
     Tier 1: Count edges via direct Kestrel API call.
 
     Uses one_hop_query with mode="preview" which returns results_count (edge count).
-    Returns None if the count fails (the caller then defaults the entity to
-    cold_start).
+    Runs under the caller's concurrency semaphore (bounds in-flight Kestrel calls). Returns a
+    NoveltyScore for a measured count (including a genuine ``results_count == 0`` → cold_start),
+    or **None when the count could not be MEASURED** (server ``isError`` / empty content /
+    unparseable JSON / exhausted retries). The caller treats None as a measurement failure and
+    routes the entity to the direct-KG path (``moderate``) with a visible ``errors`` marker —
+    NOT silently to cold_start (plan 2026-06-23-001).
 
-    A single in-place retry covers genuinely *time-varying* failures (server
-    ``isError`` / exception) so a transient hiccup does not silently downgrade a
-    well-characterized entity to cold_start (#61). *Deterministic* per-CURIE
-    failures (empty content, unparseable JSON) are NOT retried — an identical-args
-    retry would re-fail — and fall to the cold_start default by returning None.
+    Transient failures (server ``isError`` / exception) are retried with backoff up to
+    ``_MAX_ATTEMPTS``. *Deterministic* per-CURIE failures (empty content, unparseable JSON) are
+    NOT retried — an identical-args retry would re-fail — and return None immediately.
     """
     curie = entity.curie
     raw_name = entity.raw_name
@@ -160,18 +162,19 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
     """
     Triage resolved entities by KG connectivity using Tier-1 HTTP only (#61).
 
-    Tier 1 (API): Direct one_hop_query with mode="preview" for all entities,
-      with a single in-place retry for transient isError/exception failures.
-      Deterministic failures (empty content, bad JSON) are not retried.
-      Entities whose count still fails after the retry default to cold_start
-      (the broken stdio-MCP Tier-2 LLM fallback was removed).
+    Tier 1 (API): bounded-concurrency one_hop_query (mode="preview") for all entities, retried
+      with backoff on transient isError/exception. A genuine 0-edge count → cold_start; an entity
+      whose count cannot be MEASURED (None) is routed to ``moderate`` (the direct-KG path) with a
+      visible ``errors`` marker, never silently to cold_start (plan 2026-06-23-001). The broken
+      stdio-MCP Tier-2 LLM fallback was removed (#61).
 
     Returns:
         novelty_scores: List of NoveltyScore objects
         well_characterized_curies: CURIEs with >=200 edges
-        moderate_curies: CURIEs with 20-199 edges
+        moderate_curies: CURIEs with 20-199 edges (incl. measurement-failed entities)
         sparse_curies: CURIEs with 1-19 edges
-        cold_start_curies: CURIEs with 0 edges
+        cold_start_curies: CURIEs with 0 edges (genuine) + failed-resolution names
+        errors: degraded markers for entities whose edge count could not be measured
     """
     logger.info("Starting triage")
     start = time.time()

--- a/backend/src/kestrel_backend/graph/pipeline_config.py
+++ b/backend/src/kestrel_backend/graph/pipeline_config.py
@@ -411,7 +411,7 @@ def get_semaphore(node_name: str) -> asyncio.Semaphore:
     semaphore_map = {
         "direct_kg": config.direct_kg.sdk_semaphore,
         "entity_resolution": config.entity_resolution.sdk_semaphore,
-        "triage": config.triage.sdk_semaphore,
+        "triage": config.triage.kestrel_concurrency,
         "cold_start": config.cold_start.sdk_semaphore,
     }
     value = semaphore_map.get(node_name)

--- a/backend/src/kestrel_backend/graph/pipeline_config.py
+++ b/backend/src/kestrel_backend/graph/pipeline_config.py
@@ -163,14 +163,21 @@ class EntityResolutionConfig(BaseModel):
 class TriageConfig(BaseModel):
     """Configuration for the triage node."""
 
+    kestrel_concurrency: int = Field(
+        default=8,
+        ge=1,
+        description="Max concurrent Kestrel one_hop_query edge-count calls during triage. Bounds "
+        "the fan-out so a module-scale run (~hundreds of entities) does not thundering-herd Kestrel "
+        "into timeouts that would otherwise default well-characterized entities to cold_start.",
+    )
+    # Vestigial (pre-#61 SDK Tier-2 path, removed): not applied to the HTTP edge-count gather.
     sdk_semaphore: int = Field(
         default=1,
-        description="Serialized SDK calls (semaphore=1) to prevent concurrent "
-        "CLI spawn conflicts during triage edge counting.",
+        description="DEPRECATED/unused: legacy serialized-SDK knob from the removed Tier-2 path.",
     )
     batch_size: int = Field(
         default=6,
-        description="Number of entities to process in parallel per batch.",
+        description="DEPRECATED/unused: legacy batch knob from the removed Tier-2 path.",
     )
 
 

--- a/backend/tests/test_langgraph_prototype.py
+++ b/backend/tests/test_langgraph_prototype.py
@@ -408,18 +408,20 @@ class TestTriageNode:
             raw_name="glucose", curie="CHEBI:17234", resolved_name="D-glucose",
             category="biolink:ChemicalEntity", confidence=0.95, method="exact",
         )
-        with patch.object(triage, "call_kestrel_tool", side_effect=flaky_call):
-            score = await triage.count_edges_via_api(entity)
+        with patch.object(triage, "call_kestrel_tool", side_effect=flaky_call), \
+             patch.object(triage, "_RETRY_BACKOFF_S", 0):
+            score = await triage.count_edges_via_api(entity, asyncio.Semaphore(4))
 
-        assert calls["n"] == 2  # retried once
+        assert calls["n"] == 2  # recovered on the second attempt
         assert score is not None
         assert score.edge_count == 300
         assert score.classification == "well_characterized"
 
     @pytest.mark.asyncio
-    async def test_tier1_persistent_failure_routes_to_cold_start(self):
-        """#61: a count that fails even after the retry → None → the entity
-        defaults to cold_start in run(), never an SDK-guessed number."""
+    async def test_tier1_persistent_failure_routes_to_moderate_with_marker(self):
+        """plan 2026-06-23-001: a count that fails even after retries → None → the entity is a
+        MEASUREMENT failure, not a genuine 0-edge. run() routes it to the direct-KG path (moderate)
+        with a visible marker, never silently to cold_start."""
         async def always_error(tool_name, params):
             return {"isError": True, "content": []}
 
@@ -427,16 +429,18 @@ class TestTriageNode:
             raw_name="glucose", curie="CHEBI:17234", resolved_name="D-glucose",
             category="biolink:ChemicalEntity", confidence=0.95, method="exact",
         )
-        with patch.object(triage, "call_kestrel_tool", side_effect=always_error):
-            score = await triage.count_edges_via_api(entity)
-            assert score is None  # both attempts failed
+        with patch.object(triage, "call_kestrel_tool", side_effect=always_error), \
+             patch.object(triage, "_RETRY_BACKOFF_S", 0):
+            score = await triage.count_edges_via_api(entity, asyncio.Semaphore(4))
+            assert score is None  # all attempts failed to measure
 
             state: DiscoveryState = {"resolved_entities": [entity]}
             result = await triage.run(state)
 
-        # Failed count defaults the entity to cold_start (documented reroute)
-        assert "CHEBI:17234" in result["cold_start_curies"]
-        assert "CHEBI:17234" not in result["well_characterized_curies"]
+        # Measurement failure → direct-KG (moderate) + marker, NOT silent cold_start.
+        assert "CHEBI:17234" in result["moderate_curies"]
+        assert "CHEBI:17234" not in result["cold_start_curies"]
+        assert any("edge-count failed" in str(e) for e in result["errors"])
 
 
 # =============================================================================

--- a/backend/tests/test_triage.py
+++ b/backend/tests/test_triage.py
@@ -25,7 +25,7 @@ def _entity(curie, name=None, method="biomapper"):
 def _use_cfg(monkeypatch, **triage_kwargs):
     cfg = PipelineConfig(triage=TriageConfig(**triage_kwargs))
     monkeypatch.setattr(triage, "get_pipeline_config", lambda: cfg)
-    monkeypatch.setattr(triage, "_RETRY_BACKOFF_S", 0.0, raising=False)  # no real sleeps in tests
+    monkeypatch.setattr(triage, "_RETRY_BACKOFF_S", 0.0)  # no real sleeps in tests (fail-fast if renamed)
     return cfg
 
 

--- a/backend/tests/test_triage.py
+++ b/backend/tests/test_triage.py
@@ -1,0 +1,145 @@
+"""Triage reliability at module scale (plan 2026-06-23-001).
+
+Core invariant: a genuine 0-edge count → cold_start (biology); a measurement *failure*
+(isError / empty / unparseable / exhausted retries) → moderate (direct-KG path) + a visible
+marker, never silent cold_start. Edge-count concurrency is bounded by config.
+"""
+
+import asyncio
+import json
+
+import pytest
+
+from kestrel_backend.graph.nodes import triage
+from kestrel_backend.graph.pipeline_config import PipelineConfig, TriageConfig
+from kestrel_backend.graph.state import EntityResolution
+
+
+def _entity(curie, name=None, method="biomapper"):
+    return EntityResolution(
+        raw_name=name or curie, curie=curie, resolved_name=name or curie,
+        category="biolink:Gene", confidence=0.9, method=method,
+    )
+
+
+def _use_cfg(monkeypatch, **triage_kwargs):
+    cfg = PipelineConfig(triage=TriageConfig(**triage_kwargs))
+    monkeypatch.setattr(triage, "get_pipeline_config", lambda: cfg)
+    monkeypatch.setattr(triage, "_RETRY_BACKOFF_S", 0.0, raising=False)  # no real sleeps in tests
+    return cfg
+
+
+def _ok(n):
+    return {"isError": False, "content": [{"text": json.dumps({"results_count": n})}]}
+
+
+def _err():
+    return {"isError": True, "content": []}
+
+
+def _empty():
+    return {"isError": False, "content": []}
+
+
+class FakeKestrel:
+    """Async stand-in for call_kestrel_tool. `script` maps curie -> list of response-builders
+    consumed per attempt; `default` is used when a curie has no script. Tracks max concurrency."""
+
+    def __init__(self, script=None, default=None):
+        self.script = {k: list(v) for k, v in (script or {}).items()}
+        self.default = default or (lambda: _ok(500))
+        self.concurrent = 0
+        self.max_concurrent = 0
+
+    async def __call__(self, tool, args):
+        self.concurrent += 1
+        self.max_concurrent = max(self.max_concurrent, self.concurrent)
+        try:
+            await asyncio.sleep(0)  # yield so concurrent calls actually overlap
+            curie = args["start_node_ids"]
+            seq = self.script.get(curie)
+            builder = seq.pop(0) if seq else self.default
+            return builder()
+        finally:
+            self.concurrent -= 1
+
+
+async def _run(monkeypatch, entities, fake):
+    monkeypatch.setattr(triage, "call_kestrel_tool", fake)
+    return await triage.run({"resolved_entities": entities})
+
+
+# --- classification happy paths -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("count,bucket", [(500, "well_characterized_curies"), (50, "moderate_curies"),
+                                          (5, "sparse_curies"), (0, "cold_start_curies")])
+async def test_classification_by_count(monkeypatch, count, bucket):
+    _use_cfg(monkeypatch, kestrel_concurrency=4)
+    fake = FakeKestrel(default=lambda: _ok(count))
+    out = await _run(monkeypatch, [_entity("NCBIGene:1")], fake)
+    assert out[bucket] == ["NCBIGene:1"]
+
+
+@pytest.mark.asyncio
+async def test_genuine_zero_is_cold_start(monkeypatch):
+    """A successful query returning results_count=0 is real biology → cold_start, no marker."""
+    _use_cfg(monkeypatch, kestrel_concurrency=4)
+    out = await _run(monkeypatch, [_entity("CHEBI:1")], FakeKestrel(default=lambda: _ok(0)))
+    assert out["cold_start_curies"] == ["CHEBI:1"]
+    assert not [e for e in out["errors"] if "edge-count" in str(e)]
+
+
+# --- the core fix: measurement failure must NOT masquerade as cold_start ---------------
+
+
+@pytest.mark.asyncio
+async def test_measurement_failure_routes_to_moderate_with_marker(monkeypatch):
+    _use_cfg(monkeypatch, kestrel_concurrency=4)
+    out = await _run(monkeypatch, [_entity("NCBIGene:3569", "IL6")], FakeKestrel(default=_err))
+    assert out["moderate_curies"] == ["NCBIGene:3569"]      # routed to direct-KG path
+    assert "NCBIGene:3569" not in out["cold_start_curies"]  # NOT silently cold-started
+    score = next(s for s in out["novelty_scores"] if s.curie == "NCBIGene:3569")
+    assert score.classification == "moderate"
+    marker = [e for e in out["errors"] if "edge-count" in str(e) and "NCBIGene:3569" in str(e)]
+    assert marker, "a visible degraded marker must be emitted"
+
+
+@pytest.mark.asyncio
+async def test_empty_content_is_measurement_failure(monkeypatch):
+    _use_cfg(monkeypatch, kestrel_concurrency=4)
+    out = await _run(monkeypatch, [_entity("NCBIGene:7422", "VEGFA")], FakeKestrel(default=_empty))
+    assert "NCBIGene:7422" in out["moderate_curies"]
+    assert "NCBIGene:7422" not in out["cold_start_curies"]
+
+
+@pytest.mark.asyncio
+async def test_retry_recovers_transient_failure(monkeypatch):
+    """isError on attempt 1, success on attempt 2 → classified by the real count, no marker."""
+    _use_cfg(monkeypatch, kestrel_concurrency=4)
+    fake = FakeKestrel(script={"NCBIGene:3569": [_err, lambda: _ok(9911)]})
+    out = await _run(monkeypatch, [_entity("NCBIGene:3569", "IL6")], fake)
+    assert out["well_characterized_curies"] == ["NCBIGene:3569"]
+    assert not [e for e in out["errors"] if "edge-count" in str(e)]
+
+
+@pytest.mark.asyncio
+async def test_failed_resolution_still_cold_start(monkeypatch):
+    """An entity that failed resolution (no usable curie) is genuinely cold_start — unchanged."""
+    _use_cfg(monkeypatch, kestrel_concurrency=4)
+    out = await _run(monkeypatch, [_entity("x", "mystery", method="failed")], FakeKestrel())
+    assert "mystery" in out["cold_start_curies"]
+
+
+# --- concurrency bound (R1) -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_edge_count_concurrency_is_bounded(monkeypatch):
+    _use_cfg(monkeypatch, kestrel_concurrency=3)
+    fake = FakeKestrel(default=lambda: _ok(500))
+    entities = [_entity(f"NCBIGene:{i}") for i in range(20)]
+    out = await _run(monkeypatch, entities, fake)
+    assert fake.max_concurrent <= 3, f"expected <=3 concurrent, saw {fake.max_concurrent}"
+    assert len(out["well_characterized_curies"]) == 20  # all still counted


### PR DESCRIPTION
## Summary

Fixes the triage node misclassifying well-characterized entities as **cold-start at module scale**. Triage fanned out an **unbounded** `asyncio.gather` of one Kestrel `one_hop_query` per entity; at ~194 entities (the full Brown module, unlocked by #88) that burst overwhelmed Kestrel, the edge-count queries failed, and a failed count **silently defaulted the entity to cold_start**. Verified live: IL6 (`NCBIGene:3569`, 9,911 edges), HMOX1, LEP, VEGFA, MMP9 and ~60 other hubs were flagged "0-edge cold-start" despite carrying thousands of real edges — they resolved correctly; triage was the sole failure point. (Not a biomapper2 conflation issue.)

## Changes
- **Bound concurrency** (`triage.py` + `TriageConfig.kestrel_concurrency`, default 8): per-invocation semaphore acquired around each individual Kestrel call (so a backoff sleep doesn't hold the slot). `entity_resolution`'s `http_concurrency` pattern.
- **Retry with backoff** (`_MAX_ATTEMPTS=3`, `_RETRY_BACKOFF_S`) for transient `isError`/exception.
- **Failed-vs-zero semantics (the core fix):** a genuine `results_count==0` → `cold_start` (biology); a *measurement failure* (`isError`/empty/unparseable/exhausted retries → `None`) → routed to the direct-KG path (`moderate`) with a visible `state['errors']` marker, never silently to cold_start. Same "fail loud" principle as PR #85.
- **Machine-checkable acceptance gate** (`brown_c1_pilot_e2e.py`): `triage_coldstart_not_mass_failure` (cold_start < 45) + `triage_hubs_well_characterized` (IL6/HMOX1 must land well_characterized) + a `triage_measurement_failures` counter. Verified to fail pre-fix, pass post-fix.

## Validation (full-203 re-run, real LLM, exit 0, all U7 PASS incl. the 2 new gates)
| Triage bucket | Pre-fix | Post-fix |
|---|---|---|
| well_characterized | 28 | **81** |
| moderate | 38 | 41 |
| sparse | 58 | 61 |
| **cold_start** | **70** | **11** |
| measurement failures | ~59 (silent) | **0** |

- IL6 + HMOX1 now `well_characterized`; `triage_measurement_failures=0` (it was purely the thundering herd, **not** a QPS limit — no rate-limiter needed).
- Findings rose 1,958 → 3,148 (more entities correctly analyzed on real `[KG Evidence]`).
- Cost trade: total run 1,176s → 1,542s, `pathway_enrichment` ~doubled to 707s because ~122 entities (was 66) are now genuinely analyzed instead of dumped to cold-start — well under the ceiling; `pathway_enrichment` is the next latency target.

## Testing
- New `tests/test_triage.py` (10): classification, genuine-0→cold_start, **measurement-failure→moderate+marker**, retry-recovers, concurrency-bound, failed-resolution. Updated 2 prototype triage tests for the new signature/behavior. (Pre-existing stale-name `test_full_pipeline_with_triage` is unrelated.)

## Notes
- Plan: `docs/plans/2026-06-23-001-fix-triage-concurrency-scale-plan.md`. Builds on #88 (which surfaced this) + #85 (fail-loud). No schema/deploy changes. Greptile won't auto-review dev PRs here — trigger manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
