### PR TITLE
feat(byok): per-session bring-your-own-key (kraken pilot)

### DIFF
--- a/.superpowers/sdd/task-8-report.md
+++ b/.superpowers/sdd/task-8-report.md
@@ -1,0 +1,89 @@
+# Task 8 Implementation Report — Frontend BYOK Key Entry, WS Wiring, Source Badge
+
+## Files Created
+
+### `client/src/hooks/useApiKey.ts` (new)
+Exports `useApiKey()` returning `{ key, setKey, clearKey, validate }`. Key is held exclusively in React state — no `localStorage`, `sessionStorage`, or cookies. `validate(key)` POSTs to `/api/validate-key` and returns a typed `ValidateResult`. A page reload intentionally clears the key (per-session design).
+
+### `client/src/components/ApiKeyGate.tsx` (new)
+A context-sensitive gate component that:
+- Renders **nothing** when `needsKey` is false and no key is set (server hasn't asked yet).
+- Renders a **blocking form** (amber card with password input + Validate button) when `needsKey` is true and `key === null`. Validates on button click or Enter key. Shows an inline error on failure. Sets the key on success.
+- Renders a **"clear key" affordance only** (muted text + X button) when a key is already set, regardless of `needsKey`.
+
+Uses `Button`, `Input`, and `Card` from `components/ui/` to match existing styling conventions. Uses lucide-react icons consistent with the codebase.
+
+## Files Modified
+
+### `client/src/types/messages.ts`
+- Added `KeySource = "byok" | "server"` type.
+- Added `SetKeyRequest` type for the outgoing `{"type":"set_key","key":...}` frame.
+- Added `{ type: "key_source"; source: KeySource }` to the `IncomingMessage` union.
+- The existing `{ type: "error"; ...; code?: string }` variant already covers `NEEDS_KEY` — no change needed there.
+
+### `client/src/hooks/useWebSocket.ts`
+- Accepts optional `{ apiKey?: string | null }` options parameter (defaults to `null`).
+- Stores `apiKey` in a `useRef` so `onopen` always reads the current value without a stale closure.
+- Added `sendSetKey(ws, key)` helper.
+- `onopen`: sends `{"type":"set_key","key":...}` **before** any other message.
+- `handleIncomingMessage` switch: handles `"key_source"` (updates `keySource` state; clears `needsKey` optimistically when `source === "byok"`). Handles `"error"` with `code === "NEEDS_KEY"` (sets `needsKey = true`, surfaces the error in chat, stops the responding spinner).
+- Added a `useEffect` watching `apiKey` prop: when it changes mid-session, sends an updated `set_key` frame and clears `needsKey` optimistically if a key was provided.
+- Returns `needsKey: boolean` and `keySource: KeySource | null` to consumers.
+
+### `client/src/pages/chat.tsx`
+- Adds `useApiKey()` at the top of `ChatPage`.
+- Passes `{ apiKey: apiKey.key }` to `useWebSocket`.
+- Destructures `needsKey` and `keySource` from the hook return.
+- Computes `keyGateBlocking = needsKey && apiKey.key === null`.
+- Renders `<ApiKeyGate apiKey={apiKey} needsKey={needsKey} />` above `ChatInput` (hidden behind `!hasAuthError` to avoid conflicting UI states).
+- Renders a `<Badge>` ("Using your key" / "Using server key") in the mode toggle row whenever `keySource !== null`.
+- Extends `ChatInput disabled` prop to include `keyGateBlocking`.
+
+## TypeScript Typecheck
+
+Command: `npm run check` (runs `tsc` from repo root)
+
+**Baseline (before changes):**
+```
+client/src/lib/analyteParse.ts(11,18): error TS2307: Cannot find module 'papaparse' or its corresponding type declarations.
+```
+One pre-existing error — missing `@types/papaparse`, unrelated to this task.
+
+**After changes:**
+```
+client/src/lib/analyteParse.ts(11,18): error TS2307: Cannot find module 'papaparse' or its corresponding type declarations.
+```
+Same single pre-existing error. Zero new errors introduced by this task.
+
+## Self-Review
+
+- Key is never written to `localStorage`, `sessionStorage`, cookies, or any URL parameter. Verified by inspection — only `useState`.
+- `set_key` is sent in `onopen` before the client can call `sendMessage` (the browser cannot send user input before the socket fires `onopen`).
+- The `needsKey` flag is set by `code === "NEEDS_KEY"`, exactly matching the ground-truth WS protocol in the brief (not a `needs_key` type field).
+- `key_source` is handled in the `switch` — TypeScript's exhaustive narrowing covers the new union member.
+- `ApiKeyGate` is suppressed behind `!hasAuthError` so a Clerk auth failure doesn't create conflicting UI states.
+- The `keyGateBlocking` path blocks send but does NOT prevent the user from reading the existing chat — only the composer is disabled.
+
+## Live Browser Verification (pending — manual step)
+
+The following scenario should be verified in a running browser session:
+
+```
+1. Start backend with BYOK feature enabled and no server key configured for the test user.
+2. Open the chat in the browser as a non-phenome (untrusted) user.
+3. Type a message and press Send.
+   Expected: server returns NEEDS_KEY error frame; chat shows an error bubble;
+             amber ApiKeyGate form appears; composer textarea is disabled.
+4. Paste a valid Anthropic API key into the gate form and click "Validate".
+   Expected: form disappears; "clear key" affordance appears;
+             composer is re-enabled; badge not yet visible.
+5. Send a message.
+   Expected: server sends key_source:"byok" before the response stream;
+             badge reads "Using your key" in the mode toggle row;
+             the response streams normally.
+6. Click "Clear key".
+   Expected: key is cleared; "clear key" affordance disappears; gate re-shows
+             only on next NEEDS_KEY (badge clears on next turn).
+7. Reload the page.
+   Expected: key is gone (no persistence); no gate shown until another send attempt.
+```

--- a/backend/src/kestrel_backend/agent.py
+++ b/backend/src/kestrel_backend/agent.py
@@ -27,6 +27,7 @@ from claude_agent_sdk import (
 from claude_agent_sdk.types import McpStdioServerConfig
 from .config import get_settings
 from .bash_sandbox import bash_security_hook
+from .byok import current_api_key
 
 
 # Langfuse client (lazy initialized)
@@ -355,6 +356,33 @@ class AgentEvent:
     data: dict[str, Any]
 
 
+def build_agent_options() -> ClaudeAgentOptions:
+    """Build ClaudeAgentOptions for the classic single-agent path.
+
+    Extracts all option construction into one place so the turn loop
+    and tests can call it without duplicating the kwarg logic.
+    Injects the per-request BYOK key (if set on the contextvar) into
+    the env dict, which the SDK merges over the inherited process env.
+    """
+    kestrel_config = _get_kestrel_mcp_config()
+    options_kwargs = {
+        "allowed_tools": list(ALLOWED_TOOLS),
+        "system_prompt": SYSTEM_PROMPT,
+        "mcp_servers": {"kestrel": kestrel_config},
+        "hooks": {"PreToolUse": [HookMatcher(matcher="Bash", hooks=[bash_security_hook])]},
+        "max_buffer_size": 10 * 1024 * 1024,
+    }
+    settings = get_settings()
+    if settings.model:
+        options_kwargs["model"] = settings.model
+    key = current_api_key.get()
+    if key:
+        # env is MERGED over the inherited process environment by the SDK, so we
+        # only override the credential and leave PATH/etc. intact.
+        options_kwargs["env"] = {"ANTHROPIC_API_KEY": key}
+    return ClaudeAgentOptions(**options_kwargs)
+
+
 async def run_agent_turn(user_message: str, session_id: str | None = None) -> AsyncIterator[AgentEvent]:
     """
     Run a single agent turn and yield events for streaming to the client.
@@ -386,29 +414,8 @@ async def run_agent_turn(user_message: str, session_id: str | None = None) -> As
         if session_id:
             trace.update_trace(session_id=session_id)
 
-    # Configure Kestrel MCP server via stdio proxy
-    # The proxy handles Kestrel's non-standard MCP-over-HTTP protocol
-    kestrel_config = _get_kestrel_mcp_config()
-
-    # Build options with Kestrel MCP server and Bash security hook
-    options_kwargs = {
-        "allowed_tools": list(ALLOWED_TOOLS),
-        "system_prompt": SYSTEM_PROMPT,
-        "mcp_servers": {
-            "kestrel": kestrel_config,
-        },
-        # Security: Validate all Bash commands before execution
-        "hooks": {
-            "PreToolUse": [
-                HookMatcher(matcher="Bash", hooks=[bash_security_hook])
-            ]
-        },
-        "max_buffer_size": 10 * 1024 * 1024,  # 10MB buffer for large KG responses
-    }
-    if settings.model:
-        options_kwargs["model"] = settings.model
-
-    options = ClaudeAgentOptions(**options_kwargs)
+    # Build options for Kestrel MCP server, Bash security hook, and BYOK key injection
+    options = build_agent_options()
 
     # Track tool_use_id -> tool_name mapping for matching results
     tool_id_to_name: dict[str, str] = {}

--- a/backend/src/kestrel_backend/byok.py
+++ b/backend/src/kestrel_backend/byok.py
@@ -1,0 +1,30 @@
+"""Per-session BYOK key resolution. No persistence, no os.environ mutation."""
+from contextvars import ContextVar
+from .config import get_settings
+
+# The resolved effective key for the active request (byok or server). Option
+# builders in agent.py and sdk_utils.py read this; nodes never do precedence logic.
+current_api_key: ContextVar[str | None] = ContextVar("current_api_key", default=None)
+
+
+class NeedsKeyError(Exception):
+    """Untrusted user made an LLM request without providing a BYOK key."""
+
+
+def is_trusted_email(verified_email: str | None) -> bool:
+    if not verified_email or "@" not in verified_email:
+        return False
+    domain = verified_email.rsplit("@", 1)[-1].lower()
+    trusted = {d.lower() for d in get_settings().byok_trusted_email_domains}
+    return domain in trusted
+
+
+def resolve_effective_key(byok_key: str | None, verified_email: str | None) -> tuple[str, str]:
+    if byok_key:
+        return byok_key, "byok"
+    if is_trusted_email(verified_email):
+        server_key = get_settings().server_anthropic_api_key
+        if not server_key:
+            raise NeedsKeyError("Trusted user but no server key configured.")
+        return server_key, "server"
+    raise NeedsKeyError("No API key provided and user is not trusted.")

--- a/backend/src/kestrel_backend/clerk_identity.py
+++ b/backend/src/kestrel_backend/clerk_identity.py
@@ -1,10 +1,17 @@
 """Resolve a user's verified primary email via the Clerk Backend API."""
 import logging
+import time
 import httpx
 from .config import get_settings
 
 logger = logging.getLogger(__name__)
-_email_cache: dict[str, str | None] = {}  # sub -> verified email or None
+
+# sub -> (verified email or None, monotonic expiry). Bounded TTL so that when a
+# user's Clerk email/verification/domain changes, their server-key eligibility is
+# re-checked within TTL seconds instead of being frozen for the process lifetime.
+# Without this, revoking a trusted email in Clerk would never take effect here.
+_CACHE_TTL_SECONDS = 600.0
+_email_cache: dict[str, tuple[str | None, float]] = {}
 
 
 async def _clerk_get(url: str, headers: dict) -> httpx.Response:
@@ -12,17 +19,22 @@ async def _clerk_get(url: str, headers: dict) -> httpx.Response:
         return await client.get(url, headers=headers)
 
 
+def _cache_put(sub: str, email: str | None) -> str | None:
+    _email_cache[sub] = (email, time.monotonic() + _CACHE_TTL_SECONDS)
+    return email
+
+
 async def get_verified_email(user_info: dict) -> str | None:
     sub = user_info.get("sub")
     if not sub:
         return None
-    if sub in _email_cache:
-        return _email_cache[sub]
+    cached = _email_cache.get(sub)
+    if cached is not None and cached[1] > time.monotonic():
+        return cached[0]
 
     secret = get_settings().clerk_secret_key
     if not secret:
-        _email_cache[sub] = None
-        return None
+        return _cache_put(sub, None)
 
     try:
         resp = await _clerk_get(
@@ -42,5 +54,4 @@ async def get_verified_email(user_info: dict) -> str | None:
            addr.get("verification", {}).get("status") == "verified":
             email = addr.get("email_address")
             break
-    _email_cache[sub] = email
-    return email
+    return _cache_put(sub, email)

--- a/backend/src/kestrel_backend/clerk_identity.py
+++ b/backend/src/kestrel_backend/clerk_identity.py
@@ -1,0 +1,46 @@
+"""Resolve a user's verified primary email via the Clerk Backend API."""
+import logging
+import httpx
+from .config import get_settings
+
+logger = logging.getLogger(__name__)
+_email_cache: dict[str, str | None] = {}  # sub -> verified email or None
+
+
+async def _clerk_get(url: str, headers: dict) -> httpx.Response:
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        return await client.get(url, headers=headers)
+
+
+async def get_verified_email(user_info: dict) -> str | None:
+    sub = user_info.get("sub")
+    if not sub:
+        return None
+    if sub in _email_cache:
+        return _email_cache[sub]
+
+    secret = get_settings().clerk_secret_key
+    if not secret:
+        _email_cache[sub] = None
+        return None
+
+    try:
+        resp = await _clerk_get(
+            f"https://api.clerk.com/v1/users/{sub}",
+            {"Authorization": f"Bearer {secret}"},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception:  # never let identity lookup break a request
+        logger.warning("Clerk user lookup failed for sub=%s", sub)
+        return None  # not cached: allow retry on a transient failure
+
+    primary_id = data.get("primary_email_address_id")
+    email = None
+    for addr in data.get("email_addresses", []):
+        if addr.get("id") == primary_id and \
+           addr.get("verification", {}).get("status") == "verified":
+            email = addr.get("email_address")
+            break
+    _email_cache[sub] = email
+    return email

--- a/backend/src/kestrel_backend/config.py
+++ b/backend/src/kestrel_backend/config.py
@@ -49,6 +49,11 @@ class Settings(BaseModel):
     log_format: str = "text"  # "json" or "text"
     log_module_levels: dict[str, str] = {}  # Module-specific log levels
 
+    # BYOK: domains whose verified users ride the SERVER key; everyone else must BYOK.
+    byok_trusted_email_domains: list[str] = []
+    # The Anthropic key used only for the trusted server-key fallback.
+    server_anthropic_api_key: str | None = None
+
     # Analyte file-upload ingest guards (R19). These are stability guardrails independent of the
     # client UI, enforced at every entry point (WS handler + runner/intake boundary) so LangGraph
     # Studio and the assessment harnesses cannot bypass them.

--- a/backend/src/kestrel_backend/graph/sdk_utils.py
+++ b/backend/src/kestrel_backend/graph/sdk_utils.py
@@ -227,6 +227,16 @@ def create_agent_options(
     return ClaudeAgentOptions(**kwargs)
 
 
+def _apply_byok_env(options):
+    """Inject the per-request BYOK key into options.env at the SDK boundary.
+    No-op when no key is set (classic path / internal callers keep ambient env)."""
+    key = current_api_key.get()
+    if key and options is not None:
+        existing = getattr(options, "env", None) or {}
+        options.env = {**existing, "ANTHROPIC_API_KEY": key}
+    return options
+
+
 def chunk(items: list, size: int) -> list[list]:
     """Split a list into chunks of specified size.
 
@@ -302,6 +312,7 @@ async def query_with_usage(
     )
 
     with generation_cm as generation:
+        options = _apply_byok_env(options)
         async for event in query(prompt=prompt, options=options):
             # Capture the available-tool list from the SDK init event (best-effort;
             # stays None if this SDK version/stream doesn't expose it). Issue #44.

--- a/backend/src/kestrel_backend/graph/sdk_utils.py
+++ b/backend/src/kestrel_backend/graph/sdk_utils.py
@@ -14,6 +14,8 @@ from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import Any
 
+from ..byok import current_api_key
+
 # Optional pipeline-wide model override. When KRAKEN_PIPELINE_MODEL is set (e.g.
 # "claude-opus-4-8"), every SDK-backed node runs on that model AND the usage label /
 # cost estimate attribute to it. Unset -> SDK default model + the Sonnet label below.
@@ -217,6 +219,10 @@ def create_agent_options(
     effective_model = model or _PIPELINE_MODEL
     if effective_model:
         kwargs["model"] = effective_model
+
+    key = current_api_key.get()
+    if key:
+        kwargs["env"] = {"ANTHROPIC_API_KEY": key}
 
     return ClaudeAgentOptions(**kwargs)
 

--- a/backend/src/kestrel_backend/local_tools.py
+++ b/backend/src/kestrel_backend/local_tools.py
@@ -6,14 +6,23 @@ They provide safe data processing capabilities without code execution.
 
 import anthropic
 from claude_agent_sdk import tool, create_sdk_mcp_server
+from .byok import current_api_key
 
 
-# Anthropic client for the analyze tool
+# Anthropic client for the analyze tool (None = ambient-env key, i.e. no BYOK active)
 _anthropic_client = None
 
 
 def _get_anthropic_client():
-    """Get or create the Anthropic client."""
+    """Get or create the Anthropic client.
+
+    If a per-request BYOK key is set on the contextvar, creates a fresh client
+    scoped to that key. Otherwise returns the cached ambient-env client so that
+    trusted / server-key callers don't allocate a new client on every call.
+    """
+    key = current_api_key.get()
+    if key:
+        return anthropic.Anthropic(api_key=key)
     global _anthropic_client
     if _anthropic_client is None:
         _anthropic_client = anthropic.Anthropic()

--- a/backend/src/kestrel_backend/logging_config.py
+++ b/backend/src/kestrel_backend/logging_config.py
@@ -1,12 +1,30 @@
 """Structured JSON logging configuration with correlation ID support."""
 
 import logging
+import re
 import sys
 from contextvars import ContextVar
 from typing import Optional
 from uuid import uuid4
 
 from pythonjsonlogger.json import JsonFormatter
+
+
+_KEY_RE = re.compile(r"sk-(?:ant-)?[A-Za-z0-9_-]{16,}")
+
+
+class ApiKeyRedactionFilter(logging.Filter):
+    """Mask Anthropic and generic sk-... API keys in log records."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if isinstance(record.msg, str):
+            record.msg = _KEY_RE.sub("sk-***REDACTED***", record.msg)
+        if record.args:
+            record.args = tuple(
+                _KEY_RE.sub("sk-***REDACTED***", a) if isinstance(a, str) else a
+                for a in record.args
+            )
+        return True
 
 
 # ContextVar for correlation ID - propagates across async tasks
@@ -82,6 +100,7 @@ def configure_logging(
         )
 
     console_handler.setFormatter(formatter)
+    console_handler.addFilter(ApiKeyRedactionFilter())
     root_logger.addHandler(console_handler)
 
     # Set module-specific log levels

--- a/backend/src/kestrel_backend/logging_config.py
+++ b/backend/src/kestrel_backend/logging_config.py
@@ -19,7 +19,12 @@ class ApiKeyRedactionFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
         if isinstance(record.msg, str):
             record.msg = _KEY_RE.sub("sk-***REDACTED***", record.msg)
-        if record.args:
+        if isinstance(record.args, dict):
+            record.args = {
+                k: (_KEY_RE.sub("sk-***REDACTED***", v) if isinstance(v, str) else v)
+                for k, v in record.args.items()
+            }
+        elif record.args:
             record.args = tuple(
                 _KEY_RE.sub("sk-***REDACTED***", a) if isinstance(a, str) else a
                 for a in record.args

--- a/backend/src/kestrel_backend/main.py
+++ b/backend/src/kestrel_backend/main.py
@@ -20,6 +20,8 @@ from .agent import run_agent_turn
 from .logging_config import configure_logging, generate_correlation_id, correlation_id
 from .clerk_auth import get_current_user, validate_ws_clerk_token
 from .clerk_proxy import router as clerk_proxy_router, close_http_client
+from .byok import resolve_effective_key, current_api_key, NeedsKeyError
+from .clerk_identity import get_verified_email
 
 # Configure logging early
 settings = get_settings()
@@ -57,6 +59,7 @@ from .protocol import (
     PipelineProgressMessage,
     PipelineNodeDetailMessage,
     PipelineCompleteMessage,
+    KeySourceMessage,
     NODE_STATUS_MESSAGES,
 )
 from .graph.node_detail_extractors import extract_node_details
@@ -102,6 +105,9 @@ conversation_ids: dict[str, UUID] = {}
 
 # Turn counter per WebSocket connection: {connection_id: int}
 turn_counters: dict[str, int] = defaultdict(int)
+
+# Per-connection BYOK key: {connection_id: key_str | None}
+connection_api_keys: dict[str, str | None] = {}
 
 # Maximum number of user/assistant exchanges to keep in history
 MAX_HISTORY_EXCHANGES = 10
@@ -843,6 +849,11 @@ async def websocket_chat(websocket: WebSocket):
                 )
                 continue
 
+            # BYOK: client can set/clear per-connection key before any chat turn.
+            if data.get("type") == "set_key":
+                connection_api_keys[connection_id] = data.get("key")
+                continue
+
             # Validate message type
             if data.get("type") != "user_message":
                 await websocket.send_text(
@@ -942,6 +953,31 @@ async def websocket_chat(websocket: WebSocket):
             # Optional prod/dev biomapper2 API toggle (mirrors biomapper-ui env routing).
             biomapper_env = data.get("biomapper_env")
 
+            # BYOK: resolve the effective key for this turn when BYOK is configured.
+            # When neither server_anthropic_api_key nor byok_trusted_email_domains are set,
+            # BYOK is not active — skip key resolution to preserve legacy behavior.
+            _byok_settings = get_settings()
+            _byok_active = bool(
+                _byok_settings.server_anthropic_api_key
+                or _byok_settings.byok_trusted_email_domains
+                or connection_api_keys.get(connection_id)
+            )
+            if _byok_active:
+                try:
+                    verified = await get_verified_email(user_info or {})
+                    key, source = resolve_effective_key(
+                        connection_api_keys.get(connection_id), verified)
+                except NeedsKeyError:
+                    await websocket.send_text(ErrorMessage(
+                        message="Provide your Anthropic API key to run synthesis.",
+                        code="NEEDS_KEY").model_dump_json())
+                    await websocket.send_text(DoneMessage().model_dump_json())
+                    continue
+                await websocket.send_text(KeySourceMessage(source=source).model_dump_json())
+                tok = current_api_key.set(key)
+            else:
+                tok = None
+
             try:
                 if agent_mode == "pipeline":
                     await handle_pipeline_mode(
@@ -959,6 +995,9 @@ async def websocket_chat(websocket: WebSocket):
                     ErrorMessage(message=f"Agent error: {str(e)}").model_dump_json()
                 )
                 await websocket.send_text(DoneMessage().model_dump_json())
+            finally:
+                if tok is not None:
+                    current_api_key.reset(tok)
 
     except WebSocketDisconnect:
         # Clean up state for this connection
@@ -966,6 +1005,7 @@ async def websocket_chat(websocket: WebSocket):
         conversation_history.pop(connection_id, None)
         conversation_ids.pop(connection_id, None)
         turn_counters.pop(connection_id, None)
+        connection_api_keys.pop(connection_id, None)
     except Exception as e:
         logger.error(
             "WebSocket error",
@@ -976,6 +1016,7 @@ async def websocket_chat(websocket: WebSocket):
         conversation_history.pop(connection_id, None)
         conversation_ids.pop(connection_id, None)
         turn_counters.pop(connection_id, None)
+        connection_api_keys.pop(connection_id, None)
 
 
 if __name__ == "__main__":

--- a/backend/src/kestrel_backend/main.py
+++ b/backend/src/kestrel_backend/main.py
@@ -271,6 +271,43 @@ def check_langfuse_health() -> tuple[bool, str | None]:
         return False, f"Langfuse error: {str(e)}"
 
 
+def _probe_anthropic_key(key: str) -> tuple[bool, str | None]:
+    """Probe an Anthropic API key with a minimal 1-token request.
+
+    Returns:
+        (True, None) if the key is valid and accepted by Anthropic.
+        (False, "invalid_api_key") if Anthropic rejects the key (AuthenticationError).
+        (False, "validation_failed") for any other exception (network, timeout, etc.)
+
+    The key is NEVER logged — callers must not log it either.
+    """
+    import anthropic
+    try:
+        anthropic.Anthropic(api_key=key).messages.create(
+            model="claude-3-5-haiku-latest",
+            max_tokens=1,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        return True, None
+    except anthropic.AuthenticationError:
+        return False, "invalid_api_key"
+    except Exception:
+        return False, "validation_failed"
+
+
+@app.post("/api/validate-key")
+async def validate_key(request: Request):
+    """Pre-flight endpoint: validate an Anthropic API key without storing it.
+
+    Body: {"key": "sk-..."}
+    Returns: {"valid": true} or {"valid": false, "reason": "..."}
+    The submitted key is never written to any log.
+    """
+    body = await request.json()
+    ok, reason = _probe_anthropic_key(body.get("key", ""))
+    return {"valid": ok} if ok else {"valid": False, "reason": reason}
+
+
 @app.get("/health")
 async def health_check():
     """Simple liveness check endpoint for monitoring."""

--- a/backend/src/kestrel_backend/main.py
+++ b/backend/src/kestrel_backend/main.py
@@ -304,7 +304,10 @@ async def validate_key(request: Request):
     The submitted key is never written to any log.
     """
     body = await request.json()
-    ok, reason = _probe_anthropic_key(body.get("key", ""))
+    # _probe_anthropic_key makes a blocking (synchronous) Anthropic HTTP call.
+    # Run it in a worker thread so a slow/timing-out probe cannot stall the event
+    # loop and the active WebSocket chat streams sharing it.
+    ok, reason = await asyncio.to_thread(_probe_anthropic_key, body.get("key", ""))
     return {"valid": ok} if ok else {"valid": False, "reason": reason}
 
 

--- a/backend/src/kestrel_backend/main.py
+++ b/backend/src/kestrel_backend/main.py
@@ -852,6 +852,10 @@ async def websocket_chat(websocket: WebSocket):
             # BYOK: client can set/clear per-connection key before any chat turn.
             if data.get("type") == "set_key":
                 connection_api_keys[connection_id] = data.get("key")
+                logger.debug(
+                    "BYOK set_key received",
+                    extra={"connection_id": connection_id, "has_key": data.get("key") is not None}
+                )
                 continue
 
             # Validate message type
@@ -937,10 +941,9 @@ async def websocket_chat(websocket: WebSocket):
                 continue
 
             # Create conversation on first message
-            settings = get_settings()
             if connection_id not in conversation_ids:
                 user_id = user_info.get("user_id") if user_info else None
-                conv_id = await create_conversation(connection_id, settings.model or "default", user_id)
+                conv_id = await create_conversation(connection_id, _settings.model or "default", user_id)
                 if conv_id:
                     conversation_ids[connection_id] = conv_id
                     # Send conversation_id to frontend for copy link functionality
@@ -953,30 +956,21 @@ async def websocket_chat(websocket: WebSocket):
             # Optional prod/dev biomapper2 API toggle (mirrors biomapper-ui env routing).
             biomapper_env = data.get("biomapper_env")
 
-            # BYOK: resolve the effective key for this turn when BYOK is configured.
-            # When neither server_anthropic_api_key nor byok_trusted_email_domains are set,
-            # BYOK is not active — skip key resolution to preserve legacy behavior.
-            _byok_settings = get_settings()
-            _byok_active = bool(
-                _byok_settings.server_anthropic_api_key
-                or _byok_settings.byok_trusted_email_domains
-                or connection_api_keys.get(connection_id)
-            )
-            if _byok_active:
-                try:
-                    verified = await get_verified_email(user_info or {})
-                    key, source = resolve_effective_key(
-                        connection_api_keys.get(connection_id), verified)
-                except NeedsKeyError:
-                    await websocket.send_text(ErrorMessage(
-                        message="Provide your Anthropic API key to run synthesis.",
-                        code="NEEDS_KEY").model_dump_json())
-                    await websocket.send_text(DoneMessage().model_dump_json())
-                    continue
-                await websocket.send_text(KeySourceMessage(source=source).model_dump_json())
-                tok = current_api_key.set(key)
-            else:
-                tok = None
+            # BYOK: unconditional per-turn key resolution (fail closed).
+            # An untrusted user with no key must NEVER reach synthesis — gate applies
+            # regardless of server configuration.
+            verified = await get_verified_email(user_info or {})
+            try:
+                key, source = resolve_effective_key(
+                    connection_api_keys.get(connection_id), verified)
+            except NeedsKeyError:
+                await websocket.send_text(ErrorMessage(
+                    message="Provide your Anthropic API key to run synthesis.",
+                    code="NEEDS_KEY").model_dump_json())
+                await websocket.send_text(DoneMessage().model_dump_json())
+                continue
+            await websocket.send_text(KeySourceMessage(source=source).model_dump_json())
+            tok = current_api_key.set(key)
 
             try:
                 if agent_mode == "pipeline":
@@ -996,8 +990,7 @@ async def websocket_chat(websocket: WebSocket):
                 )
                 await websocket.send_text(DoneMessage().model_dump_json())
             finally:
-                if tok is not None:
-                    current_api_key.reset(tok)
+                current_api_key.reset(tok)
 
     except WebSocketDisconnect:
         # Clean up state for this connection

--- a/backend/src/kestrel_backend/protocol.py
+++ b/backend/src/kestrel_backend/protocol.py
@@ -120,6 +120,18 @@ class StructuredAnalyte(BaseModel):
     )
 
 
+class KeySourceMessage(BaseModel):
+    """Server → Client: which key the current turn ran on."""
+    type: Literal["key_source"] = "key_source"
+    source: Literal["byok", "server"]
+
+
+class SetKeyRequest(BaseModel):
+    """Client → Server: set/clear the per-connection BYOK key."""
+    type: Literal["set_key"] = "set_key"
+    key: str | None = None
+
+
 class UserMessageRequest(BaseModel):
     """User sends a chat message.
 

--- a/backend/src/kestrel_backend/semantic_scholar.py
+++ b/backend/src/kestrel_backend/semantic_scholar.py
@@ -218,6 +218,9 @@ Return ONLY one word: supporting, contradicting, tangential, or methodological""
             permission_mode="bypassPermissions",
         )
 
+        from .graph.sdk_utils import _apply_byok_env
+        options = _apply_byok_env(options)
+
         result_text = ""
         async for event in query(prompt=prompt, options=options):
             if hasattr(event, "text"):

--- a/backend/tests/test_byok.py
+++ b/backend/tests/test_byok.py
@@ -1,0 +1,36 @@
+import pytest
+from kestrel_backend import byok
+from kestrel_backend.config import Settings, get_settings
+
+
+@pytest.fixture(autouse=True)
+def _settings(monkeypatch):
+    s = Settings(byok_trusted_email_domains=["phenomehealth.org"],
+                 server_anthropic_api_key="sk-server")
+    monkeypatch.setattr(byok, "get_settings", lambda: s)
+
+
+def test_byok_key_wins_even_for_trusted_user():
+    key, source = byok.resolve_effective_key("sk-user", "trent@phenomehealth.org")
+    assert (key, source) == ("sk-user", "byok")
+
+
+def test_trusted_user_no_byok_uses_server_key():
+    key, source = byok.resolve_effective_key(None, "trent@phenomehealth.org")
+    assert (key, source) == ("sk-server", "server")
+
+
+def test_untrusted_no_byok_raises():
+    with pytest.raises(byok.NeedsKeyError):
+        byok.resolve_effective_key(None, "someone@gmail.com")
+
+
+def test_no_verified_email_is_untrusted():
+    with pytest.raises(byok.NeedsKeyError):
+        byok.resolve_effective_key(None, None)
+
+
+def test_domain_match_is_case_insensitive_exact_suffix():
+    assert byok.is_trusted_email("A@Phenomehealth.org") is True
+    assert byok.is_trusted_email("x@evil-phenomehealth.org") is False
+    assert byok.is_trusted_email("x@phenomehealth.org.evil.com") is False

--- a/backend/tests/test_byok_injection_classic.py
+++ b/backend/tests/test_byok_injection_classic.py
@@ -1,0 +1,14 @@
+from kestrel_backend import agent, byok
+
+
+def test_classic_options_inject_contextvar_key(monkeypatch):
+    captured = {}
+    class FakeOptions:
+        def __init__(self, **kw): captured.update(kw)
+    monkeypatch.setattr(agent, "ClaudeAgentOptions", FakeOptions)
+    token = byok.current_api_key.set("sk-abc")
+    try:
+        agent.build_agent_options()   # extracted builder (see Step 3)
+    finally:
+        byok.current_api_key.reset(token)
+    assert captured["env"]["ANTHROPIC_API_KEY"] == "sk-abc"

--- a/backend/tests/test_byok_injection_pipeline.py
+++ b/backend/tests/test_byok_injection_pipeline.py
@@ -1,0 +1,37 @@
+import asyncio
+
+import pytest
+
+from kestrel_backend.graph import sdk_utils
+from kestrel_backend import byok
+
+
+def test_pipeline_options_inject_contextvar_key(monkeypatch):
+    captured = {}
+    class FakeOptions:
+        def __init__(self, **kw): captured.update(kw)
+    monkeypatch.setattr(sdk_utils, "ClaudeAgentOptions", FakeOptions)
+    monkeypatch.setattr(sdk_utils, "HAS_SDK", True)
+    token = byok.current_api_key.set("sk-node")
+    try:
+        sdk_utils.create_agent_options(system_prompt="x")
+    finally:
+        byok.current_api_key.reset(token)
+    assert captured["env"]["ANTHROPIC_API_KEY"] == "sk-node"
+
+
+@pytest.mark.asyncio
+async def test_no_cross_task_key_bleed(monkeypatch):
+    seen = []
+    class FakeOptions:
+        def __init__(self, **kw): seen.append(kw.get("env", {}).get("ANTHROPIC_API_KEY"))
+    monkeypatch.setattr(sdk_utils, "ClaudeAgentOptions", FakeOptions)
+    monkeypatch.setattr(sdk_utils, "HAS_SDK", True)
+
+    async def run(k):
+        byok.current_api_key.set(k)          # set inside the task's own context
+        await asyncio.sleep(0.01)
+        sdk_utils.create_agent_options(system_prompt="x")
+
+    await asyncio.gather(run("sk-A"), run("sk-B"))
+    assert set(seen) == {"sk-A", "sk-B"}     # each task kept its own key

--- a/backend/tests/test_byok_injection_pipeline.py
+++ b/backend/tests/test_byok_injection_pipeline.py
@@ -31,6 +31,10 @@ async def test_no_cross_task_key_bleed(monkeypatch):
     async def run(k):
         byok.current_api_key.set(k)          # set inside the task's own context
         await asyncio.sleep(0.01)
+        # After yielding, each task must still see its OWN key.
+        # Under any shared-state (module-global / os.environ) implementation,
+        # both tasks would see the last writer's key and this assertion would fail.
+        assert byok.current_api_key.get() == k
         sdk_utils.create_agent_options(system_prompt="x")
 
     await asyncio.gather(run("sk-A"), run("sk-B"))

--- a/backend/tests/test_byok_injection_pipeline.py
+++ b/backend/tests/test_byok_injection_pipeline.py
@@ -1,4 +1,13 @@
+"""Tests that the BYOK per-request key is correctly injected at every SDK call boundary.
+
+Three surfaces are covered:
+1. create_agent_options() — still valid for future callers (classic + PR5 scorer).
+2. query_with_usage() — the REAL funnel used by all 6 pipeline nodes.
+3. _apply_byok_env() — unit test of the helper itself.
+4. Concurrency isolation — no cross-task key bleed.
+"""
 import asyncio
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -6,10 +15,34 @@ from kestrel_backend.graph import sdk_utils
 from kestrel_backend import byok
 
 
+# ---------------------------------------------------------------------------
+# Helper: async generator that captures the options it was given
+# ---------------------------------------------------------------------------
+
+def _make_fake_query(captured: dict):
+    """Return an async-generator function that records the options argument."""
+    async def fake_query(*, prompt, options):
+        captured["options"] = options
+        # Yield a minimal ResultMessage-like event so query_with_usage doesn't fail
+        event = MagicMock()
+        event.usage = None
+        event.content = []
+        # Make isinstance(event, ResultMessage) return False (MagicMock default)
+        yield event
+    return fake_query
+
+
+# ---------------------------------------------------------------------------
+# 1. create_agent_options still injects (kept for future callers)
+# ---------------------------------------------------------------------------
+
 def test_pipeline_options_inject_contextvar_key(monkeypatch):
     captured = {}
+
     class FakeOptions:
-        def __init__(self, **kw): captured.update(kw)
+        def __init__(self, **kw):
+            captured.update(kw)
+
     monkeypatch.setattr(sdk_utils, "ClaudeAgentOptions", FakeOptions)
     monkeypatch.setattr(sdk_utils, "HAS_SDK", True)
     token = byok.current_api_key.set("sk-node")
@@ -20,11 +53,142 @@ def test_pipeline_options_inject_contextvar_key(monkeypatch):
     assert captured["env"]["ANTHROPIC_API_KEY"] == "sk-node"
 
 
+# ---------------------------------------------------------------------------
+# 2. query_with_usage() injects at the real SDK boundary (funnel for 6 nodes)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_query_with_usage_injects_byok_key(monkeypatch):
+    """Verify that query_with_usage applies the BYOK key to options before calling query."""
+    captured = {}
+
+    # Patch the SDK's `query` symbol imported into sdk_utils
+    monkeypatch.setattr(sdk_utils, "query", _make_fake_query(captured))
+    monkeypatch.setattr(sdk_utils, "HAS_SDK", True)
+
+    # Build a minimal options object with a settable .env attribute
+    class FakeOptions:
+        def __init__(self):
+            self.env = None
+
+    options = FakeOptions()
+
+    token = byok.current_api_key.set("sk-pipeline")
+    try:
+        await sdk_utils.query_with_usage(
+            prompt="test prompt",
+            options=options,
+            node_name="test_node",
+        )
+    finally:
+        byok.current_api_key.reset(token)
+
+    assert captured["options"] is options, "query() should receive the same options object"
+    assert captured["options"].env is not None, "env should have been set by _apply_byok_env"
+    assert captured["options"].env["ANTHROPIC_API_KEY"] == "sk-pipeline"
+
+
+@pytest.mark.asyncio
+async def test_query_with_usage_no_key_leaves_env_unchanged(monkeypatch):
+    """When no BYOK key is set, query_with_usage must not mutate options.env."""
+    captured = {}
+
+    monkeypatch.setattr(sdk_utils, "query", _make_fake_query(captured))
+    monkeypatch.setattr(sdk_utils, "HAS_SDK", True)
+
+    class FakeOptions:
+        def __init__(self):
+            self.env = None
+
+    options = FakeOptions()
+
+    # Ensure no key is set (clear any inherited context)
+    token = byok.current_api_key.set(None)
+    try:
+        await sdk_utils.query_with_usage(
+            prompt="test prompt",
+            options=options,
+            node_name="test_node",
+        )
+    finally:
+        byok.current_api_key.reset(token)
+
+    assert captured["options"].env is None, "env must remain None when no BYOK key is active"
+
+
+# ---------------------------------------------------------------------------
+# 3. _apply_byok_env() unit tests
+# ---------------------------------------------------------------------------
+
+def test_apply_byok_env_sets_key_when_present():
+    class FakeOptions:
+        def __init__(self):
+            self.env = None
+
+    options = FakeOptions()
+    token = byok.current_api_key.set("sk-unit")
+    try:
+        result = sdk_utils._apply_byok_env(options)
+    finally:
+        byok.current_api_key.reset(token)
+
+    assert result is options
+    assert result.env["ANTHROPIC_API_KEY"] == "sk-unit"
+
+
+def test_apply_byok_env_merges_with_existing_env():
+    """Existing env entries must be preserved; BYOK key is added/overwritten."""
+    class FakeOptions:
+        def __init__(self):
+            self.env = {"OTHER_VAR": "keep_me"}
+
+    options = FakeOptions()
+    token = byok.current_api_key.set("sk-merge")
+    try:
+        sdk_utils._apply_byok_env(options)
+    finally:
+        byok.current_api_key.reset(token)
+
+    assert options.env["ANTHROPIC_API_KEY"] == "sk-merge"
+    assert options.env["OTHER_VAR"] == "keep_me"
+
+
+def test_apply_byok_env_noop_when_no_key():
+    class FakeOptions:
+        def __init__(self):
+            self.env = None
+
+    options = FakeOptions()
+    token = byok.current_api_key.set(None)
+    try:
+        sdk_utils._apply_byok_env(options)
+    finally:
+        byok.current_api_key.reset(token)
+
+    assert options.env is None
+
+
+def test_apply_byok_env_noop_when_options_is_none():
+    token = byok.current_api_key.set("sk-present")
+    try:
+        result = sdk_utils._apply_byok_env(None)
+    finally:
+        byok.current_api_key.reset(token)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# 4. No cross-task key bleed (scheduling / concurrency isolation)
+# ---------------------------------------------------------------------------
+
 @pytest.mark.asyncio
 async def test_no_cross_task_key_bleed(monkeypatch):
     seen = []
+
     class FakeOptions:
-        def __init__(self, **kw): seen.append(kw.get("env", {}).get("ANTHROPIC_API_KEY"))
+        def __init__(self, **kw):
+            seen.append(kw.get("env", {}).get("ANTHROPIC_API_KEY"))
+
     monkeypatch.setattr(sdk_utils, "ClaudeAgentOptions", FakeOptions)
     monkeypatch.setattr(sdk_utils, "HAS_SDK", True)
 

--- a/backend/tests/test_clerk_identity.py
+++ b/backend/tests/test_clerk_identity.py
@@ -1,0 +1,48 @@
+import pytest
+from kestrel_backend import clerk_identity as ci
+from kestrel_backend.config import Settings
+
+
+class _Resp:
+    def __init__(self, payload): self._p = payload; self.status_code = 200
+    def raise_for_status(self): pass
+    def json(self): return self._p
+
+
+@pytest.fixture(autouse=True)
+def _settings(monkeypatch):
+    monkeypatch.setattr(ci, "get_settings", lambda: Settings(clerk_secret_key="sk_test"))
+    ci._email_cache.clear()
+
+
+@pytest.mark.asyncio
+async def test_returns_verified_primary_email(monkeypatch):
+    payload = {
+        "primary_email_address_id": "idb- 1",
+        "email_addresses": [
+            {"id": "idb- 1", "email_address": "trent@phenomehealth.org",
+             "verification": {"status": "verified"}},
+        ],
+    }
+    async def fake_get(*a, **k): return _Resp(payload)
+    monkeypatch.setattr(ci, "_clerk_get", fake_get)
+    assert await ci.get_verified_email({"sub": "user_1"}) == "trent@phenomehealth.org"
+
+
+@pytest.mark.asyncio
+async def test_unverified_primary_returns_none(monkeypatch):
+    payload = {
+        "primary_email_address_id": "e1",
+        "email_addresses": [
+            {"id": "e1", "email_address": "x@phenomehealth.org",
+             "verification": {"status": "unverified"}},
+        ],
+    }
+    async def fake_get(*a, **k): return _Resp(payload)
+    monkeypatch.setattr(ci, "_clerk_get", fake_get)
+    assert await ci.get_verified_email({"sub": "user_2"}) is None
+
+
+@pytest.mark.asyncio
+async def test_missing_sub_returns_none():
+    assert await ci.get_verified_email({}) is None

--- a/backend/tests/test_clerk_identity.py
+++ b/backend/tests/test_clerk_identity.py
@@ -46,3 +46,54 @@ async def test_unverified_primary_returns_none(monkeypatch):
 @pytest.mark.asyncio
 async def test_missing_sub_returns_none():
     assert await ci.get_verified_email({}) is None
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_avoids_refetch_within_ttl(monkeypatch):
+    """A second lookup within the TTL is served from cache (no second Clerk call)."""
+    calls = {"n": 0}
+    payload = {
+        "primary_email_address_id": "e1",
+        "email_addresses": [
+            {"id": "e1", "email_address": "a@phenomehealth.org",
+             "verification": {"status": "verified"}},
+        ],
+    }
+    async def fake_get(*a, **k):
+        calls["n"] += 1
+        return _Resp(payload)
+    monkeypatch.setattr(ci, "_clerk_get", fake_get)
+    assert await ci.get_verified_email({"sub": "u"}) == "a@phenomehealth.org"
+    assert await ci.get_verified_email({"sub": "u"}) == "a@phenomehealth.org"
+    assert calls["n"] == 1  # cached, not re-fetched
+
+
+@pytest.mark.asyncio
+async def test_cache_expires_and_refetches_revoked_email(monkeypatch):
+    """After the TTL lapses, a revoked trusted email is re-fetched and drops to None."""
+    verified = {
+        "primary_email_address_id": "e1",
+        "email_addresses": [
+            {"id": "e1", "email_address": "a@phenomehealth.org",
+             "verification": {"status": "verified"}},
+        ],
+    }
+    revoked = {
+        "primary_email_address_id": "e1",
+        "email_addresses": [
+            {"id": "e1", "email_address": "a@phenomehealth.org",
+             "verification": {"status": "unverified"}},
+        ],
+    }
+    state = {"payload": verified}
+    async def fake_get(*a, **k): return _Resp(state["payload"])
+    monkeypatch.setattr(ci, "_clerk_get", fake_get)
+
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(ci.time, "monotonic", lambda: clock["t"])
+
+    assert await ci.get_verified_email({"sub": "u"}) == "a@phenomehealth.org"
+    # Clerk revokes verification; advance past the TTL so the cache entry expires.
+    state["payload"] = revoked
+    clock["t"] += ci._CACHE_TTL_SECONDS + 1
+    assert await ci.get_verified_email({"sub": "u"}) is None

--- a/backend/tests/test_key_redaction.py
+++ b/backend/tests/test_key_redaction.py
@@ -1,0 +1,21 @@
+import logging
+from kestrel_backend.logging_config import ApiKeyRedactionFilter
+
+
+def test_filter_masks_anthropic_key():
+    f = ApiKeyRedactionFilter()
+    rec = logging.LogRecord("x", logging.INFO, "f", 1,
+                            "using key sk-ant-abc123DEF456ghi789", None, None)
+    f.filter(rec)
+    assert "sk-ant-abc123DEF456ghi789" not in rec.getMessage()
+    assert "REDACTED" in rec.getMessage()
+
+
+def test_filter_masks_key_in_args():
+    f = ApiKeyRedactionFilter()
+    rec = logging.LogRecord("x", logging.INFO, "f", 1,
+                            "key=%s", None, None)
+    rec.args = ("sk-ant-abc123DEF456ghi789",)
+    f.filter(rec)
+    assert "sk-ant-abc123DEF456ghi789" not in rec.getMessage()
+    assert "REDACTED" in rec.getMessage()

--- a/backend/tests/test_key_redaction.py
+++ b/backend/tests/test_key_redaction.py
@@ -19,3 +19,15 @@ def test_filter_masks_key_in_args():
     f.filter(rec)
     assert "sk-ant-abc123DEF456ghi789" not in rec.getMessage()
     assert "REDACTED" in rec.getMessage()
+
+
+def test_filter_masks_key_in_dict_args():
+    f = ApiKeyRedactionFilter()
+    # LogRecord.__init__ in Python 3.x unpacks a single-element tuple containing
+    # a Mapping into record.args as the dict itself.  Simulate that here.
+    rec = logging.LogRecord("x", logging.INFO, "f", 1,
+                            "key=%(k)s", None, None)
+    rec.args = {"k": "sk-ant-abc123DEF456ghi789"}
+    f.filter(rec)
+    assert "sk-ant-abc123DEF456ghi789" not in rec.getMessage()
+    assert "REDACTED" in rec.getMessage()

--- a/backend/tests/test_validate_key.py
+++ b/backend/tests/test_validate_key.py
@@ -1,0 +1,16 @@
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+from kestrel_backend.main import app
+
+
+def test_validate_key_ok():
+    with patch("kestrel_backend.main._probe_anthropic_key", return_value=(True, None)):
+        r = TestClient(app).post("/api/validate-key", json={"key": "sk-good"})
+        assert r.status_code == 200 and r.json()["valid"] is True
+
+
+def test_validate_key_bad():
+    with patch("kestrel_backend.main._probe_anthropic_key",
+               return_value=(False, "invalid_api_key")):
+        r = TestClient(app).post("/api/validate-key", json={"key": "sk-bad"})
+        assert r.json() == {"valid": False, "reason": "invalid_api_key"}

--- a/backend/tests/test_websocket_e2e.py
+++ b/backend/tests/test_websocket_e2e.py
@@ -22,6 +22,32 @@ import pytest
 
 
 # ============================================================================
+# BYOK passthrough fixture — applies to every test in this module.
+# After the unconditional BYOK gating fix, every user_message turn resolves a
+# key. Tests here are about WS behaviour (routing, history, error propagation),
+# not BYOK policy; mock the identity + byok layer so they see a trusted user
+# with a server key and never hit NeedsKeyError.
+# ============================================================================
+
+@pytest.fixture(autouse=True)
+def byok_passthrough(monkeypatch):
+    """Patch get_verified_email → trusted address; patch byok.get_settings → server key."""
+    from kestrel_backend import byok as byok_module
+
+    class _ByokSettings:
+        byok_trusted_email_domains = ["test.com"]
+        server_anthropic_api_key = "sk-test"
+
+    monkeypatch.setattr(byok_module, "get_settings", lambda: _ByokSettings())
+
+    with patch(
+        "kestrel_backend.main.get_verified_email",
+        AsyncMock(return_value="user@test.com"),
+    ):
+        yield
+
+
+# ============================================================================
 # Test Helpers
 # ============================================================================
 
@@ -100,10 +126,9 @@ class TestWebSocketConnection:
                                 # Connect, send message, and disconnect
                                 with client.websocket_connect("/ws/chat") as websocket:
                                     websocket.send_text(create_user_message("test"))
-                                    # Wait for done
-                                    data = websocket.receive_text()
-                                    msg = json.loads(data)
-                                    assert msg["type"] == "done"
+                                    # Drain until done (key_source is sent before dispatch)
+                                    messages = collect_messages_until_done(websocket)
+                                    assert any(m["type"] == "done" for m in messages)
 
                                 # After disconnect, state should be cleaned up
                                 # (clean_connection_state fixture handles verification)
@@ -466,12 +491,12 @@ class TestRateLimiting:
                                 client = TestClient(app)
 
                                 with client.websocket_connect("/ws/chat") as websocket:
-                                    # First two messages should succeed
+                                    # First two messages should succeed (drain until done each time;
+                                    # key_source is sent before dispatch)
                                     for _ in range(2):
                                         websocket.send_text(create_user_message("test"))
-                                        data = websocket.receive_text()
-                                        msg = json.loads(data)
-                                        assert msg["type"] == "done"
+                                        messages = collect_messages_until_done(websocket)
+                                        assert any(m["type"] == "done" for m in messages)
 
                                     # Third message should be rate limited
                                     websocket.send_text(create_user_message("test"))
@@ -635,9 +660,9 @@ class TestWebSocketAuthentication:
                                     # Should connect successfully
                                     with client.websocket_connect("/ws/chat?token=valid-token") as websocket:
                                         websocket.send_text(create_user_message("test"))
-                                        data = websocket.receive_text()
-                                        msg = json.loads(data)
-                                        assert msg["type"] == "done"
+                                        # Drain until done (key_source is sent before dispatch)
+                                        messages = collect_messages_until_done(websocket)
+                                        assert any(m["type"] == "done" for m in messages)
 
 
 # ============================================================================

--- a/backend/tests/test_ws_byok_wiring.py
+++ b/backend/tests/test_ws_byok_wiring.py
@@ -1,0 +1,66 @@
+"""Tests for Task 5: WebSocket BYOK wiring — key intake, per-turn resolution, untrusted gating."""
+from unittest.mock import AsyncMock, patch
+from fastapi.testclient import TestClient
+from kestrel_backend.main import app
+
+
+def _drain_until(ws, predicate, limit=5):
+    frames = []
+    for _ in range(limit):
+        f = ws.receive_json()
+        frames.append(f)
+        if predicate(f):
+            return frames
+    return frames
+
+
+def test_untrusted_no_key_is_gated():
+    # Patch get_settings in both main and byok so BYOK is active (server key configured,
+    # trusted domains set), but user is untrusted (no email) and provides no key.
+    with patch("kestrel_backend.main.validate_ws_clerk_token",
+               AsyncMock(return_value={"sub": "u1"})), \
+         patch("kestrel_backend.main.get_verified_email",
+               AsyncMock(return_value=None)), \
+         patch("kestrel_backend.main.get_settings") as gs, \
+         patch("kestrel_backend.byok.get_settings") as gs_byok:
+        gs.return_value.server_anthropic_api_key = "sk-server"
+        gs.return_value.byok_trusted_email_domains = ["phenomehealth.org"]
+        gs.return_value.max_ws_message_bytes = 1_000_000
+        gs.return_value.clerk_auth_enabled = False
+        gs.return_value.rate_limit_per_minute = 100
+        gs_byok.return_value.byok_trusted_email_domains = ["phenomehealth.org"]
+        gs_byok.return_value.server_anthropic_api_key = "sk-server"
+        client = TestClient(app)
+        with client.websocket_connect("/ws/chat?token=x") as ws:
+            ws.send_json({"type": "set_key", "key": None})
+            ws.send_json({"type": "user_message", "content": "hi", "agent_mode": "classic"})
+            frames = _drain_until(ws, lambda f: f.get("code") == "NEEDS_KEY")
+            assert any(f.get("type") == "error" and f.get("code") == "NEEDS_KEY"
+                       for f in frames)
+
+
+def test_trusted_no_key_runs_on_server_key():
+    # get_settings is lru_cache'd and called from both main.py and byok.py —
+    # patch both module references so resolve_effective_key sees trusted domains.
+    with patch("kestrel_backend.main.validate_ws_clerk_token",
+               AsyncMock(return_value={"sub": "u2"})), \
+         patch("kestrel_backend.main.get_verified_email",
+               AsyncMock(return_value="trent@phenomehealth.org")), \
+         patch("kestrel_backend.main.handle_classic_mode", AsyncMock()) as h, \
+         patch("kestrel_backend.main.get_settings") as gs, \
+         patch("kestrel_backend.byok.get_settings") as gs_byok:
+        gs.return_value.byok_trusted_email_domains = ["phenomehealth.org"]
+        gs.return_value.server_anthropic_api_key = "sk-server"
+        gs.return_value.max_ws_message_bytes = 1_000_000
+        gs.return_value.clerk_auth_enabled = False
+        gs.return_value.rate_limit_per_minute = 100
+        gs_byok.return_value.byok_trusted_email_domains = ["phenomehealth.org"]
+        gs_byok.return_value.server_anthropic_api_key = "sk-server"
+        client = TestClient(app)
+        with client.websocket_connect("/ws/chat?token=x") as ws:
+            ws.send_json({"type": "set_key", "key": None})
+            ws.send_json({"type": "user_message", "content": "hi", "agent_mode": "classic"})
+            frames = _drain_until(ws, lambda f: f.get("type") == "key_source")
+            assert any(f.get("type") == "key_source" and f.get("source") == "server"
+                       for f in frames)
+            assert h.await_count == 1

--- a/client/src/components/ApiKeyGate.tsx
+++ b/client/src/components/ApiKeyGate.tsx
@@ -1,0 +1,122 @@
+import { useState } from "react";
+import { KeyRound, X, Loader2, AlertCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card } from "@/components/ui/card";
+import type { UseApiKeyReturn } from "@/hooks/useApiKey";
+
+interface ApiKeyGateProps {
+  /** Provided by useApiKey(). */
+  apiKey: UseApiKeyReturn;
+  /**
+   * When true the gate renders as a blocking form (composer is disabled).
+   * When false (a key is already set, or no NEEDS_KEY yet) the gate renders
+   * only a "clear key" control.
+   */
+  needsKey: boolean;
+}
+
+export function ApiKeyGate({ apiKey, needsKey }: ApiKeyGateProps) {
+  const { key, setKey, clearKey, validate } = apiKey;
+
+  const [draft, setDraft] = useState("");
+  const [validating, setValidating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleValidate = async () => {
+    if (!draft.trim()) return;
+    setValidating(true);
+    setError(null);
+    const result = await validate(draft.trim());
+    setValidating(false);
+    if (result.valid) {
+      setKey(draft.trim());
+      setDraft("");
+    } else {
+      setError(result.reason);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") void handleValidate();
+  };
+
+  // A key is set — show only the "clear key" affordance.
+  if (key !== null) {
+    return (
+      <div className="flex items-center gap-2 px-1 py-1">
+        <span className="text-xs text-muted-foreground">Your API key is set for this session.</span>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={clearKey}
+          className="h-7 px-2 text-xs text-muted-foreground hover:text-foreground"
+          title="Clear API key"
+        >
+          <X className="h-3.5 w-3.5 mr-1" />
+          Clear key
+        </Button>
+      </div>
+    );
+  }
+
+  // Server hasn't asked for a key yet — nothing to render.
+  if (!needsKey) return null;
+
+  // The server returned NEEDS_KEY and no key is set — show the blocking form.
+  return (
+    <Card className="border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/30">
+      <div className="flex flex-col gap-3 p-4">
+        <div className="flex items-center gap-2">
+          <KeyRound className="h-4 w-4 text-amber-600 dark:text-amber-400 flex-shrink-0" />
+          <p className="text-sm font-medium text-amber-800 dark:text-amber-300">
+            An Anthropic API key is required to use this chat
+          </p>
+        </div>
+        <p className="text-xs text-amber-700 dark:text-amber-400 leading-relaxed">
+          Paste your key below. It is held only in memory for this session and never stored or sent
+          anywhere other than the server for this conversation.
+        </p>
+
+        <div className="flex gap-2">
+          <Input
+            type="password"
+            placeholder="sk-ant-..."
+            value={draft}
+            onChange={(e) => {
+              setDraft(e.target.value);
+              setError(null);
+            }}
+            onKeyDown={handleKeyDown}
+            disabled={validating}
+            className="font-mono text-sm"
+            autoComplete="off"
+            autoFocus
+          />
+          <Button
+            onClick={() => void handleValidate()}
+            disabled={!draft.trim() || validating}
+            size="default"
+            className="flex-shrink-0"
+          >
+            {validating ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin mr-1" />
+                Checking…
+              </>
+            ) : (
+              "Validate"
+            )}
+          </Button>
+        </div>
+
+        {error && (
+          <div className="flex items-center gap-1.5 text-xs text-destructive">
+            <AlertCircle className="h-3.5 w-3.5 flex-shrink-0" />
+            <span>{error}</span>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/client/src/hooks/useApiKey.ts
+++ b/client/src/hooks/useApiKey.ts
@@ -1,0 +1,52 @@
+import { useState, useCallback } from "react";
+
+export type ValidateResult =
+  | { valid: true }
+  | { valid: false; reason: string };
+
+export interface UseApiKeyReturn {
+  /** Current in-memory key for this session (null = not set). */
+  key: string | null;
+  /** Store the key in memory (never persisted to any storage). */
+  setKey: (key: string) => void;
+  /** Clear the in-memory key. */
+  clearKey: () => void;
+  /**
+   * POST /api/validate-key and return the result.
+   * Does NOT set the key; caller decides what to do on success.
+   */
+  validate: (key: string) => Promise<ValidateResult>;
+}
+
+export function useApiKey(): UseApiKeyReturn {
+  // Key lives ONLY in React state — no localStorage, no sessionStorage, no cookies.
+  // A full page reload intentionally clears it (per-session design).
+  const [key, setKeyState] = useState<string | null>(null);
+
+  const setKey = useCallback((k: string) => {
+    setKeyState(k);
+  }, []);
+
+  const clearKey = useCallback(() => {
+    setKeyState(null);
+  }, []);
+
+  const validate = useCallback(async (k: string): Promise<ValidateResult> => {
+    try {
+      const res = await fetch("/api/validate-key", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ key: k }),
+      });
+      const json = (await res.json()) as { valid: boolean; reason?: string };
+      if (json.valid) {
+        return { valid: true };
+      }
+      return { valid: false, reason: json.reason ?? "Invalid key" };
+    } catch {
+      return { valid: false, reason: "Network error — could not reach validation endpoint" };
+    }
+  }, []);
+
+  return { key, setKey, clearKey, validate };
+}

--- a/client/src/hooks/useWebSocket.ts
+++ b/client/src/hooks/useWebSocket.ts
@@ -4,6 +4,8 @@ import type {
   ChatMessage,
   ConnectionStatus,
   IncomingMessage,
+  KeySource,
+  SetKeyRequest,
   ToolUseMessage,
   TraceMessage,
   SessionStats,
@@ -226,7 +228,16 @@ const DEMO_PIPELINE_SCENARIO: IncomingMessage[] = [
 
 const DEMO_PIPELINE_DELAYS = [300, 400, 300, 600, 300, 400, 300, 800, 300, 600, 300, 700, 300, 500, 300, 800, 200, 100];
 
-export function useWebSocket() {
+interface UseWebSocketOptions {
+  /**
+   * The user's current BYOK API key (or null when not set).
+   * Passed as a prop so the hook can send `set_key` frames whenever it changes
+   * without reconstructing the WebSocket.
+   */
+  apiKey?: string | null;
+}
+
+export function useWebSocket({ apiKey = null }: UseWebSocketOptions = {}) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [connectionStatus, setConnectionStatus] =
     useState<ConnectionStatus>("disconnected");
@@ -242,6 +253,15 @@ export function useWebSocket() {
   // after each successful send so a follow-up text message doesn't silently re-run the panel.
   const [structuredAnalytes, setStructuredAnalytes] = useState<StructuredAnalyte[]>([]);
   const [selectedGroups, setSelectedGroups] = useState<string[]>([]);
+
+  // BYOK state: set true when the server returns a NEEDS_KEY error, reset when a key is accepted.
+  const [needsKey, setNeedsKey] = useState(false);
+  // The key source reported by the server at the start of each turn.
+  const [keySource, setKeySource] = useState<KeySource | null>(null);
+
+  // Keep a ref to the latest apiKey so onopen and the key-change effect can
+  // always read the current value without capturing a stale closure.
+  const apiKeyRef = useRef<string | null>(apiKey);
 
   // Clerk auth: get a fresh session token for WebSocket connections.
   // When Clerk isn't configured (local dev / no publishable key) there's no
@@ -260,12 +280,22 @@ export function useWebSocket() {
     ? useAuth()
     : { getToken: NOOP_GET_TOKEN, isSignedIn: false };
 
+  // Sync the ref every render so closures that capture it always see the latest key.
+  apiKeyRef.current = apiKey;
+
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectAttemptRef = useRef(0);
   const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const mountedRef = useRef(true);
   const demoModeRef = useRef(false);
   const demoTimeoutsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+
+  /** Send a set_key frame on the currently-open socket (no-op if socket isn't open). */
+  const sendSetKey = useCallback((ws: WebSocket, key: string | null) => {
+    if (ws.readyState !== WebSocket.OPEN) return;
+    const frame: SetKeyRequest = { type: "set_key", key };
+    ws.send(JSON.stringify(frame));
+  }, []);
 
   const addTraceToSession = useCallback((trace: TraceMessage) => {
     setSessionStats((prev) => ({
@@ -360,7 +390,34 @@ export function useWebSocket() {
         break;
       }
 
+      case "key_source":
+        // Server confirms which key is powering this turn.
+        setKeySource(data.source);
+        // A key_source frame arriving means the server accepted the key — clear needsKey.
+        if (data.source === "byok") {
+          setNeedsKey(false);
+        }
+        break;
+
       case "error":
+        // NEEDS_KEY: server is telling us it can't proceed without a user-supplied key.
+        if (data.code === "NEEDS_KEY") {
+          setNeedsKey(true);
+          setIsAgentResponding(false);
+          setPipelineProgress(null);
+          // Surface the error message in the chat so the user understands what happened.
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: generateId(),
+              type: "error" as const,
+              message: data.message,
+              code: data.code,
+              timestamp: Date.now(),
+            },
+          ]);
+          break;
+        }
         setMessages((prev) => [
           ...prev,
           {
@@ -493,6 +550,9 @@ export function useWebSocket() {
         setConnectionStatus("connected");
         reconnectAttemptRef.current = 0;
         demoModeRef.current = false;
+        // BYOK: send set_key FIRST, before any user_message, so the server knows
+        // which key to use. Reads the ref to get the current value at open time.
+        sendSetKey(ws, apiKeyRef.current);
       };
 
       ws.onmessage = (event) => {
@@ -537,7 +597,7 @@ export function useWebSocket() {
       setConnectionStatus("disconnected");
       scheduleReconnect();
     }
-  }, [handleIncomingMessage, scheduleReconnect, enterDemoMode, getToken, isSignedIn]);
+  }, [handleIncomingMessage, scheduleReconnect, enterDemoMode, getToken, isSignedIn, sendSetKey]);
 
   const runDemoScenario = useCallback(
     (userContent: string) => {
@@ -672,6 +732,18 @@ export function useWebSocket() {
     };
   }, [connectWs]);
 
+  // BYOK: when the key changes mid-session, send an updated set_key frame so the
+  // server's in-memory slot is always in sync with what the user has set (or cleared).
+  useEffect(() => {
+    if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
+    sendSetKey(wsRef.current, apiKey);
+    // When the user provides a key, clear needsKey optimistically (the server will
+    // confirm by sending key_source:"byok" at the start of the next turn).
+    if (apiKey !== null) {
+      setNeedsKey(false);
+    }
+  }, [apiKey, sendSetKey]);
+
   return {
     messages,
     connectionStatus,
@@ -689,5 +761,8 @@ export function useWebSocket() {
     setSelectedGroups,
     sendMessage,
     clearMessages,
+    // BYOK additions
+    needsKey,
+    keySource,
   };
 }

--- a/client/src/pages/chat.tsx
+++ b/client/src/pages/chat.tsx
@@ -9,7 +9,10 @@ import { PipelineProgress } from "@/components/PipelineProgress";
 import { AnalyteUpload } from "@/components/AnalyteUpload";
 import { ColumnMappingPanel } from "@/components/ColumnMappingPanel";
 import { AnalyteReviewSummary } from "@/components/AnalyteReviewSummary";
+import { ApiKeyGate } from "@/components/ApiKeyGate";
 import { useWebSocket } from "@/hooks/useWebSocket";
+import { useApiKey } from "@/hooks/useApiKey";
+import { Badge } from "@/components/ui/badge";
 import { distinctGroups, type ParsedFile } from "@/lib/analyteParse";
 import type { ErrorMessage } from "@/types/messages";
 
@@ -19,6 +22,9 @@ type UploadStage =
   | { step: "mapping"; parsed: ParsedFile; fileName: string };
 
 export default function ChatPage() {
+  // BYOK: key lives only in React state (never persisted).
+  const apiKey = useApiKey();
+
   const {
     messages,
     connectionStatus,
@@ -36,7 +42,9 @@ export default function ChatPage() {
     setSelectedGroups,
     sendMessage,
     clearMessages,
-  } = useWebSocket();
+    needsKey,
+    keySource,
+  } = useWebSocket({ apiKey: apiKey.key });
 
   const [uploadStage, setUploadStage] = useState<UploadStage>({ step: "idle" });
   const [queryEmpty, setQueryEmpty] = useState(true);
@@ -49,6 +57,9 @@ export default function ChatPage() {
   const hasAuthError = messages.some(
     (m) => m.type === "error" && (m as ErrorMessage).code === "AUTH_ERROR"
   );
+
+  // BYOK: composer is additionally blocked when the server needs a key and none is set.
+  const keyGateBlocking = needsKey && apiKey.key === null;
 
   const resetUpload = () => {
     setUploadStage({ step: "idle" });
@@ -105,6 +116,12 @@ export default function ChatPage() {
             disabled={isAgentResponding}
           />
         )}
+        {/* BYOK: key-source badge — shown when the server has confirmed which key is in use. */}
+        {keySource !== null && (
+          <Badge variant={keySource === "byok" ? "default" : "secondary"} className="text-xs">
+            {keySource === "byok" ? "Using your key" : "Using server key"}
+          </Badge>
+        )}
       </div>
 
       <ChatArea
@@ -156,9 +173,17 @@ export default function ChatPage() {
         </div>
       )}
 
+      {/* BYOK: key gate — blocks composer when server sends NEEDS_KEY and no key is set,
+          or shows a "clear key" control when a key is already loaded for this session. */}
+      {!hasAuthError && (
+        <div className="px-4 pb-2">
+          <ApiKeyGate apiKey={apiKey} needsKey={needsKey} />
+        </div>
+      )}
+
       <ChatInput
         onSend={handleSend}
-        disabled={isAgentResponding || hasAuthError}
+        disabled={isAgentResponding || hasAuthError || keyGateBlocking}
         isConnected={isConnected}
         hasPanel={isPipeline && hasPanel}
         onQueryEmptyChange={setQueryEmpty}

--- a/client/src/types/messages.ts
+++ b/client/src/types/messages.ts
@@ -134,6 +134,15 @@ export type ChatMessage =
   | PipelineNodeDetailMessage
   | PipelineCompleteMessage;
 
+// BYOK: which key is powering the current turn ("byok" = user's key, "server" = operator key).
+export type KeySource = "byok" | "server";
+
+// BYOK: outgoing frame to register or clear the user's API key for this session.
+export type SetKeyRequest = {
+  type: "set_key";
+  key: string | null;
+};
+
 export type IncomingMessage =
   | { type: "text"; content: string }
   | { type: "tool_use"; tool: string; args: Record<string, unknown> }
@@ -154,6 +163,11 @@ export type IncomingMessage =
       duration_ms?: number;
       tool_calls_count?: number;
       model?: string;
+    }
+  | {
+      // BYOK: server sends this at the start of each turn to indicate which key is in use.
+      type: "key_source";
+      source: KeySource;
     }
   | {
       type: "pipeline_progress";

--- a/docs/brainstorms/2026-07-11-byok-per-session-requirements.md
+++ b/docs/brainstorms/2026-07-11-byok-per-session-requirements.md
@@ -1,0 +1,144 @@
+# BYOK (Bring Your Own Key) — Per-Session Design
+
+**Date:** 2026-07-11
+**Pilot app:** kraken-chatbot
+**Reuse targets:** expert-in-the-loop (web module); ddharmon (env-var note only)
+**Status:** Design approved, pre-implementation
+
+---
+
+## 1. Motivation
+
+Let people other than Trent use the LLM-backed apps without Trent paying for their
+inference and without provisioning a key for each person.
+
+Two drivers, in priority order:
+
+1. **Cost offload** — the public / collaborators pay for their own inference.
+2. **Distribution** — hand the apps to others without per-person key provisioning.
+
+Explicitly **not** a driver: compliance / data-residency. Users' prompts do not need to
+flow through their own provider account for legal reasons. This lowers the security bar:
+we must not be reckless with the key, but we are not obligated to protect it at rest.
+
+## 2. Scope
+
+- **Pilot:** kraken-chatbot (most public-facing, richest LLM surface, real cost pressure).
+- **Reuse:** extract an app-agnostic web BYOK module and later apply to expert-in-the-loop.
+- **ddharmon:** out of the web pattern. It is a Python library/CLI — "BYOK" there is just
+  reading `ANTHROPIC_API_KEY` from caller-supplied env/config. Documented in one paragraph,
+  no UI, no session handling.
+
+## 3. Key decisions (settled during brainstorm)
+
+| # | Decision | Choice |
+|---|----------|--------|
+| 1 | Motivation | Cost offload + distribution (no compliance) |
+| 2 | Persistence | **Per-session only** — no accounts, no DB, no at-rest encryption, no KMS |
+| 3 | Rollout | Reusable web module; **kraken is the pilot**; port to EITL after |
+| 4 | Provider | **Single Anthropic key** (forced by the Claude Agent SDK path) |
+| 5 | No-key fallback | **Trusted users ride Trent's key; everyone else must BYOK** |
+| 6 | Trusted definition | Any Clerk user with a **verified** `phenomehealth.org` email |
+
+### Why single Anthropic key (decision 4)
+
+kraken's synthesis pipeline runs on the **Claude Agent SDK** (`claude_agent_sdk.query`
+with `ClaudeAgentOptions`; it spawns Claude Code as a subprocess reading creds from process
+env). That path is Anthropic-specific and will not cleanly route through OpenRouter, so a
+provider-aggregator key is not viable. OpenAI is **not** a meaningful cost center here —
+embeddings / vector search run through Kestrel/SPOKE server-side, not OpenAI — so a single
+Anthropic key covers the entire cost driver.
+
+## 4. Architecture
+
+```
+Browser (key held in memory only — never localStorage/sessionStorage)
+   │  POST /api/session/key   (TLS)
+   ▼
+Backend: validate key → store in server-side session (keyed to existing cookie)
+   │        frontend discards its copy; the server session is the source of truth
+   ▼
+Every LLM request → resolve_api_key(request) → inject → Anthropic
+```
+
+No database, no at-rest encryption, no accounts. The key lives in the server session and
+dies with it (TTL or explicit clear).
+
+### 4.1 The one chokepoint: `resolve_api_key(request)`
+
+A single function all LLM-invoking code must call. Precedence:
+
+1. **Session BYOK key** present → use it. Source = `"byok"`.
+2. else **Clerk identity has a verified `phenomehealth.org` email** → server default key.
+   Source = `"server"`.
+3. else → `401 needs-key`.
+
+After this change, **no LLM path reads the key from process env directly** — they all ask
+`resolve_api_key`.
+
+> Security note on decision 6: the domain check must use Clerk's **verified primary email**,
+> not any user-editable field, or the trust gate is spoofable.
+
+### 4.2 Injection into kraken's two LLM paths (the real implementation lift)
+
+- **Claude Agent SDK:** pass `env={"ANTHROPIC_API_KEY": key}` into `ClaudeAgentOptions`
+  **per query**. Never mutate global `os.environ` — that races across concurrent sessions.
+- **LangChain:** `ChatAnthropic(api_key=key)` per request (currently in
+  `src/kestrel_backend/local_tools.py`).
+
+Both currently read from process env / settings, so the bulk of the work is **threading a
+per-request key context down into the pipeline** to reach these two call sites.
+
+### 4.3 Reusable module boundary
+
+- **App-agnostic (the module):**
+  - frontend key-entry component + in-memory key handling
+  - backend session-key store
+  - `resolve_api_key` with the trusted-fallback rule
+  - key validation
+- **App-specific (thin adapter):** how each app *injects* the resolved key. kraken =
+  SDK + LangChain; EITL = its own client. The module never knows how the key is used.
+
+## 5. Security posture (matched to per-session, non-compliance)
+
+- Key never in browser `localStorage` / `sessionStorage`. In memory during entry, then the
+  server session.
+- **Scrubbed from logs and Langfuse traces.** Langfuse is already wired into kraken
+  (`sdk_utils.py`) — this is a concrete leak risk and must be explicitly prevented and tested.
+- TLS required.
+- Session TTL + explicit "clear key" button.
+- No at-rest persistence → nothing to encrypt.
+
+## 6. Validation & error UX
+
+- **On submit:** one cheap Anthropic ping (e.g. a 1-token message) to confirm the key works
+  before accepting it → instant feedback.
+- **No key + untrusted user:** chat disabled, inline "enter your Anthropic key to start."
+- **Key revoked / over-quota mid-session:** surface the provider error, clear the stored
+  session key, re-prompt.
+- **"Whose key am I on?" indicator:** show source (`your key` vs `server`) so trusted users
+  know when they are spending Trent's budget.
+
+## 7. Testing
+
+- **Precedence unit tests** for `resolve_api_key`: byok > trusted-fallback > deny; verified
+  vs unverified email; wrong domain.
+- **Concurrency test:** two sessions with two different keys, assert no SDK-subprocess env
+  bleed between them.
+- **Log/trace scrub assertion:** the key never appears in logs or Langfuse payloads.
+- **Validation happy/sad path.**
+- **End-to-end:** paste → validate → synthesize → clear.
+
+## 8. ddharmon note
+
+ddharmon reads `ANTHROPIC_API_KEY` from caller-supplied environment or config. No settings
+UI, no session handling. This is the entirety of its "BYOK" story and is already how a
+library should behave — document the convention, add nothing.
+
+## 9. Out of scope (YAGNI)
+
+Accounts · remembered keys · at-rest encryption / KMS · metering / free tier ·
+OpenRouter / multi-provider · OpenAI BYOK.
+
+These are deliberately excluded for the first cut. If a "remembered key" experience is
+wanted later, that is a separate design (it reintroduces accounts + encrypted storage).

--- a/docs/plans/2026-07-11-byok-per-session-kraken.md
+++ b/docs/plans/2026-07-11-byok-per-session-kraken.md
@@ -412,20 +412,53 @@ git commit -m "feat(byok): inject effective key into pipeline nodes + concurrenc
 ### Task 5: Wire the WebSocket handler — receive key, resolve, gate
 
 **Files:**
-- Modify: `backend/src/kestrel_backend/main.py` (`websocket_chat` ~777, message loop, `handle_classic_mode`/`handle_pipeline_mode` call sites)
+- Modify: `backend/src/kestrel_backend/protocol.py` (add `SetKeyRequest` incoming + `KeySourceMessage` outgoing; add `NEEDS_KEY` code convention)
+- Modify: `backend/src/kestrel_backend/main.py` (`websocket_chat` ~777-870, message loop, `handle_classic_mode`/`handle_pipeline_mode` call sites)
 - Test: `backend/tests/test_ws_byok_wiring.py`
+
+**GROUND TRUTH — the real WS protocol (verified in `protocol.py` / `main.py`, use these EXACTLY):**
+- Incoming chat frames are `{"type": "user_message", "content": "...", "agent_mode": "classic"|"pipeline"}` (`UserMessageRequest`). The field is `agent_mode`, NOT `mode`, and the type is `user_message`, NOT `message`.
+- The loop at `main.py:~848` rejects **any** `data.get("type") != "user_message"` with `ErrorMessage(message="Unknown message type")`. A `set_key` frame therefore needs its own branch placed **before** that guard, ending in `continue`.
+- `ErrorMessage` (protocol.py:29) is `type: Literal["error"]="error"`, `message: str`, `code: str | None = None`. There is **no** `needs_key`/`error=`/`type=` override. Signal "needs key" as `ErrorMessage(message="...", code="NEEDS_KEY")` — this mirrors the existing `AUTH_ERROR` code convention. Existing error paths follow the error frame with `DoneMessage()`; do the same.
+- `connection_id = str(id(websocket))` (main.py:803). Per-connection dicts (`conversation_history`, `conversation_ids`, `turn_counters`) live near main.py:94-103 and are cleaned in the disconnect handler.
 
 **Interfaces:**
 - Consumes: `byok.resolve_effective_key`, `byok.current_api_key`, `byok.NeedsKeyError`, `clerk_identity.get_verified_email`.
-- Message contract: client's **first WS message** after connect is `{"type": "set_key", "key": "sk-..."}` (or `{"type": "set_key", "key": null}` to declare no key). Stored in a new per-connection dict `connection_api_keys: dict[str, str | None]`, cleaned up alongside `conversation_history` on disconnect.
-- Per turn, before invoking a handler: resolve `(key, source)` and set `current_api_key`; on `NeedsKeyError` send an error frame and skip the turn.
+- Message contract: client's **first WS frame** after connect is `{"type": "set_key", "key": "sk-..."}` (or `{"type": "set_key", "key": null}` to declare no key). Stored in a new per-connection dict `connection_api_keys: dict[str, str | None]`, cleaned up alongside `conversation_history` on disconnect.
+- Produces (outgoing): `KeySourceMessage(type="key_source", source: Literal["byok","server"])`, sent as the first frame of each successful turn so the UI can show "whose key".
+- Per turn, before invoking a handler: resolve `(key, source)`, send `KeySourceMessage`, set `current_api_key`; on `NeedsKeyError` send `ErrorMessage(code="NEEDS_KEY")` + `DoneMessage()` and skip the turn.
 
-- [ ] **Step 1: Write failing test** in `backend/tests/test_ws_byok_wiring.py` using `fastapi.testclient.TestClient` websocket. Assert: (a) an untrusted connection that sends `set_key` with `null` then a chat message receives a `needs_key` error frame and no synthesis runs; (b) a connection that sends a real key sets `current_api_key` (spy on `resolve_effective_key`). Mock `validate_ws_clerk_token` to return `{"sub": "u1"}` and `get_verified_email` to return `None` (untrusted) / a phenome email (trusted).
+- [ ] **Step 1: Add protocol models** to `protocol.py`:
+
+```python
+class KeySourceMessage(BaseModel):
+    """Server → Client: which key the current turn ran on."""
+    type: Literal["key_source"] = "key_source"
+    source: Literal["byok", "server"]
+
+
+class SetKeyRequest(BaseModel):
+    """Client → Server: set/clear the per-connection BYOK key."""
+    type: Literal["set_key"] = "set_key"
+    key: str | None = None
+```
+
+- [ ] **Step 2: Write failing test** in `backend/tests/test_ws_byok_wiring.py`:
 
 ```python
 from unittest.mock import AsyncMock, patch
 from fastapi.testclient import TestClient
 from kestrel_backend.main import app
+
+
+def _drain_until(ws, predicate, limit=5):
+    frames = []
+    for _ in range(limit):
+        f = ws.receive_json()
+        frames.append(f)
+        if predicate(f):
+            return frames
+    return frames
 
 
 def test_untrusted_no_key_is_gated():
@@ -436,46 +469,77 @@ def test_untrusted_no_key_is_gated():
         client = TestClient(app)
         with client.websocket_connect("/ws/chat?token=x") as ws:
             ws.send_json({"type": "set_key", "key": None})
-            ws.send_json({"type": "message", "content": "hi", "mode": "classic"})
-            frames = [ws.receive_json() for _ in range(1)]
-            assert any(f.get("type") == "needs_key" for f in frames)
+            ws.send_json({"type": "user_message", "content": "hi", "agent_mode": "classic"})
+            frames = _drain_until(ws, lambda f: f.get("code") == "NEEDS_KEY")
+            assert any(f.get("type") == "error" and f.get("code") == "NEEDS_KEY"
+                       for f in frames)
+
+
+def test_trusted_no_key_runs_on_server_key():
+    with patch("kestrel_backend.main.validate_ws_clerk_token",
+               AsyncMock(return_value={"sub": "u2"})), \
+         patch("kestrel_backend.main.get_verified_email",
+               AsyncMock(return_value="trent@phenomehealth.org")), \
+         patch("kestrel_backend.main.handle_classic_mode", AsyncMock()) as h, \
+         patch("kestrel_backend.main.get_settings") as gs:
+        gs.return_value.byok_trusted_email_domains = ["phenomehealth.org"]
+        gs.return_value.server_anthropic_api_key = "sk-server"
+        gs.return_value.max_ws_message_bytes = 1_000_000
+        client = TestClient(app)
+        with client.websocket_connect("/ws/chat?token=x") as ws:
+            ws.send_json({"type": "set_key", "key": None})
+            ws.send_json({"type": "user_message", "content": "hi", "agent_mode": "classic"})
+            frames = _drain_until(ws, lambda f: f.get("type") == "key_source")
+            assert any(f.get("type") == "key_source" and f.get("source") == "server"
+                       for f in frames)
+            assert h.await_count == 1
 ```
 
-- [ ] **Step 2: Run test, verify it fails.** Run: `.venv/bin/pytest tests/test_ws_byok_wiring.py -v` — Expected: FAIL.
+> Note: `get_settings` is `@lru_cache`'d and imported at module scope in several places; patch it where `main.py` and `byok.py` look it up. If patching proves brittle, set the values via environment/`Settings` construction in a fixture instead — the assertion (server-source frame + handler invoked) is what matters.
 
-- [ ] **Step 3: Implement.** In `main.py`:
+- [ ] **Step 3: Run tests, verify they fail.** Run: `.venv/bin/pytest tests/test_ws_byok_wiring.py -v` — Expected: FAIL.
+
+- [ ] **Step 4: Implement.** In `main.py`:
   - Add `connection_api_keys: dict[str, str | None] = {}` near the other per-connection dicts (~line 94-103).
-  - In `websocket_chat`, capture `user_info` from `validate_ws_clerk_token`, keep it in scope.
-  - In the message loop, handle `set_key` frames: `connection_api_keys[connection_id] = data.get("key")`.
-  - Before dispatching to `handle_classic_mode` / `handle_pipeline_mode`, add:
+  - Import at module scope: `from .byok import resolve_effective_key, current_api_key, NeedsKeyError` and `from .clerk_identity import get_verified_email` (module-scope so tests can `patch("kestrel_backend.main.get_verified_email", ...)`).
+  - `websocket_chat` already binds `user_info` — keep it in scope for the loop.
+  - In the message loop, **before** the `!= "user_message"` guard, add:
 
 ```python
-    from .byok import resolve_effective_key, current_api_key, NeedsKeyError
-    from .clerk_identity import get_verified_email
-    try:
-        verified = await get_verified_email(user_info)
-        key, source = resolve_effective_key(connection_api_keys.get(connection_id), verified)
-    except NeedsKeyError:
-        await websocket.send_text(ErrorMessage(
-            type="needs_key",
-            error="Provide your Anthropic API key to run synthesis.").model_dump_json())
-        continue
-    tok = current_api_key.set(key)
-    try:
-        # existing dispatch to handle_classic_mode / handle_pipeline_mode
-        ...
-    finally:
-        current_api_key.reset(tok)
+            if data.get("type") == "set_key":
+                connection_api_keys[connection_id] = data.get("key")
+                continue
 ```
-  - In the disconnect/cleanup block, `connection_api_keys.pop(connection_id, None)`.
-  - If `ErrorMessage` lacks a `type` field for `needs_key`, add the literal to the model in `models.py` (or reuse the existing error frame and set a dedicated field). Verify against `models.py` before implementing.
+  - After the `user_message` type check and content validation, **before** dispatching to `handle_classic_mode` / `handle_pipeline_mode`:
 
-- [ ] **Step 4: Run test, verify it passes.** Run: `.venv/bin/pytest tests/test_ws_byok_wiring.py -v` — Expected: PASS. Send the `source` ("byok"/"server") to the client in the turn's first frame so the UI can show "whose key" (Task 8).
+```python
+            try:
+                verified = await get_verified_email(user_info)
+                key, source = resolve_effective_key(
+                    connection_api_keys.get(connection_id), verified)
+            except NeedsKeyError:
+                await websocket.send_text(ErrorMessage(
+                    message="Provide your Anthropic API key to run synthesis.",
+                    code="NEEDS_KEY").model_dump_json())
+                await websocket.send_text(DoneMessage().model_dump_json())
+                continue
+            await websocket.send_text(KeySourceMessage(source=source).model_dump_json())
+            tok = current_api_key.set(key)
+            try:
+                # existing dispatch to handle_classic_mode / handle_pipeline_mode
+                ...
+            finally:
+                current_api_key.reset(tok)
+```
+  - Import `KeySourceMessage` from `.protocol` alongside the existing `ErrorMessage`/`DoneMessage` imports.
+  - In the disconnect/cleanup block (where `conversation_history` etc. are popped), add `connection_api_keys.pop(connection_id, None)`.
 
-- [ ] **Step 5: Commit.**
+- [ ] **Step 5: Run tests, verify they pass.** Run: `.venv/bin/pytest tests/test_ws_byok_wiring.py -v` — Expected: PASS.
+
+- [ ] **Step 6: Commit.**
 
 ```bash
-git add backend/src/kestrel_backend/main.py backend/src/kestrel_backend/models.py backend/tests/test_ws_byok_wiring.py
+git add backend/src/kestrel_backend/protocol.py backend/src/kestrel_backend/main.py backend/tests/test_ws_byok_wiring.py
 git commit -m "feat(byok): WS key intake, per-turn resolution, untrusted gating"
 ```
 
@@ -596,17 +660,22 @@ git commit -m "feat(byok): redact API keys from logs"
 **Files:**
 - Create: `client/src/hooks/useApiKey.ts`
 - Create: `client/src/components/ApiKeyGate.tsx`
-- Modify: `client/src/hooks/useWebSocket.ts` (send `set_key` first; surface `needs_key`/`source`)
+- Modify: `client/src/hooks/useWebSocket.ts` (send `set_key` first; surface needs-key + source)
 - Modify: `client/src/pages/chat.tsx` (mount `ApiKeyGate`; show source badge)
+
+**GROUND TRUTH — WS frames (match Task 5 / `protocol.py`):**
+- Send first: `{"type":"set_key","key": <string|null>}`.
+- "Needs key" arrives as an **error frame**: `{"type":"error","code":"NEEDS_KEY","message":"..."}` — react to `code === "NEEDS_KEY"`, NOT a `needs_key` type.
+- Key source arrives as `{"type":"key_source","source":"byok"|"server"}` at the start of each turn.
+- Check `client/src/types/` for the existing WS message TS union and extend it with `key_source` + the `code` field / `set_key` request so the client stays type-safe.
 
 **Interfaces:**
 - `useApiKey()` → `{ key: string | null, setKey, clearKey, validate }`. Holds the key in React state **only** (never `localStorage`/`sessionStorage`). `validate(key)` calls `POST /api/validate-key`.
-- WS contract (matches Task 5): first frame `{"type":"set_key","key": <string|null>}`; the client reacts to a `{"type":"needs_key"}` frame by opening the gate, and reads `source` from the turn's first frame to render a "your key / server" badge.
 
 - [ ] **Step 1:** Implement `useApiKey.ts` — state + `validate` (fetch `/api/validate-key`). Key lives only in memory; a full page reload clears it (acceptable per per-session design).
-- [ ] **Step 2:** Implement `ApiKeyGate.tsx` — a form (paste key → Validate → on success call `setKey`). If `key` is null and the server sent `needs_key`, block the composer and show the form inline. Show a "clear key" control when a key is set.
-- [ ] **Step 3:** In `useWebSocket.ts`, on `onopen` send `{"type":"set_key","key": <current key or null>}` before any message; expose `needs_key` and `source` to consumers.
-- [ ] **Step 4:** In `chat.tsx`, mount `ApiKeyGate`; render a small badge from `source` ("Using your key" / "Using server key"). On a `needs_key` frame, reveal the gate.
+- [ ] **Step 2:** Implement `ApiKeyGate.tsx` — a form (paste key → Validate → on success call `setKey`). If `key` is null and the server sent a `NEEDS_KEY` error, block the composer and show the form inline. Show a "clear key" control when a key is set.
+- [ ] **Step 3:** In `useWebSocket.ts`, on `onopen` send `{"type":"set_key","key": <current key or null>}` before any message; expose a `needsKey` boolean (set on a `code === "NEEDS_KEY"` error frame) and the latest `source` to consumers. Extend the TS message types in `client/src/types/`.
+- [ ] **Step 4:** In `chat.tsx`, mount `ApiKeyGate`; render a small badge from `source` ("Using your key" / "Using server key"). On `needsKey`, reveal the gate.
 - [ ] **Step 5:** Manual verification — run the client, connect without a key as a non-phenome user → composer blocked, gate shown; paste a valid key → chat works, badge reads "Using your key". Commit.
 
 ```bash
@@ -642,6 +711,6 @@ git commit -m "docs(byok): document ddharmon env-var key convention"
 - §7 testing: precedence (T1), concurrency (T4), scrub (T7), validation (T6), e2e (T5+T8 manual). ✓
 - §8 ddharmon → Task 9. ✓
 
-**Placeholder scan:** No TBD/TODO. Two verify-before-implement notes are explicit and bounded: `models.py` error-frame shape (Task 5 Step 3) and SDK `env` merge-vs-replace (Task 3 — mitigated by only overriding the credential). Acceptable.
+**Placeholder scan:** No TBD/TODO. The WS-protocol shape (Task 5) is now pinned to verified ground truth (`user_message`/`set_key`, `ErrorMessage(code="NEEDS_KEY")`, `KeySourceMessage`). One bounded verify-before-implement note remains: SDK `env` merge-vs-replace (Task 3 — mitigated by only overriding the credential). Acceptable.
 
 **Type consistency:** `current_api_key`, `resolve_effective_key(byok_key, verified_email) -> (key, source)`, `is_trusted_email`, `NeedsKeyError`, `get_verified_email(user_info) -> str | None`, `build_agent_options()`, `_probe_anthropic_key(key) -> (bool, str|None)`, `ApiKeyRedactionFilter` — names used consistently across tasks. ✓

--- a/docs/plans/2026-07-11-byok-per-session-kraken.md
+++ b/docs/plans/2026-07-11-byok-per-session-kraken.md
@@ -1,0 +1,647 @@
+# BYOK Per-Session (kraken) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let untrusted users run kraken's LLM synthesis on their own Anthropic key (per-session, never persisted), while verified `phenomehealth.org` users transparently fall back to the server key.
+
+**Architecture:** A single backend chokepoint (`byok.py`) resolves the effective Anthropic key per request and publishes it on a `ContextVar`. Both LLM paths — the classic single-agent (`agent.py`) and the LangGraph pipeline nodes (`sdk_utils.create_agent_options`) — read that contextvar and inject it into `ClaudeAgentOptions(env=...)` (SDK 0.1.31 supports a per-call `env` override, verified), plus the LangChain `ChatAnthropic` client. The key travels over the existing WebSocket as the first message, lives only in a per-connection dict (mirroring `conversation_history`), and dies on disconnect. No DB, no encryption, no `os.environ` mutation.
+
+**Tech Stack:** Python 3 (uv), FastAPI + WebSockets, `claude_agent_sdk` 0.1.31, LangChain/LangGraph, PyJWT + Clerk JWKS/Backend API, pytest; React/TS client (Vite).
+
+## Global Constraints
+
+- **Never mutate `os.environ`** to set a per-request key — concurrent sessions would race. Inject via `ClaudeAgentOptions(env=...)` and `ChatAnthropic(api_key=...)` only.
+- **Key is never persisted** — no DB, no file, no browser `localStorage`/`sessionStorage`. In-memory only (per-connection dict server-side; React state client-side).
+- **Key never appears in logs or Langfuse traces.** Redaction is a required, tested deliverable (Task 7).
+- **Server-key fallback requires a *verified* email** from Clerk, resolved server-side — never a client-asserted or unverified field (Task 2).
+- **Trusted domain list is config-driven:** new setting `byok_trusted_email_domains`, deployed as `["phenomehealth.org"]`. This is distinct from the existing `clerk_allowed_email_domains` (app access gate).
+- SDK version pinned at **0.1.31**; `ClaudeAgentOptions` fields available: `model`, `fallback_model`, `env`.
+- Anthropic is the only BYOK provider; OpenAI/embeddings run server-side through Kestrel and are out of scope.
+
+---
+
+### Task 1: BYOK core — contextvar, resolution, config
+
+**Files:**
+- Create: `backend/src/kestrel_backend/byok.py`
+- Modify: `backend/src/kestrel_backend/config.py` (add settings)
+- Test: `backend/tests/test_byok.py`
+
+**Interfaces:**
+- Produces:
+  - `current_api_key: ContextVar[str | None]` — the *resolved effective* key for the active request (default `None`).
+  - `class NeedsKeyError(Exception)` — raised when an untrusted user has no BYOK key.
+  - `resolve_effective_key(byok_key: str | None, verified_email: str | None) -> tuple[str, str]` — returns `(key, source)` where `source` ∈ `{"byok", "server"}`.
+  - `is_trusted_email(verified_email: str | None) -> bool`
+- Consumes: `config.get_settings()` → `byok_trusted_email_domains: list[str]`, `server_anthropic_api_key: str | None`.
+
+- [ ] **Step 1: Add settings.** In `config.py`, inside `class Settings(BaseModel)`, add:
+
+```python
+    # BYOK: domains whose verified users ride the SERVER key; everyone else must BYOK.
+    byok_trusted_email_domains: list[str] = []
+    # The Anthropic key used only for the trusted server-key fallback.
+    server_anthropic_api_key: str | None = None
+```
+
+- [ ] **Step 2: Write failing tests** in `backend/tests/test_byok.py`:
+
+```python
+import pytest
+from kestrel_backend import byok
+from kestrel_backend.config import Settings, get_settings
+
+
+@pytest.fixture(autouse=True)
+def _settings(monkeypatch):
+    s = Settings(byok_trusted_email_domains=["phenomehealth.org"],
+                 server_anthropic_api_key="sk-server")
+    monkeypatch.setattr(byok, "get_settings", lambda: s)
+
+
+def test_byok_key_wins_even_for_trusted_user():
+    key, source = byok.resolve_effective_key("sk-user", "trent@phenomehealth.org")
+    assert (key, source) == ("sk-user", "byok")
+
+
+def test_trusted_user_no_byok_uses_server_key():
+    key, source = byok.resolve_effective_key(None, "trent@phenomehealth.org")
+    assert (key, source) == ("sk-server", "server")
+
+
+def test_untrusted_no_byok_raises():
+    with pytest.raises(byok.NeedsKeyError):
+        byok.resolve_effective_key(None, "someone@gmail.com")
+
+
+def test_no_verified_email_is_untrusted():
+    with pytest.raises(byok.NeedsKeyError):
+        byok.resolve_effective_key(None, None)
+
+
+def test_domain_match_is_case_insensitive_exact_suffix():
+    assert byok.is_trusted_email("A@Phenomehealth.org") is True
+    assert byok.is_trusted_email("x@evil-phenomehealth.org") is False
+    assert byok.is_trusted_email("x@phenomehealth.org.evil.com") is False
+```
+
+- [ ] **Step 3: Run tests, verify they fail.** Run: `cd backend && .venv/bin/pytest tests/test_byok.py -v` — Expected: FAIL (module/attrs missing).
+
+- [ ] **Step 4: Implement `byok.py`:**
+
+```python
+"""Per-session BYOK key resolution. No persistence, no os.environ mutation."""
+from contextvars import ContextVar
+from .config import get_settings
+
+# The resolved effective key for the active request (byok or server). Option
+# builders in agent.py and sdk_utils.py read this; nodes never do precedence logic.
+current_api_key: ContextVar[str | None] = ContextVar("current_api_key", default=None)
+
+
+class NeedsKeyError(Exception):
+    """Untrusted user made an LLM request without providing a BYOK key."""
+
+
+def is_trusted_email(verified_email: str | None) -> bool:
+    if not verified_email or "@" not in verified_email:
+        return False
+    domain = verified_email.rsplit("@", 1)[-1].lower()
+    trusted = {d.lower() for d in get_settings().byok_trusted_email_domains}
+    return domain in trusted
+
+
+def resolve_effective_key(byok_key: str | None, verified_email: str | None) -> tuple[str, str]:
+    if byok_key:
+        return byok_key, "byok"
+    if is_trusted_email(verified_email):
+        server_key = get_settings().server_anthropic_api_key
+        if not server_key:
+            raise NeedsKeyError("Trusted user but no server key configured.")
+        return server_key, "server"
+    raise NeedsKeyError("No API key provided and user is not trusted.")
+```
+
+- [ ] **Step 5: Run tests, verify they pass.** Run: `.venv/bin/pytest tests/test_byok.py -v` — Expected: PASS (5 tests).
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add backend/src/kestrel_backend/byok.py backend/src/kestrel_backend/config.py backend/tests/test_byok.py
+git commit -m "feat(byok): key resolution chokepoint + trusted-domain config"
+```
+
+---
+
+### Task 2: Server-side verified-email resolution via Clerk Backend API
+
+**Files:**
+- Create: `backend/src/kestrel_backend/clerk_identity.py`
+- Test: `backend/tests/test_clerk_identity.py`
+
+**Interfaces:**
+- Produces: `async def get_verified_email(user_info: dict) -> str | None` — returns the user's **verified primary** email, or `None`. Reads `user_info["sub"]`, calls Clerk Backend API `GET https://api.clerk.com/v1/users/{sub}` with `Authorization: Bearer <clerk_secret_key>`, returns the primary email only if its verification status is `"verified"`. Result cached per `sub`.
+- Consumes: `config.get_settings()` → `clerk_secret_key`; `httpx` (already a dependency via clerk_proxy).
+
+**Why this task exists:** `clerk_auth.py` documents that session JWTs often omit email and currently *allows* access when it can't check — safe for a UI gate, unsafe for spending the server key. The server-key fallback must confirm a verified email itself.
+
+- [ ] **Step 1: Write failing test** in `backend/tests/test_clerk_identity.py`:
+
+```python
+import pytest
+from kestrel_backend import clerk_identity as ci
+from kestrel_backend.config import Settings
+
+
+class _Resp:
+    def __init__(self, payload): self._p = payload; self.status_code = 200
+    def raise_for_status(self): pass
+    def json(self): return self._p
+
+
+@pytest.fixture(autouse=True)
+def _settings(monkeypatch):
+    monkeypatch.setattr(ci, "get_settings", lambda: Settings(clerk_secret_key="sk_test"))
+    ci._email_cache.clear()
+
+
+@pytest.mark.asyncio
+async def test_returns_verified_primary_email(monkeypatch):
+    payload = {
+        "primary_email_address_id": "idb- 1",
+        "email_addresses": [
+            {"id": "idb- 1", "email_address": "trent@phenomehealth.org",
+             "verification": {"status": "verified"}},
+        ],
+    }
+    async def fake_get(*a, **k): return _Resp(payload)
+    monkeypatch.setattr(ci, "_clerk_get", fake_get)
+    assert await ci.get_verified_email({"sub": "user_1"}) == "trent@phenomehealth.org"
+
+
+@pytest.mark.asyncio
+async def test_unverified_primary_returns_none(monkeypatch):
+    payload = {
+        "primary_email_address_id": "e1",
+        "email_addresses": [
+            {"id": "e1", "email_address": "x@phenomehealth.org",
+             "verification": {"status": "unverified"}},
+        ],
+    }
+    async def fake_get(*a, **k): return _Resp(payload)
+    monkeypatch.setattr(ci, "_clerk_get", fake_get)
+    assert await ci.get_verified_email({"sub": "user_2"}) is None
+
+
+@pytest.mark.asyncio
+async def test_missing_sub_returns_none():
+    assert await ci.get_verified_email({}) is None
+```
+
+- [ ] **Step 2: Run test, verify it fails.** Run: `.venv/bin/pytest tests/test_clerk_identity.py -v` — Expected: FAIL (module missing).
+
+- [ ] **Step 3: Implement `clerk_identity.py`:**
+
+```python
+"""Resolve a user's verified primary email via the Clerk Backend API."""
+import logging
+import httpx
+from .config import get_settings
+
+logger = logging.getLogger(__name__)
+_email_cache: dict[str, str | None] = {}  # sub -> verified email or None
+
+
+async def _clerk_get(url: str, headers: dict) -> httpx.Response:
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        return await client.get(url, headers=headers)
+
+
+async def get_verified_email(user_info: dict) -> str | None:
+    sub = user_info.get("sub")
+    if not sub:
+        return None
+    if sub in _email_cache:
+        return _email_cache[sub]
+
+    secret = get_settings().clerk_secret_key
+    if not secret:
+        _email_cache[sub] = None
+        return None
+
+    try:
+        resp = await _clerk_get(
+            f"https://api.clerk.com/v1/users/{sub}",
+            {"Authorization": f"Bearer {secret}"},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception:  # never let identity lookup break a request
+        logger.warning("Clerk user lookup failed for sub=%s", sub)
+        return None  # not cached: allow retry on a transient failure
+
+    primary_id = data.get("primary_email_address_id")
+    email = None
+    for addr in data.get("email_addresses", []):
+        if addr.get("id") == primary_id and \
+           addr.get("verification", {}).get("status") == "verified":
+            email = addr.get("email_address")
+            break
+    _email_cache[sub] = email
+    return email
+```
+
+- [ ] **Step 4: Run tests, verify they pass.** Run: `.venv/bin/pytest tests/test_clerk_identity.py -v` — Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add backend/src/kestrel_backend/clerk_identity.py backend/tests/test_clerk_identity.py
+git commit -m "feat(byok): server-side verified-email resolution via Clerk Backend API"
+```
+
+---
+
+### Task 3: Inject the effective key into classic mode (SDK + LangChain)
+
+**Files:**
+- Modify: `backend/src/kestrel_backend/agent.py:394-411` (options_kwargs build)
+- Modify: `backend/src/kestrel_backend/local_tools.py:~43` (ChatAnthropic construction)
+- Test: `backend/tests/test_byok_injection_classic.py`
+
+**Interfaces:**
+- Consumes: `byok.current_api_key` (ContextVar from Task 1).
+- Produces: classic-mode `ClaudeAgentOptions` carries `env={"ANTHROPIC_API_KEY": <effective key>}`; LangChain `ChatAnthropic` receives `api_key=<effective key>`.
+
+- [ ] **Step 1: Write failing test** in `backend/tests/test_byok_injection_classic.py`:
+
+```python
+from kestrel_backend import agent, byok
+
+
+def test_classic_options_inject_contextvar_key(monkeypatch):
+    captured = {}
+    class FakeOptions:
+        def __init__(self, **kw): captured.update(kw)
+    monkeypatch.setattr(agent, "ClaudeAgentOptions", FakeOptions)
+    token = byok.current_api_key.set("sk-abc")
+    try:
+        agent.build_agent_options()   # extracted builder (see Step 3)
+    finally:
+        byok.current_api_key.reset(token)
+    assert captured["env"]["ANTHROPIC_API_KEY"] == "sk-abc"
+```
+
+- [ ] **Step 2: Run test, verify it fails.** Run: `.venv/bin/pytest tests/test_byok_injection_classic.py -v` — Expected: FAIL (`build_agent_options` not defined).
+
+- [ ] **Step 3: Extract + inject in `agent.py`.** Extract the `options_kwargs` dict (lines ~394-409) into a module-level `build_agent_options()` that the turn loop calls, and add the env injection before `ClaudeAgentOptions(**options_kwargs)`:
+
+```python
+from .byok import current_api_key
+
+def build_agent_options():
+    kestrel_config = _get_kestrel_mcp_config()
+    options_kwargs = {
+        "allowed_tools": list(ALLOWED_TOOLS),
+        "system_prompt": SYSTEM_PROMPT,
+        "mcp_servers": {"kestrel": kestrel_config},
+        "hooks": {"PreToolUse": [HookMatcher(matcher="Bash", hooks=[bash_security_hook])]},
+        "max_buffer_size": 10 * 1024 * 1024,
+    }
+    settings = get_settings()
+    if settings.model:
+        options_kwargs["model"] = settings.model
+    key = current_api_key.get()
+    if key:
+        # env is MERGED over the inherited process environment by the SDK, so we
+        # only override the credential and leave PATH/etc. intact.
+        options_kwargs["env"] = {"ANTHROPIC_API_KEY": key}
+    return ClaudeAgentOptions(**options_kwargs)
+```
+
+Replace the inline `options = ClaudeAgentOptions(**options_kwargs)` at line ~411 with `options = build_agent_options()`.
+
+- [ ] **Step 4: Inject into LangChain** in `local_tools.py`. At the `ChatAnthropic(model="claude-sonnet-4-20250514", ...)` construction, add `api_key=current_api_key.get()` (import `from .byok import current_api_key` at top). When the contextvar is `None` the SDK/LangChain falls back to ambient env — acceptable for non-request-scoped internal callers.
+
+- [ ] **Step 5: Run test, verify it passes.** Run: `.venv/bin/pytest tests/test_byok_injection_classic.py -v` — Expected: PASS.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add backend/src/kestrel_backend/agent.py backend/src/kestrel_backend/local_tools.py backend/tests/test_byok_injection_classic.py
+git commit -m "feat(byok): inject effective key into classic SDK + LangChain paths"
+```
+
+---
+
+### Task 4: Inject the effective key into pipeline nodes
+
+**Files:**
+- Modify: `backend/src/kestrel_backend/graph/sdk_utils.py:207-221` (`create_agent_options`)
+- Test: `backend/tests/test_byok_injection_pipeline.py`
+
+**Interfaces:**
+- Consumes: `byok.current_api_key`.
+- Produces: every pipeline node's `ClaudeAgentOptions` carries `env={"ANTHROPIC_API_KEY": <effective key>}`. No node signatures change — the contextvar is read centrally in `create_agent_options`, which all nodes already call.
+
+- [ ] **Step 1: Write failing test** in `backend/tests/test_byok_injection_pipeline.py`:
+
+```python
+from kestrel_backend.graph import sdk_utils
+from kestrel_backend import byok
+
+
+def test_pipeline_options_inject_contextvar_key(monkeypatch):
+    captured = {}
+    class FakeOptions:
+        def __init__(self, **kw): captured.update(kw)
+    monkeypatch.setattr(sdk_utils, "ClaudeAgentOptions", FakeOptions)
+    monkeypatch.setattr(sdk_utils, "HAS_SDK", True)
+    token = byok.current_api_key.set("sk-node")
+    try:
+        sdk_utils.create_agent_options(system_prompt="x")
+    finally:
+        byok.current_api_key.reset(token)
+    assert captured["env"]["ANTHROPIC_API_KEY"] == "sk-node"
+```
+
+- [ ] **Step 2: Run test, verify it fails.** Run: `.venv/bin/pytest tests/test_byok_injection_pipeline.py -v` — Expected: FAIL (no `env` in kwargs).
+
+- [ ] **Step 3: Inject in `create_agent_options`.** Add at top of `sdk_utils.py`: `from ..byok import current_api_key`. Inside `create_agent_options`, before `return ClaudeAgentOptions(**kwargs)`:
+
+```python
+    key = current_api_key.get()
+    if key:
+        kwargs["env"] = {"ANTHROPIC_API_KEY": key}
+```
+
+- [ ] **Step 4: Run test, verify it passes.** Run: `.venv/bin/pytest tests/test_byok_injection_pipeline.py -v` — Expected: PASS.
+
+- [ ] **Step 5: Concurrency test** — two contextvar values in two tasks must not bleed. Append to the same test file:
+
+```python
+import asyncio, pytest
+
+@pytest.mark.asyncio
+async def test_no_cross_task_key_bleed(monkeypatch):
+    seen = []
+    class FakeOptions:
+        def __init__(self, **kw): seen.append(kw.get("env", {}).get("ANTHROPIC_API_KEY"))
+    monkeypatch.setattr(sdk_utils, "ClaudeAgentOptions", FakeOptions)
+    monkeypatch.setattr(sdk_utils, "HAS_SDK", True)
+
+    async def run(k):
+        byok.current_api_key.set(k)          # set inside the task's own context
+        await asyncio.sleep(0.01)
+        sdk_utils.create_agent_options(system_prompt="x")
+
+    await asyncio.gather(run("sk-A"), run("sk-B"))
+    assert set(seen) == {"sk-A", "sk-B"}     # each task kept its own key
+```
+
+- [ ] **Step 6: Run it, verify PASS**, then commit.
+
+```bash
+.venv/bin/pytest tests/test_byok_injection_pipeline.py -v
+git add backend/src/kestrel_backend/graph/sdk_utils.py backend/tests/test_byok_injection_pipeline.py
+git commit -m "feat(byok): inject effective key into pipeline nodes + concurrency guard"
+```
+
+---
+
+### Task 5: Wire the WebSocket handler — receive key, resolve, gate
+
+**Files:**
+- Modify: `backend/src/kestrel_backend/main.py` (`websocket_chat` ~777, message loop, `handle_classic_mode`/`handle_pipeline_mode` call sites)
+- Test: `backend/tests/test_ws_byok_wiring.py`
+
+**Interfaces:**
+- Consumes: `byok.resolve_effective_key`, `byok.current_api_key`, `byok.NeedsKeyError`, `clerk_identity.get_verified_email`.
+- Message contract: client's **first WS message** after connect is `{"type": "set_key", "key": "sk-..."}` (or `{"type": "set_key", "key": null}` to declare no key). Stored in a new per-connection dict `connection_api_keys: dict[str, str | None]`, cleaned up alongside `conversation_history` on disconnect.
+- Per turn, before invoking a handler: resolve `(key, source)` and set `current_api_key`; on `NeedsKeyError` send an error frame and skip the turn.
+
+- [ ] **Step 1: Write failing test** in `backend/tests/test_ws_byok_wiring.py` using `fastapi.testclient.TestClient` websocket. Assert: (a) an untrusted connection that sends `set_key` with `null` then a chat message receives a `needs_key` error frame and no synthesis runs; (b) a connection that sends a real key sets `current_api_key` (spy on `resolve_effective_key`). Mock `validate_ws_clerk_token` to return `{"sub": "u1"}` and `get_verified_email` to return `None` (untrusted) / a phenome email (trusted).
+
+```python
+from unittest.mock import AsyncMock, patch
+from fastapi.testclient import TestClient
+from kestrel_backend.main import app
+
+
+def test_untrusted_no_key_is_gated():
+    with patch("kestrel_backend.main.validate_ws_clerk_token",
+               AsyncMock(return_value={"sub": "u1"})), \
+         patch("kestrel_backend.main.get_verified_email",
+               AsyncMock(return_value=None)):
+        client = TestClient(app)
+        with client.websocket_connect("/ws/chat?token=x") as ws:
+            ws.send_json({"type": "set_key", "key": None})
+            ws.send_json({"type": "message", "content": "hi", "mode": "classic"})
+            frames = [ws.receive_json() for _ in range(1)]
+            assert any(f.get("type") == "needs_key" for f in frames)
+```
+
+- [ ] **Step 2: Run test, verify it fails.** Run: `.venv/bin/pytest tests/test_ws_byok_wiring.py -v` — Expected: FAIL.
+
+- [ ] **Step 3: Implement.** In `main.py`:
+  - Add `connection_api_keys: dict[str, str | None] = {}` near the other per-connection dicts (~line 94-103).
+  - In `websocket_chat`, capture `user_info` from `validate_ws_clerk_token`, keep it in scope.
+  - In the message loop, handle `set_key` frames: `connection_api_keys[connection_id] = data.get("key")`.
+  - Before dispatching to `handle_classic_mode` / `handle_pipeline_mode`, add:
+
+```python
+    from .byok import resolve_effective_key, current_api_key, NeedsKeyError
+    from .clerk_identity import get_verified_email
+    try:
+        verified = await get_verified_email(user_info)
+        key, source = resolve_effective_key(connection_api_keys.get(connection_id), verified)
+    except NeedsKeyError:
+        await websocket.send_text(ErrorMessage(
+            type="needs_key",
+            error="Provide your Anthropic API key to run synthesis.").model_dump_json())
+        continue
+    tok = current_api_key.set(key)
+    try:
+        # existing dispatch to handle_classic_mode / handle_pipeline_mode
+        ...
+    finally:
+        current_api_key.reset(tok)
+```
+  - In the disconnect/cleanup block, `connection_api_keys.pop(connection_id, None)`.
+  - If `ErrorMessage` lacks a `type` field for `needs_key`, add the literal to the model in `models.py` (or reuse the existing error frame and set a dedicated field). Verify against `models.py` before implementing.
+
+- [ ] **Step 4: Run test, verify it passes.** Run: `.venv/bin/pytest tests/test_ws_byok_wiring.py -v` — Expected: PASS. Send the `source` ("byok"/"server") to the client in the turn's first frame so the UI can show "whose key" (Task 8).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add backend/src/kestrel_backend/main.py backend/src/kestrel_backend/models.py backend/tests/test_ws_byok_wiring.py
+git commit -m "feat(byok): WS key intake, per-turn resolution, untrusted gating"
+```
+
+---
+
+### Task 6: Pre-flight key validation endpoint
+
+**Files:**
+- Modify: `backend/src/kestrel_backend/main.py` (new REST route)
+- Test: `backend/tests/test_validate_key.py`
+
+**Interfaces:**
+- Produces: `POST /api/validate-key` body `{"key": "sk-..."}` → `200 {"valid": true}` or `200 {"valid": false, "reason": "..."}`. Validation = one minimal Anthropic call (a 1-token `messages.create`) using the submitted key, nothing stored.
+
+- [ ] **Step 1: Write failing test** in `backend/tests/test_validate_key.py`:
+
+```python
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+from kestrel_backend.main import app
+
+
+def test_validate_key_ok():
+    with patch("kestrel_backend.main._probe_anthropic_key", return_value=(True, None)):
+        r = TestClient(app).post("/api/validate-key", json={"key": "sk-good"})
+        assert r.status_code == 200 and r.json()["valid"] is True
+
+
+def test_validate_key_bad():
+    with patch("kestrel_backend.main._probe_anthropic_key",
+               return_value=(False, "invalid_api_key")):
+        r = TestClient(app).post("/api/validate-key", json={"key": "sk-bad"})
+        assert r.json() == {"valid": False, "reason": "invalid_api_key"}
+```
+
+- [ ] **Step 2: Run test, verify it fails.** Run: `.venv/bin/pytest tests/test_validate_key.py -v` — Expected: FAIL.
+
+- [ ] **Step 3: Implement** `_probe_anthropic_key(key: str) -> tuple[bool, str | None]` (uses the `anthropic` SDK: `Anthropic(api_key=key).messages.create(model="claude-3-5-haiku-latest", max_tokens=1, messages=[{"role":"user","content":"hi"}])`; return `(False, "invalid_api_key")` on `anthropic.AuthenticationError`, `(True, None)` on success) and the route:
+
+```python
+@app.post("/api/validate-key")
+async def validate_key(request: Request):
+    body = await request.json()
+    ok, reason = _probe_anthropic_key(body.get("key", ""))
+    return {"valid": ok} if ok else {"valid": False, "reason": reason}
+```
+
+- [ ] **Step 4: Run tests, verify they pass**, then commit.
+
+```bash
+.venv/bin/pytest tests/test_validate_key.py -v
+git add backend/src/kestrel_backend/main.py backend/tests/test_validate_key.py
+git commit -m "feat(byok): pre-flight key validation endpoint"
+```
+
+---
+
+### Task 7: Redact the key from logs and Langfuse traces
+
+**Files:**
+- Modify: `backend/src/kestrel_backend/logging_config.py` (add a redaction filter)
+- Test: `backend/tests/test_key_redaction.py`
+
+**Interfaces:**
+- Produces: a `logging.Filter` that masks anything matching `sk-ant-[A-Za-z0-9_-]+` (and a generic `sk-[A-Za-z0-9_-]{16,}`) as `sk-***REDACTED***` on every log record, installed on the root handler. Langfuse: confirm no trace `input`/`metadata` carries the key (the injection sites in Tasks 3-4 put the key only in `env`, never in prompts/metadata) and add a regression test asserting a crafted record is masked.
+
+- [ ] **Step 1: Write failing test** in `backend/tests/test_key_redaction.py`:
+
+```python
+import logging
+from kestrel_backend.logging_config import ApiKeyRedactionFilter
+
+
+def test_filter_masks_anthropic_key():
+    f = ApiKeyRedactionFilter()
+    rec = logging.LogRecord("x", logging.INFO, "f", 1,
+                            "using key sk-ant-abc123DEF456ghi789", None, None)
+    f.filter(rec)
+    assert "sk-ant-abc123DEF456ghi789" not in rec.getMessage()
+    assert "REDACTED" in rec.getMessage()
+```
+
+- [ ] **Step 2: Run test, verify it fails.** Run: `.venv/bin/pytest tests/test_key_redaction.py -v` — Expected: FAIL (filter missing).
+
+- [ ] **Step 3: Implement `ApiKeyRedactionFilter`** in `logging_config.py`:
+
+```python
+import re
+_KEY_RE = re.compile(r"sk-(?:ant-)?[A-Za-z0-9_-]{16,}")
+
+class ApiKeyRedactionFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        if isinstance(record.msg, str):
+            record.msg = _KEY_RE.sub("sk-***REDACTED***", record.msg)
+        if record.args:
+            record.args = tuple(
+                _KEY_RE.sub("sk-***REDACTED***", a) if isinstance(a, str) else a
+                for a in record.args
+            )
+        return True
+```
+
+Install it wherever handlers are configured in `logging_config.py` (add `handler.addFilter(ApiKeyRedactionFilter())` to each configured handler).
+
+- [ ] **Step 4: Run test, verify it passes.** Run: `.venv/bin/pytest tests/test_key_redaction.py -v` — Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add backend/src/kestrel_backend/logging_config.py backend/tests/test_key_redaction.py
+git commit -m "feat(byok): redact API keys from logs"
+```
+
+---
+
+### Task 8: Frontend — key entry, WS wiring, source indicator
+
+**Files:**
+- Create: `client/src/hooks/useApiKey.ts`
+- Create: `client/src/components/ApiKeyGate.tsx`
+- Modify: `client/src/hooks/useWebSocket.ts` (send `set_key` first; surface `needs_key`/`source`)
+- Modify: `client/src/pages/chat.tsx` (mount `ApiKeyGate`; show source badge)
+
+**Interfaces:**
+- `useApiKey()` → `{ key: string | null, setKey, clearKey, validate }`. Holds the key in React state **only** (never `localStorage`/`sessionStorage`). `validate(key)` calls `POST /api/validate-key`.
+- WS contract (matches Task 5): first frame `{"type":"set_key","key": <string|null>}`; the client reacts to a `{"type":"needs_key"}` frame by opening the gate, and reads `source` from the turn's first frame to render a "your key / server" badge.
+
+- [ ] **Step 1:** Implement `useApiKey.ts` — state + `validate` (fetch `/api/validate-key`). Key lives only in memory; a full page reload clears it (acceptable per per-session design).
+- [ ] **Step 2:** Implement `ApiKeyGate.tsx` — a form (paste key → Validate → on success call `setKey`). If `key` is null and the server sent `needs_key`, block the composer and show the form inline. Show a "clear key" control when a key is set.
+- [ ] **Step 3:** In `useWebSocket.ts`, on `onopen` send `{"type":"set_key","key": <current key or null>}` before any message; expose `needs_key` and `source` to consumers.
+- [ ] **Step 4:** In `chat.tsx`, mount `ApiKeyGate`; render a small badge from `source` ("Using your key" / "Using server key"). On a `needs_key` frame, reveal the gate.
+- [ ] **Step 5:** Manual verification — run the client, connect without a key as a non-phenome user → composer blocked, gate shown; paste a valid key → chat works, badge reads "Using your key". Commit.
+
+```bash
+git add client/src/hooks/useApiKey.ts client/src/components/ApiKeyGate.tsx client/src/hooks/useWebSocket.ts client/src/pages/chat.tsx
+git commit -m "feat(byok): frontend key entry, WS wiring, source badge"
+```
+
+---
+
+### Task 9: ddharmon env-var note
+
+**Files:**
+- Modify: `ddharmon/README.md` (or `ddharmon/docs/`)
+
+- [ ] **Step 1:** Add a short "API key" section: ddharmon reads `ANTHROPIC_API_KEY` from the caller-supplied environment/config; there is no settings UI or session handling — the caller (a human, a script, or a host app) is responsible for setting it. Commit.
+
+```bash
+git add ddharmon/README.md
+git commit -m "docs(byok): document ddharmon env-var key convention"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §3 decisions 1-6 → Tasks 1 (resolution+config), 2 (verified email = decision 6), 5 (gating/fallback = decision 5). ✓
+- §4.1 chokepoint → Task 1. ✓
+- §4.2 SDK + LangChain injection → Tasks 3 (classic) + 4 (pipeline). ✓
+- §4.3 reusable boundary → `byok.py` + `clerk_identity.py` are app-agnostic; injection sites are the app-specific adapters. (EITL port is a separate future plan.) ✓
+- §5 security: no browser storage → Task 8; Langfuse/log scrub → Task 7; TLS/TTL → per-connection lifetime (dies on disconnect), TLS is deployment. ✓
+- §6 validation + error UX + "whose key" indicator → Tasks 6, 5, 8. ✓
+- §7 testing: precedence (T1), concurrency (T4), scrub (T7), validation (T6), e2e (T5+T8 manual). ✓
+- §8 ddharmon → Task 9. ✓
+
+**Placeholder scan:** No TBD/TODO. Two verify-before-implement notes are explicit and bounded: `models.py` error-frame shape (Task 5 Step 3) and SDK `env` merge-vs-replace (Task 3 — mitigated by only overriding the credential). Acceptable.
+
+**Type consistency:** `current_api_key`, `resolve_effective_key(byok_key, verified_email) -> (key, source)`, `is_trusted_email`, `NeedsKeyError`, `get_verified_email(user_info) -> str | None`, `build_agent_options()`, `_probe_anthropic_key(key) -> (bool, str|None)`, `ApiKeyRedactionFilter` — names used consistently across tasks. ✓


### PR DESCRIPTION
## Why

Part of a long-term strategy to put LLM-backed tools in public hands: let people other than the Phenome team use kraken without us paying for their inference and without provisioning a key per person. Cost-offload + distribution; no compliance/data-residency driver (which keeps the security bar at "don't be reckless," not "encrypt at rest").

Design spec: `docs/brainstorms/2026-07-11-byok-per-session-requirements.md`
Implementation plan: `docs/plans/2026-07-11-byok-per-session-kraken.md`

## What

Per-session BYOK — no accounts, no DB, no at-rest encryption. A user's Anthropic key is provided over the `/ws/chat` socket, held **only** in an in-memory per-connection dict, and dies with the connection.

- **`byok.py`** — single chokepoint `resolve_effective_key(byok_key, verified_email) -> (key, source)`: user's BYOK key > trusted server-key fallback > **fail closed** (`NEEDS_KEY`, no synthesis).
- **Trusted = verified `phenomehealth.org` email**, resolved server-side via the Clerk Backend API (`clerk_identity.py`) — not a client-asserted field, so it can't be spoofed. Trusted users transparently ride the server key; everyone else must BYOK.
- **Per-request injection via a `ContextVar`** into both LLM paths — classic (`agent.py`) and the pipeline (injected at the SDK boundary in `sdk_utils.query_with_usage` + the `semantic_scholar` direct call). Never mutates `os.environ`, so concurrent sessions can't cross-contaminate (covered by a scheduling-independent isolation test).
- **WS wiring** (`main.py`): `set_key` intake, per-turn resolution, `KeySourceMessage` ("whose key"), unconditional fail-closed gate.
- **`/api/validate-key`** pre-flight check · **log redaction** filter (masks keys in msg + tuple/dict args) · **frontend** `useApiKey` + `ApiKeyGate` + source badge (key in memory only, never `localStorage`).

## Testing

40 BYOK tests green (`resolve` precedence, verified-email resolution, classic + pipeline injection, cross-task no-key-bleed, WS gating, validation, redaction, e2e). Browser E2E is a manual step (script in the branch's task-8 report).

## Notes for review / deploy

- This branch was built subagent-driven with per-task + a final whole-branch review. The final review caught a real one: the pipeline path originally injected into a helper no node calls, so pipeline synthesis silently used the server key regardless of BYOK — **fixed** in the last commit by injecting at the real SDK boundary. Worth a careful look at `sdk_utils.query_with_usage`.
- **Deploy config required:** `BYOK_TRUSTED_EMAIL_DOMAINS=phenomehealth.org`, `SERVER_ANTHROPIC_API_KEY`, `CLERK_SECRET_KEY`, and relax the existing `clerk_allowed_email_domains` sign-in gate so the public can log in and BYOK.
- **Follow-ups (non-blocking):** rate-limit the unauthenticated `/api/validate-key`; `useApiKey.validate()` `res.ok` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)