### PR TITLE
feat(synthesis): Tier-3 falsifier + deterministic direction-awareness (Axis E)

### DIFF
--- a/backend/src/kestrel_backend/graph/nodes/synthesis.py
+++ b/backend/src/kestrel_backend/graph/nodes/synthesis.py
@@ -978,7 +978,11 @@ def render_bridge_specificity(spec: Any) -> str | None:
 
 # --- Post-LLM Direction stamp (Unit 4) ------------------------------------------------
 
-_HEADING_RE = re.compile(r"^#{1,3}\s")
+# Match h1–h6 so a prediction block anchored on ``#### <title>`` (h4, per SYNTHESIS_PROMPT) still
+# bounds the *previous* block's scan. If only h1–h3 counted, a later, non-stampable ``####`` block
+# would not be seen as a boundary and the prior hypothesis's deterministic Direction could be written
+# into it.
+_HEADING_RE = re.compile(r"^#{1,6}\s")
 
 
 def _is_direction_line(line: str) -> bool:
@@ -996,17 +1000,30 @@ def _line_prefix(line: str) -> str:
 def _find_anchor_index(lines: list[str], title: str) -> int | None:
     """Index of the report line that anchors a Tier-3 block for ``title``.
 
-    Prefers a heading (``#…``) or bold (``**title**``) occurrence over an incidental mention (e.g. in
-    the executive summary), falling back to the first line that contains the title at all.
+    Prefers the prediction *heading* (``#### <title>``, per SYNTHESIS_PROMPT) the LLM is instructed to
+    author each block under, so an incidental bold mention in the executive summary (e.g.
+    ``**title** is the lead signal``) never becomes the stamp anchor ahead of the real block. Falls
+    back, in order, to a bold ``**title**``/leading-bold occurrence, then the first line that contains
+    the title at all.
     """
+    heading: int | None = None
+    bold: int | None = None
     fallback: int | None = None
     for i, ln in enumerate(lines):
-        if title in ln:
-            if fallback is None:
-                fallback = i
-            stripped = ln.lstrip()
-            if stripped.startswith("#") or f"**{title}**" in ln or stripped.startswith("**"):
-                return i
+        if title not in ln:
+            continue
+        if fallback is None:
+            fallback = i
+        stripped = ln.lstrip()
+        if stripped.startswith("#"):
+            if heading is None:
+                heading = i
+        elif (f"**{title}**" in ln or stripped.startswith("**")) and bold is None:
+            bold = i
+    if heading is not None:
+        return heading
+    if bold is not None:
+        return bold
     return fallback
 
 

--- a/backend/src/kestrel_backend/graph/nodes/synthesis.py
+++ b/backend/src/kestrel_backend/graph/nodes/synthesis.py
@@ -15,7 +15,9 @@ ground-before-synthesis reorg).
 """
 
 import logging
+import re
 import time
+from dataclasses import dataclass
 from typing import Any
 from ..state import (
     DiscoveryState, EntityResolution, NoveltyScore, Finding,
@@ -58,10 +60,34 @@ Direct evidence from the knowledge graph:
 - Well-characterized entity relationships
 
 ### 3. Novel Predictions (Tier 3)
-Speculative associations requiring validation:
-- Each prediction MUST include the structural logic chain
-- Cite the ~18% validation gap: approximately 18% of computational predictions progress to clinical investigation
-- Prioritize by supporting evidence strength
+
+Speculative associations requiring validation. Author **one prediction block per Tier-3 hypothesis**
+below, and anchor each block on that hypothesis's exact title (use it as the block's heading, e.g.
+`#### <hypothesis title>`, so it can be matched programmatically). Open the section with a single
+**calibration preamble** (do not repeat it per prediction):
+
+> _Calibration: ~18% of computational predictions progress to clinical investigation. Evidence in
+> this analysis is graded — Discovery-1 signals rest on n≈13–15 (suggestive), Discovery-2 includes a
+> null result over 956 draws (solid), and Arivale-derived signals carry wellness-cohort selection
+> caveats. Treat "direction confidence" as an evidence-strength tier, never a probability._
+
+Each prediction block MUST contain these labeled lines (keep them compact):
+
+- **Prediction:** the claim.
+- **Direction:** LEAVE THIS TO THE SYSTEM. A deterministic ↑/↓/indeterminate value is computed from
+  signed module weights and will be **stamped** into your block after you finish — do not invent the
+  arrow. If a "Direction hint" is provided for this hypothesis below, narrate the mechanism consistent
+  with it; if none is provided, omit the line and do not guess a direction.
+- **Falsifier:** the single concrete, measurable observation that would KILL this prediction. It MUST
+  name a measurable observable and a threshold or direction (e.g. "if module eigengene correlation with
+  the trait is ≥ 0 in an independent cohort", "if metabolite X does not decrease by >20% in cases"),
+  and MUST include a null-result example. A restatement of the validation step is NOT a falsifier — a
+  falsifier states what result would refute you, not what experiment to run. (Worked example: the
+  Prevotella-null was strong evidence precisely because its falsifier was prespecified.)
+- **Logic:** the structural reasoning chain (cite [Literature] where grounded abstracts support it).
+- **Validation:** the concrete experiment/analysis to test it (distinct from the Falsifier).
+
+Prioritize blocks by supporting-evidence strength.
 
 ### 4. Biological Themes
 Emergent patterns from pathway enrichment:
@@ -86,7 +112,9 @@ Prioritized next steps:
 ## Critical Rules
 
 1. LEAD WITH NOVEL FINDINGS - Don't bury interesting predictions
-2. Every Tier 3 must have: logic chain + validation step + ~18% calibration note
+2. Every Tier 3 block must carry the labeled lines from §3: Prediction, Direction (system-stamped —
+   do not invent), Falsifier (measurable observable + threshold + null example, NOT a validation
+   restatement), Logic, Validation; the ~18% calibration note renders once as the section preamble
 3. Clearly distinguish KG facts (Tier 1) from inferences (Tier 3)
 4. De-emphasize hub-flagged associations - they may be spurious
 5. Highlight FDR-significant entities if present
@@ -628,17 +656,23 @@ def format_hub_warnings(hub_flags: list[str]) -> str:
 def format_bridges(
     bridges: list[Bridge],
     grounding_labels: dict[tuple[str, ...], str] | None = None,
+    specificity_by_bridge: dict[tuple[str, ...], Any] | None = None,
 ) -> str:
     """Format cross-type bridges discovered during integration analysis.
 
     ``grounding_labels`` maps a bridge's ``tuple(entities)`` to its evidence-provenance chain
     label (from the bridge_grounding node, via ``grounded_bridges``). When present, the label is
     rendered per bridge so the researcher sees what kind of evidence backs each leg.
+
+    ``specificity_by_bridge`` (Axis C, R3) maps ``tuple(entities)`` to a ``BridgeSpecificity``.
+    When present, a ``**Bridge specificity:**`` line is rendered and ``generic`` (high-degree
+    intermediate) bridges are visibly down-weighted. Absent entry -> no line (never fabricated).
     """
     if not bridges:
         return ""
 
     labels = grounding_labels or {}
+    specificity = specificity_by_bridge or {}
 
     # Initialise `lines` BEFORE the _render closure that appends to it: the closure captures it by
     # reference, so defining the list first keeps the dependency obvious and avoids an UnboundLocalError
@@ -665,6 +699,9 @@ def format_bridges(
         label = labels.get(tuple(b.entities))
         if label:
             lines.append(f"  - **Evidence provenance**: {label}")
+        spec_line = render_bridge_specificity(specificity.get(tuple(b.entities)))
+        if spec_line:
+            lines.append(f"  - {spec_line}")
 
     # Separate by tier
     tier2 = [b for b in bridges if b.tier == 2]
@@ -693,6 +730,497 @@ def grounding_labels_from_state(state: DiscoveryState) -> dict[tuple[str, ...], 
         if grounding is not None and getattr(grounding, "label", ""):
             labels[tuple(gb.entities)] = grounding.label
     return labels
+
+
+# =============================================================================
+# Axis E: Tier-3 direction / falsifier contract
+#
+# Two upstream seams are consumed defensively (they ship in axes A and C):
+#   - state["module_spine"]:  dict[group_key -> ModuleSpine] — axis A's signed weights.
+#       ModuleSpine.members: dict[canonical_name -> MemberWeight(kme, kim)];
+#       ModuleSpine.direction: ModuleDirection(eigengene_trait_correlation).
+#   - state["specificity_by_bridge"]: dict[tuple(entities) -> BridgeSpecificity] — axis C.
+#       BridgeSpecificity(score, label, intermediate_curies, intermediate_degrees, generic_intermediates).
+# Both are read via _seam_get so E works whether they arrive as pydantic models, SimpleNamespaces,
+# or plain dicts, and degrades to omission/`indeterminate` when a seam is absent (never fabricates).
+# =============================================================================
+
+
+def _seam_get(obj: Any, key: str, default: Any = None) -> Any:
+    """Attribute/key access that works across pydantic models, namespaces, and dicts.
+
+    The axis-A/C seams are produced by other axes and may reach synthesis as any of those shapes;
+    reading them defensively keeps E's degradation contract (absent seam -> omit) honest.
+    """
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _normalize_name(name: str | None) -> str:
+    """Canonicalize an entity name for the axis-A join (mirror axis A's strip().lower() key)."""
+    return (name or "").strip().lower()
+
+
+def _sign(x: float | None) -> int:
+    """Return -1/0/+1; 0 for None or exactly zero (an unusable sign)."""
+    if x is None:
+        return 0
+    if x > 0:
+        return 1
+    if x < 0:
+        return -1
+    return 0
+
+
+@dataclass(frozen=True)
+class DirectionResult:
+    """Deterministic direction verdict for one Tier-3 hypothesis (Axis E, R2/R5).
+
+    - ``direction``: ``"up"`` | ``"down"`` | ``"indeterminate"``.
+    - ``confidence``: capped evidence-strength tier (``"high"``/``"moderate"``/``"low"``) for a
+      determinate direction; ``None`` when indeterminate. Never a probability.
+    - ``computable``: a resolvable *signed* axis-A record existed (kME present AND a module→outcome
+      direction present) — the honest, LLM-independent coverage signal. True even when signs conflict.
+    - ``seam_present``: ``module_spine`` was present on state at all. When False the Direction line is
+      *omitted* (kept dark) rather than printed as ``indeterminate`` on every prediction.
+    """
+
+    direction: str
+    confidence: str | None
+    computable: bool
+    seam_present: bool
+
+
+_DIRECTION_ARROW = {"up": "↑", "down": "↓"}
+
+
+def _direction_records(
+    hypothesis: Hypothesis, state: DiscoveryState
+) -> list[tuple[float | None, float | None, float | None]] | None:
+    """Join a hypothesis to axis-A signed records: list of ``(kme, kim, eigengene_trait_corr)``.
+
+    Returns ``None`` when the ``module_spine`` seam is entirely absent (distinct from an empty list,
+    which means "seam present but this hypothesis matched no weighted member"). Join chain:
+    ``supporting_entities`` (CURIE) -> ``resolved_entities`` (CURIE -> canonical/raw name) ->
+    ``module_spine[*].members`` (keyed by canonical name), aggregating across every module the
+    member appears in.
+    """
+    module_spine = state.get("module_spine")
+    if not module_spine:
+        return None
+
+    resolved = state.get("resolved_entities", []) or []
+    name_by_curie: dict[str, str] = {}
+    for e in resolved:
+        curie = getattr(e, "curie", None)
+        if not curie:
+            continue
+        # raw_name is the upload/panel name that axis A canonicalizes as the member key; fall back
+        # to resolved_name only when raw_name is missing.
+        name_by_curie[curie] = getattr(e, "raw_name", None) or getattr(e, "resolved_name", None) or ""
+
+    target_names: set[str] = set()
+    for curie in getattr(hypothesis, "supporting_entities", []) or []:
+        nm = name_by_curie.get(curie)
+        if nm:
+            target_names.add(_normalize_name(nm))
+    if not target_names:
+        return []
+
+    records: list[tuple[float | None, float | None, float | None]] = []
+    for _group_key, spine in module_spine.items():
+        members = _seam_get(spine, "members", {}) or {}
+        direction = _seam_get(spine, "direction", None)
+        corr = _seam_get(direction, "eigengene_trait_correlation", None) if direction is not None else None
+        for mname, mw in members.items():
+            if _normalize_name(mname) in target_names:
+                records.append((_seam_get(mw, "kme", None), _seam_get(mw, "kim", None), corr))
+    return records
+
+
+def _confidence_tier(
+    max_abs_kme: float, kim_ok: bool, derivation_n: int | None, cfg: Any
+) -> str:
+    """Coarse evidence-strength tier for a determinate direction, with two conservative caps."""
+    if max_abs_kme >= cfg.direction_high_abs_kme:
+        tier = "high"
+    elif max_abs_kme >= cfg.direction_moderate_abs_kme:
+        tier = "moderate"
+    else:
+        tier = "low"
+    # kIM floor: a weakly-connected member cannot anchor top confidence (low-n kME caveat).
+    if tier == "high" and not kim_ok:
+        tier = "moderate"
+    # Small-n cap: small-sample |kME| inflation cannot reach the top tier.
+    if tier == "high" and derivation_n is not None and derivation_n < cfg.direction_small_n_cap:
+        tier = "moderate"
+    return tier
+
+
+def compute_tier3_direction(
+    hypothesis: Hypothesis,
+    state: DiscoveryState,
+    cfg: Any,
+    derivation_n: int | None = None,
+) -> DirectionResult:
+    """Deterministically compute a Tier-3 hypothesis's direction from axis-A signed weights (R2/R5).
+
+    ``sign = sign(kME) x sign(eigengene->trait correlation)`` per contributing (member, module)
+    record; a single coherent sign -> ``up``/``down``; conflicting signs -> ``indeterminate`` (never
+    a silently-picked sign); no signed record -> ``indeterminate``; seam absent -> ``indeterminate``
+    with ``seam_present=False`` so the caller omits the line entirely.
+    """
+    records = _direction_records(hypothesis, state)
+    if records is None:
+        return DirectionResult("indeterminate", None, computable=False, seam_present=False)
+
+    signs: set[int] = set()
+    abs_kmes: list[float] = []
+    kim_ok = True
+    for kme, kim, corr in records:
+        s_kme = _sign(kme)
+        if s_kme == 0:
+            continue  # no usable kME magnitude/sign
+        s_corr = _sign(corr)
+        if s_corr == 0:
+            continue  # no module->outcome direction -> this record is not signable
+        signs.add(s_kme * s_corr)
+        abs_kmes.append(abs(kme))
+        if kim is not None and cfg.direction_kim_floor > 0 and kim < cfg.direction_kim_floor:
+            kim_ok = False
+
+    if not signs:
+        # Seam present, but no record could be signed (missing kME or missing module direction).
+        return DirectionResult("indeterminate", None, computable=False, seam_present=True)
+    if len(signs) > 1:
+        # Genuine sign conflict across the hypothesis's members: honest indeterminate, still computable.
+        return DirectionResult("indeterminate", None, computable=True, seam_present=True)
+
+    sign = next(iter(signs))
+    direction = "up" if sign > 0 else "down"
+    confidence = _confidence_tier(max(abs_kmes), kim_ok, derivation_n, cfg)
+    return DirectionResult(direction, confidence, computable=True, seam_present=True)
+
+
+def render_direction_value(result: DirectionResult) -> str | None:
+    """Render the ``**Direction:**`` line value, or ``None`` when the line must be omitted.
+
+    Omission (``None``) is reserved for a wholly-absent axis-A seam; ``indeterminate`` is a
+    first-class rendered value meaning "seam present, this prediction's sign is absent/conflicting".
+    """
+    if not result.seam_present:
+        return None
+    if result.direction == "indeterminate":
+        return "indeterminate"
+    return f"{_DIRECTION_ARROW[result.direction]} (confidence: {result.confidence})"
+
+
+def tier3_direction_map(state: DiscoveryState, cfg: Any) -> dict[str, DirectionResult]:
+    """Compute ``{hypothesis.title -> DirectionResult}`` for every Tier-3 hypothesis in state.
+
+    The title is the anchor the LLM is instructed to author each prediction block under (Unit 3),
+    and the key the post-LLM stamp (Unit 4) matches on. Later titles win on a collision.
+    """
+    out: dict[str, DirectionResult] = {}
+    for h in state.get("hypotheses", []) or []:
+        if getattr(h, "tier", None) != 3:
+            continue
+        out[h.title] = compute_tier3_direction(h, state, cfg)
+    return out
+
+
+def specificity_by_bridge_from_state(
+    state: DiscoveryState,
+) -> dict[tuple[str, ...], Any]:
+    """Build a ``{tuple(entities) -> BridgeSpecificity}`` map from axis C's state side-map (R3).
+
+    Mirrors ``grounding_labels_from_state``: specificity lives in a side-map keyed by the bridge's
+    entity tuple, NOT on the frozen ``Bridge`` (which E commits not to extend). Keys may arrive as
+    lists or tuples; both normalize to a tuple. Absent seam -> empty map (specificity line omitted).
+    """
+    raw = state.get("specificity_by_bridge") or {}
+    out: dict[tuple[str, ...], Any] = {}
+    try:
+        for key, spec in raw.items():
+            out[tuple(key)] = spec
+    except (AttributeError, TypeError):
+        logger.warning("specificity_by_bridge is not a mapping; ignoring", exc_info=True)
+        return {}
+    return out
+
+
+def render_bridge_specificity(spec: Any) -> str | None:
+    """Render the ``**Bridge specificity:**`` line for one bridge, or ``None`` to omit it (R3).
+
+    ``generic`` bridges are structurally down-weighted and name their ``generic_intermediates`` —
+    framed as *genericity* (a high-degree pass-through node connects to everything), NOT as low
+    mechanism confidence (prior work: per-bridge confidence is not tractable). Absent label -> omit.
+    """
+    if spec is None:
+        return None
+    label = _seam_get(spec, "label", None)
+    if not label:
+        return None
+    if label == "generic":
+        generic = _seam_get(spec, "generic_intermediates", []) or []
+        if generic:
+            joined = ", ".join(f"`{g}`" for g in generic)
+            return (
+                f"**Bridge specificity**: generic — routes through high-degree intermediate(s) "
+                f"{joined}; structurally generic (a hub connects to nearly everything), down-weight"
+            )
+        return "**Bridge specificity**: generic — structurally generic (high-degree intermediate), down-weight"
+    return f"**Bridge specificity**: {label}"
+
+
+# --- Post-LLM Direction stamp (Unit 4) ------------------------------------------------
+
+_HEADING_RE = re.compile(r"^#{1,3}\s")
+
+
+def _is_direction_line(line: str) -> bool:
+    """True if ``line`` is a ``**Direction:**`` line, tolerant of bullet/bold/italic variants."""
+    s = re.sub(r"^[-*]\s+", "", line.strip()).replace("**", "").replace("__", "")
+    return s.lower().startswith("direction:")
+
+
+def _line_prefix(line: str) -> str:
+    """The leading indentation + optional bullet marker, preserved when rewriting a line."""
+    m = re.match(r"^(\s*(?:[-*]\s+)?)", line)
+    return m.group(1) if m else ""
+
+
+def _find_anchor_index(lines: list[str], title: str) -> int | None:
+    """Index of the report line that anchors a Tier-3 block for ``title``.
+
+    Prefers a heading (``#…``) or bold (``**title**``) occurrence over an incidental mention (e.g. in
+    the executive summary), falling back to the first line that contains the title at all.
+    """
+    fallback: int | None = None
+    for i, ln in enumerate(lines):
+        if title in ln:
+            if fallback is None:
+                fallback = i
+            stripped = ln.lstrip()
+            if stripped.startswith("#") or f"**{title}**" in ln or stripped.startswith("**"):
+                return i
+    return fallback
+
+
+def stamp_directions(report: str, direction_map: dict[str, DirectionResult]) -> str:
+    """Overwrite/insert the authoritative ``**Direction:**`` value in each Tier-3 block (R2, Unit 4).
+
+    This is what makes the direction value synthesis-owned rather than an LLM prompt-hope: whatever
+    arrow the LLM wrote (or omitted) is replaced by the deterministic value. Blocks whose axis-A seam
+    is absent get no line (``render_direction_value`` -> ``None``). Title anchors that cannot be found
+    are logged and skipped; other blocks are still stamped. Callers wrap this best-effort so a stamp
+    failure never blanks the report.
+    """
+    if not report or not direction_map:
+        return report
+    stampable = {
+        title: val
+        for title, res in direction_map.items()
+        if title and (val := render_direction_value(res)) is not None
+    }
+    if not stampable:
+        return report
+
+    lines = report.split("\n")
+    anchors: dict[str, int] = {}
+    for title in stampable:
+        idx = _find_anchor_index(lines, title)
+        if idx is None:
+            logger.warning(
+                "synthesis direction stamp: no block anchor found for Tier-3 hypothesis %r", title
+            )
+            continue
+        anchors[title] = idx
+    if not anchors:
+        return report
+
+    anchor_set = set(anchors.values())
+
+    def _block_end(anchor: int) -> int:
+        for j in range(anchor + 1, len(lines)):
+            if j in anchor_set or _HEADING_RE.match(lines[j]):
+                return j
+        return len(lines)
+
+    ops: list[tuple[str, int, str]] = []  # (kind, index, text)
+    for title, anchor in anchors.items():
+        value = stampable[title]
+        end = _block_end(anchor)
+        replaced = False
+        for j in range(anchor + 1, end):
+            if _is_direction_line(lines[j]):
+                ops.append(("replace", j, f"{_line_prefix(lines[j])}**Direction:** {value}"))
+                replaced = True
+                break
+        if not replaced:
+            ops.append(("insert", anchor + 1, f"**Direction:** {value}"))
+
+    # Apply bottom-up so earlier indices stay valid across insertions.
+    for kind, idx, text in sorted(ops, key=lambda o: o[1], reverse=True):
+        if kind == "replace":
+            lines[idx] = text
+        else:
+            lines.insert(idx, text)
+    return "\n".join(lines)
+
+
+# --- Fallback-path Tier-3 direction section (R6) --------------------------------------
+
+
+def format_fallback_tier3_directions(state: DiscoveryState, cfg: Any) -> str:
+    """Render a deterministic Tier-3 direction section for the fallback report (R6).
+
+    The fallback path has no LLM to author per-hypothesis prediction blocks, so it would otherwise
+    silently drop Direction entirely (the historical fallback-omission regression class). This renders
+    ``**Direction:**`` per Tier-3 hypothesis directly from state via the same helper. Seam-gated:
+    empty when ``module_spine`` is absent. Falsifiers are LLM-authored and stay absent here (R6:
+    ``falsifier_rendered`` is honestly 0 on this path).
+    """
+    dmap = tier3_direction_map(state, cfg)
+    if not dmap:
+        return ""
+    rendered = [(t, v) for t, r in dmap.items() if (v := render_direction_value(r)) is not None]
+    if not rendered:
+        return ""
+    lines = [
+        "## Tier-3 Prediction Directions\n",
+        "*Deterministic direction (sign of kME × module→outcome correlation) per speculative "
+        "prediction. Direction confidence is an evidence-strength tier, not a probability; all "
+        "predictions require validation. (Falsifiers are authored during LLM synthesis and are "
+        "absent on this deterministic fallback path.)*\n",
+    ]
+    for title, value in rendered:
+        lines.append(f"### {title}")
+        lines.append(f"**Direction:** {value}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+# --- Tier-3 prediction telemetry (Unit 5) ---------------------------------------------
+
+_FALSIFIER_OBSERVABLE_RE = re.compile(
+    r"\d|>|<|≥|≤|increase|decreas|higher|lower|above|below|threshold|null|absent|"
+    r"no change|fails to|does not|reduc|elevat|correlat",
+    re.IGNORECASE,
+)
+
+
+def _is_falsifier_line(line: str) -> bool:
+    s = re.sub(r"^[-*]\s+", "", line.strip()).replace("**", "").replace("__", "")
+    return s.lower().startswith("falsifier:")
+
+
+def _falsifier_content(line: str) -> str:
+    s = re.sub(r"^[-*]\s+", "", line.strip()).replace("**", "").replace("__", "")
+    return s[len("falsifier:"):].strip() if s.lower().startswith("falsifier:") else ""
+
+
+def _count_direction_lines(report: str) -> int:
+    return sum(1 for ln in report.split("\n") if _is_direction_line(ln))
+
+
+def _count_wellformed_falsifiers(report: str) -> int:
+    """Count ``**Falsifier:**`` lines that name a measurable observable + threshold/direction.
+
+    A bare label, an empty line, or a mere restatement of the validation step (no observable, no
+    threshold word/number) is NOT counted. This is a COMPLIANCE (format) signal, explicitly not a
+    proof of genuine falsifiability.
+    """
+    count = 0
+    for ln in report.split("\n"):
+        if _is_falsifier_line(ln):
+            content = _falsifier_content(ln)
+            if len(content) >= 15 and _FALSIFIER_OBSERVABLE_RE.search(content):
+                count += 1
+    return count
+
+
+def _compute_tier3_stats(state: DiscoveryState, report: str, cfg: Any) -> dict[str, Any]:
+    """Split Tier-3 telemetry: a DETERMINISTIC coverage metric vs COMPLIANCE marker counts (R4).
+
+    ``direction_computable_pct`` is a pure function of state (resolvable signed axis-A records) and is
+    the honest measure of R2 — it is NOT affected by whether the LLM emitted any marker. The
+    ``*_rendered_pct`` are regexes over the report text, explicitly labeled compliance so they are
+    never read as "predictions are now falsifiable/directional".
+    """
+    tier3 = [h for h in state.get("hypotheses", []) or [] if getattr(h, "tier", None) == 3]
+    total = len(tier3)
+
+    computable = 0
+    indeterminate = 0
+    seam_present = False
+    for h in tier3:
+        res = compute_tier3_direction(h, state, cfg)
+        seam_present = seam_present or res.seam_present
+        if res.computable:
+            computable += 1
+        if res.seam_present and res.direction == "indeterminate":
+            indeterminate += 1
+
+    direction_rendered = _count_direction_lines(report)
+    falsifier_rendered = _count_wellformed_falsifiers(report)
+
+    def _pct(n: int) -> float:
+        return round(n / total * 100, 1) if total else 0.0
+
+    return {
+        "total_tier3": total,  # base rate (premise note) — makes the DIRECTION-not-hit-rate assumption checkable
+        "seam_present": seam_present,
+        # DETERMINISTIC (from state; LLM-independent):
+        "direction_computable": computable,
+        "direction_computable_pct": _pct(computable),
+        "indeterminate_direction": indeterminate,
+        # COMPLIANCE (regex over the report; marker emission, NOT proof of the property):
+        "direction_rendered": direction_rendered,
+        "direction_rendered_pct": _pct(direction_rendered),
+        "falsifier_rendered": falsifier_rendered,
+        "falsifier_rendered_pct": _pct(falsifier_rendered),
+        "metric_kind": {
+            "direction_computable_pct": "deterministic",
+            "direction_rendered_pct": "compliance",
+            "falsifier_rendered_pct": "compliance",
+        },
+    }
+
+
+def format_direction_hints(state: DiscoveryState, cfg: Any) -> str:
+    """Inject a per-Tier-3-hypothesis direction hint block (Axis E, Unit 3).
+
+    Emits ``{title -> ↑/↓/indeterminate (confidence)}`` for every Tier-3 hypothesis, so the LLM can
+    anchor each prediction block on the title and narrate a mechanism consistent with the computed
+    sign. Returns ``""`` when the axis-A seam is absent (seam-gating: no hints, and the prompt then
+    omits the Direction line) so a seam-less run does not read as ``indeterminate`` everywhere.
+    """
+    dmap = tier3_direction_map(state, cfg)
+    if not dmap:
+        return ""
+    rendered: list[tuple[str, str]] = []
+    for title, res in dmap.items():
+        val = render_direction_value(res)
+        if val is None:
+            continue  # seam absent -> omit hints entirely
+        rendered.append((title, val))
+    if not rendered:
+        return ""
+    lines = [
+        "## Tier-3 Direction Hints (system-computed — narrate, do not override)\n",
+        "_Each Tier-3 prediction has a deterministic direction computed from signed module weights "
+        "(kME x module→outcome correlation). Anchor your prediction block on the exact title and "
+        "narrate a mechanism consistent with the hint; the value itself is stamped into the report "
+        "automatically. 'indeterminate' means the sign is absent or conflicting — say so honestly._\n",
+    ]
+    for title, val in rendered:
+        lines.append(f"- **{title}** → Direction: {val}")
+    lines.append("")
+    return "\n".join(lines)
 
 
 def format_gap_entities(gaps: list[GapEntity]) -> str:
@@ -1069,7 +1597,9 @@ def assemble_synthesis_context(state: DiscoveryState, stats_out: dict | None = N
     
     # Cross-type bridges
     bridges = state.get("bridges", [])
-    bridges_section = format_bridges(bridges, grounding_labels_from_state(state))
+    bridges_section = format_bridges(
+        bridges, grounding_labels_from_state(state), specificity_by_bridge_from_state(state)
+    )
     if bridges_section:
         sections.append(bridges_section)
     
@@ -1108,6 +1638,12 @@ def assemble_synthesis_context(state: DiscoveryState, stats_out: dict | None = N
     literature_section = format_literature_evidence(hypotheses)
     if literature_section:
         sections.append(literature_section)
+
+    # Tier-3 direction hints (Axis E): deterministic ↑/↓/indeterminate per Tier-3 hypothesis, so the
+    # LLM narrates a mechanism consistent with the sign. Seam-gated (empty when module_spine absent).
+    direction_hints = format_direction_hints(state, cfg)
+    if direction_hints:
+        sections.append(direction_hints)
 
     context = "\n".join(sections)
 
@@ -1195,7 +1731,9 @@ def fallback_report(state: DiscoveryState) -> str:
         report_lines.append(enrichment_section)
 
     # Cross-type bridges - Phase 4b
-    bridges_section = format_bridges(bridges, grounding_labels_from_state(state))
+    bridges_section = format_bridges(
+        bridges, grounding_labels_from_state(state), specificity_by_bridge_from_state(state)
+    )
     if bridges_section:
         report_lines.append(bridges_section)
 
@@ -1217,6 +1755,13 @@ def fallback_report(state: DiscoveryState) -> str:
     inference_section = format_inferred_associations(inferred_associations, analogues_found)
     if inference_section:
         report_lines.append(inference_section)
+
+    # Tier-3 deterministic directions (R6): the fallback path has no LLM, so it renders Direction per
+    # Tier-3 hypothesis directly from state (seam-gated). Keeps Direction from silently vanishing when
+    # synthesis degrades to the deterministic report.
+    fallback_directions = format_fallback_tier3_directions(state, cfg)
+    if fallback_directions:
+        report_lines.append(fallback_directions)
 
     # Analysis findings (summary from both branches) — capped per tier (dominant section)
     findings_section = format_findings_summary(
@@ -1365,6 +1910,22 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
     # literature_grounding; read them from state.
     hypotheses = state.get("hypotheses", [])
 
+    # Axis E Unit 4: stamp the authoritative deterministic Tier-3 direction into the report — on BOTH
+    # the SDK and fallback paths, before the references table — overwriting any arrow the LLM wrote.
+    # Best-effort: a stamp failure must never blank the report (mirrors synthesis_context_stats).
+    cfg = get_pipeline_config().synthesis
+    try:
+        report = stamp_directions(report, tier3_direction_map(state, cfg))
+    except Exception:  # noqa: BLE001 — stamping is best-effort, never break the report
+        logger.warning("synthesis direction stamp failed; returning unstamped report", exc_info=True)
+
+    # Axis E Unit 5: Tier-3 prediction telemetry (deterministic coverage vs compliance markers).
+    tier3_stats: dict[str, Any] = {}
+    try:
+        tier3_stats = _compute_tier3_stats(state, report, cfg)
+    except Exception:  # noqa: BLE001 — telemetry is best-effort, never break the node
+        logger.warning("tier3_prediction_stats computation failed", exc_info=True)
+
     # R6: synthesis owns the references table now (grounding stopped appending it in Unit 3).
     # Append it AFTER the SDK/fallback convergence point so BOTH the LLM-success path and the
     # fallback_report path emit it — the fallback omission was the highest-risk silent regression.
@@ -1388,6 +1949,9 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
     # Context-compression telemetry (plan 004) — single-writer plain field, last-write-wins.
     if context_stats:
         result["synthesis_context_stats"] = context_stats
+    # Tier-3 prediction telemetry (Axis E) — single-writer plain field, last-write-wins.
+    if tier3_stats:
+        result["tier3_prediction_stats"] = tier3_stats
     # errors uses an operator.add reducer; only emit on a degraded fallback (Unit 7).
     if fallback_marker:
         result["errors"] = [fallback_marker]

--- a/backend/src/kestrel_backend/graph/pipeline_config.py
+++ b/backend/src/kestrel_backend/graph/pipeline_config.py
@@ -387,6 +387,43 @@ class SynthesisConfig(BaseModel):
         "prevent reaching it. Tune downward if R7 shows headroom is tight.",
     )
 
+    # --- Tier-3 direction / falsifier contract (Axis E) ---------------------------------
+    # Deterministic direction (sign) label for Tier-3 predictions, computed from axis A's signed
+    # module weights (`module_spine`) and stamped into the report post-LLM. Coarse banding now;
+    # refine once axis A's real kME distribution is observable (plan Deferred-to-Implementation).
+    direction_high_abs_kme: float = Field(
+        default=0.7,
+        ge=0.0,
+        le=1.0,
+        description="Minimum |kME| for a Tier-3 direction to render the 'high' confidence tier. "
+        "kME is a WGCNA module-membership correlation in [-1, 1]; a high magnitude means the member "
+        "sits near the module eigengene. Coarse default; tune against axis A's real distribution.",
+    )
+    direction_moderate_abs_kme: float = Field(
+        default=0.4,
+        ge=0.0,
+        le=1.0,
+        description="Minimum |kME| for the 'moderate' direction confidence tier; below this the tier "
+        "is 'low'. Must be <= direction_high_abs_kme.",
+    )
+    direction_kim_floor: float = Field(
+        default=0.0,
+        ge=0.0,
+        description="Intramodular-connectivity (kIM) floor. When > 0 and a contributing member's kIM "
+        "is present and below this floor, the confidence tier is capped one step below 'high' (a "
+        "weakly-connected member cannot anchor top confidence — the low-n kME caveat). Default 0 "
+        "disables the cap until axis A's kIM values are observable.",
+    )
+    direction_small_n_cap: int = Field(
+        default=15,
+        ge=1,
+        description="Derivation-cohort size below which a Tier-3 direction cannot reach the 'high' "
+        "confidence tier (small-sample |kME| inflation crowns weakly-supported members — validation "
+        "memo low-n kME caveat). Applied only when a per-module derivation n is supplied to the "
+        "direction helper; axis A does not yet emit cohort n, so the cap is exercised via unit tests "
+        "and ready when that field lands.",
+    )
+
 
 class PipelineConfig(BaseModel):
     """Top-level pipeline configuration with per-node sub-models.

--- a/backend/src/kestrel_backend/graph/state.py
+++ b/backend/src/kestrel_backend/graph/state.py
@@ -483,3 +483,8 @@ class DiscoveryState(TypedDict, total=False):
     # Context-compression telemetry emitted by synthesis (shown/total/elided per capped section +
     # budget utilization). Single-writer (synthesis only) → plain field, last-write-wins; no reducer.
     synthesis_context_stats: dict
+    # Tier-3 prediction telemetry emitted by synthesis (Axis E): a DETERMINISTIC coverage metric
+    # (direction_computable_pct, from state) kept explicitly separate from COMPLIANCE metrics
+    # (direction_rendered_pct / falsifier_rendered_pct, regex over the report). Single-writer
+    # (synthesis only) → plain field, last-write-wins; no reducer.
+    tier3_prediction_stats: dict

--- a/backend/tests/test_langgraph_prototype.py
+++ b/backend/tests/test_langgraph_prototype.py
@@ -2420,12 +2420,15 @@ class TestSynthesisReportOnly:
     async def test_return_is_report_only(self):
         """Return dict carries no `hypotheses` or `bridges` keys (owned upstream now).
 
-        synthesis_context_stats (plan 004) is a legitimate synthesis-owned output and is present
-        whenever the context was assembled (it always is); hypotheses/bridges remain excluded.
+        synthesis_context_stats (plan 004) and tier3_prediction_stats (Axis E) are legitimate
+        synthesis-owned telemetry outputs, present whenever the node runs; hypotheses/bridges
+        remain excluded (produced/owned upstream).
         """
         with patch.object(synthesis, "HAS_SDK", False):
             result = await synthesis.run(self._grounded_state())
-        assert set(result.keys()) == {"synthesis_report", "model_usages", "synthesis_context_stats"}
+        assert set(result.keys()) == {
+            "synthesis_report", "model_usages", "synthesis_context_stats", "tier3_prediction_stats",
+        }
         assert "hypotheses" not in result
         assert "bridges" not in result
 

--- a/backend/tests/test_synthesis_bridges.py
+++ b/backend/tests/test_synthesis_bridges.py
@@ -1,0 +1,94 @@
+"""Axis E Unit 2: bridge-specificity rendering (consume axis-C `specificity_by_bridge`).
+
+Plan: docs/plans/2026-07-16-001-feat-tier3-falsifier-direction-awareness-plan.md
+
+Specificity lives in a state side-map keyed by `tuple(entities)` (mirroring grounded_bridges), NOT
+on the frozen Bridge. `generic` bridges are down-weighted and name their generic intermediates,
+framed as genericity — never as low mechanism confidence. Absent entry ⇒ the line is omitted and the
+bridge section stays byte-identical to today.
+"""
+
+from types import SimpleNamespace
+
+from kestrel_backend.graph.nodes.synthesis import (
+    format_bridges,
+    render_bridge_specificity,
+    specificity_by_bridge_from_state,
+)
+from kestrel_backend.graph.state import Bridge
+
+
+def _bridge(entities, tier=2):
+    return Bridge(
+        path_description="A → B → C", entities=entities, entity_names=[], predicates=["p1", "p2"],
+        tier=tier, novelty="inferred", significance="matters",
+    )
+
+
+def _spec(label, generic_intermediates=None):
+    return SimpleNamespace(
+        score=0.5, label=label, intermediate_curies=["CHEBI:1"],
+        intermediate_degrees=[42], generic_intermediates=generic_intermediates or [],
+    )
+
+
+# --- render_bridge_specificity --------------------------------------------------------
+
+
+def test_specific_and_moderate_render_plain_label():
+    assert render_bridge_specificity(_spec("specific")) == "**Bridge specificity**: specific"
+    assert render_bridge_specificity(_spec("moderate")) == "**Bridge specificity**: moderate"
+
+
+def test_generic_is_downweighted_and_names_intermediates():
+    line = render_bridge_specificity(_spec("generic", generic_intermediates=["CHEBI:9999"]))
+    assert "generic" in line
+    assert "CHEBI:9999" in line
+    assert "down-weight" in line
+    assert "low confidence" not in line.lower()  # framed as genericity, not low mechanism confidence
+
+
+def test_generic_without_named_intermediates_still_renders_generic():
+    line = render_bridge_specificity(_spec("generic", generic_intermediates=[]))
+    assert line.startswith("**Bridge specificity**: generic")
+
+
+def test_absent_or_labelless_spec_omits_line():
+    assert render_bridge_specificity(None) is None
+    assert render_bridge_specificity(_spec("")) is None
+
+
+# --- specificity_by_bridge_from_state -------------------------------------------------
+
+
+def test_reader_normalizes_list_keys_to_tuples():
+    state = {"specificity_by_bridge": {("A", "B", "C"): _spec("specific")}}
+    m = specificity_by_bridge_from_state(state)
+    assert ("A", "B", "C") in m
+
+
+def test_reader_absent_seam_is_empty():
+    assert specificity_by_bridge_from_state({}) == {}
+
+
+def test_reader_bad_shape_is_empty_not_crash():
+    assert specificity_by_bridge_from_state({"specificity_by_bridge": "not-a-map"}) == {}
+
+
+# --- format_bridges integration -------------------------------------------------------
+
+
+def test_format_bridges_renders_specificity_when_present():
+    bridges = [_bridge(["A", "B", "C"], tier=2)]
+    spec_map = {("A", "B", "C"): _spec("generic", generic_intermediates=["CHEBI:9999"])}
+    out = format_bridges(bridges, None, spec_map)
+    assert "Bridge specificity" in out
+    assert "CHEBI:9999" in out
+
+
+def test_format_bridges_identical_without_specificity():
+    bridges = [_bridge(["A", "B", "C"], tier=2)]
+    without = format_bridges(bridges)
+    with_absent = format_bridges(bridges, None, {("X", "Y"): _spec("specific")})  # no matching key
+    assert without == with_absent
+    assert "Bridge specificity" not in without

--- a/backend/tests/test_synthesis_direction.py
+++ b/backend/tests/test_synthesis_direction.py
@@ -1,0 +1,183 @@
+"""Axis E Unit 1: deterministic Tier-3 direction helper + entity→weight join + small-n cap.
+
+Plan: docs/plans/2026-07-16-001-feat-tier3-falsifier-direction-awareness-plan.md
+
+The helper joins a Tier-3 hypothesis to axis A's signed module weights (`module_spine`) and computes
+a deterministic ↑/↓/indeterminate label with a capped confidence tier. It reads the seam defensively
+(seam absent ⇒ omit; present-but-conflicting ⇒ `indeterminate`) and never silently picks a sign.
+The `module_spine` seam is built here from SimpleNamespaces to prove E does not depend on axis A's
+concrete pydantic models.
+"""
+
+from types import SimpleNamespace
+
+from kestrel_backend.graph.nodes.synthesis import (
+    DirectionResult,
+    compute_tier3_direction,
+    render_direction_value,
+    tier3_direction_map,
+)
+from kestrel_backend.graph.pipeline_config import SynthesisConfig
+from kestrel_backend.graph.state import EntityResolution, Hypothesis
+
+
+# --- seam + fixture builders ----------------------------------------------------------
+
+
+def _member(kme, kim=None):
+    return SimpleNamespace(kme=kme, kim=kim)
+
+
+def _spine(members, corr=None):
+    """Axis-A ModuleSpine shape: members keyed by canonical (lowercased) name, optional direction."""
+    direction = SimpleNamespace(eigengene_trait_correlation=corr) if corr is not None else None
+    return SimpleNamespace(members=members, direction=direction)
+
+
+def _entity(curie, name):
+    return EntityResolution(
+        raw_name=name, curie=curie, resolved_name=name, category="biolink:Gene",
+        confidence=0.9, method="exact",
+    )
+
+
+def _hyp(title, curies, tier=3):
+    return Hypothesis(
+        title=title, tier=tier, claim="c", supporting_entities=curies,
+        structural_logic="logic", validation_steps=["step"],
+    )
+
+
+def _cfg(**kw):
+    return SynthesisConfig(**kw)
+
+
+def _state(module_spine=None, resolved=None):
+    st = {"resolved_entities": resolved or [_entity("NCBIGene:1", "GeneX")]}
+    if module_spine is not None:
+        st["module_spine"] = module_spine
+    return st
+
+
+# --- happy paths ----------------------------------------------------------------------
+
+
+def test_kme_pos_direction_pos_is_up():
+    state = _state({"modA": _spine({"genex": _member(0.8)}, corr=0.5)})
+    res = compute_tier3_direction(_hyp("H", ["NCBIGene:1"]), state, _cfg())
+    assert res.direction == "up"
+    assert res.computable is True and res.seam_present is True
+    assert render_direction_value(res) == "↑ (confidence: high)"
+
+
+def test_kme_pos_direction_neg_is_down():
+    state = _state({"modA": _spine({"genex": _member(0.8)}, corr=-0.5)})
+    res = compute_tier3_direction(_hyp("H", ["NCBIGene:1"]), state, _cfg())
+    assert res.direction == "down"
+    assert render_direction_value(res).startswith("↓")
+
+
+def test_kme_neg_direction_pos_is_down():
+    state = _state({"modA": _spine({"genex": _member(-0.8)}, corr=0.5)})
+    assert compute_tier3_direction(_hyp("H", ["NCBIGene:1"]), state, _cfg()).direction == "down"
+
+
+# --- indeterminate / seam-gating ------------------------------------------------------
+
+
+def test_missing_outcome_direction_is_indeterminate():
+    # module present, member present, but no eigengene→trait correlation ⇒ unsignable
+    state = _state({"modA": _spine({"genex": _member(0.8)}, corr=None)})
+    res = compute_tier3_direction(_hyp("H", ["NCBIGene:1"]), state, _cfg())
+    assert res.direction == "indeterminate"
+    assert res.computable is False and res.seam_present is True
+    assert render_direction_value(res) == "indeterminate"
+
+
+def test_seam_absent_is_indeterminate_and_omitted():
+    res = compute_tier3_direction(_hyp("H", ["NCBIGene:1"]), _state(module_spine=None), _cfg())
+    assert res.direction == "indeterminate"
+    assert res.seam_present is False and res.computable is False
+    assert render_direction_value(res) is None  # line omitted entirely
+
+
+def test_empty_module_spine_is_seam_absent():
+    res = compute_tier3_direction(_hyp("H", ["NCBIGene:1"]), _state({}), _cfg())
+    assert res.seam_present is False
+    assert render_direction_value(res) is None
+
+
+def test_conflicting_signs_is_indeterminate_but_computable():
+    # same entity weighted in two oppositely-signed modules ⇒ never a silently-picked sign
+    state = _state({
+        "modA": _spine({"genex": _member(0.8)}, corr=0.5),   # +
+        "modB": _spine({"genex": _member(0.8)}, corr=-0.5),  # -
+    })
+    res = compute_tier3_direction(_hyp("H", ["NCBIGene:1"]), state, _cfg())
+    assert res.direction == "indeterminate"
+    assert res.computable is True  # signed records existed, they just disagree
+
+
+# --- join-rate ------------------------------------------------------------------------
+
+
+def test_join_resolves_records_on_matching_names():
+    state = _state({"modA": _spine({"genex": _member(0.8)}, corr=0.5)})
+    # name normalization: EntityResolution.raw_name "GeneX" → canonical "genex" matches member key
+    assert compute_tier3_direction(_hyp("H", ["NCBIGene:1"]), state, _cfg()).computable is True
+
+
+def test_mismatched_name_space_yields_zero_computable_not_crash():
+    # module_spine present but keyed on a different name ⇒ seam present, no signed record
+    state = _state({"modA": _spine({"someotherprotein": _member(0.8)}, corr=0.5)})
+    res = compute_tier3_direction(_hyp("H", ["NCBIGene:1"]), state, _cfg())
+    assert res.seam_present is True
+    assert res.computable is False
+    assert res.direction == "indeterminate"
+
+
+# --- small-n cap + confidence banding -------------------------------------------------
+
+
+def test_confidence_bands_by_abs_kme():
+    def _tier(kme):
+        state = _state({"modA": _spine({"genex": _member(kme)}, corr=0.5)})
+        return compute_tier3_direction(_hyp("H", ["NCBIGene:1"]), state, _cfg()).confidence
+    assert _tier(0.9) == "high"
+    assert _tier(0.5) == "moderate"
+    assert _tier(0.2) == "low"
+
+
+def test_small_n_caps_high_confidence():
+    state = _state({"modA": _spine({"genex": _member(0.95)}, corr=0.5)})  # |kME| high
+    res = compute_tier3_direction(_hyp("H", ["NCBIGene:1"]), state, _cfg(direction_small_n_cap=15), derivation_n=14)
+    assert res.direction == "up"
+    assert res.confidence == "moderate"  # n=14 < 15 ⇒ cannot reach top tier
+
+
+def test_kim_floor_caps_high_confidence():
+    state = _state({"modA": _spine({"genex": _member(0.95, kim=0.1)}, corr=0.5)})
+    res = compute_tier3_direction(_hyp("H", ["NCBIGene:1"]), state, _cfg(direction_kim_floor=0.5))
+    assert res.confidence == "moderate"  # weakly-connected member cannot anchor top confidence
+
+
+def test_malformed_record_does_not_raise():
+    # member with a None kME and a member missing kme attr ⇒ helper still returns, no exception
+    state = _state({"modA": _spine({"genex": _member(None), "genex2": SimpleNamespace()}, corr=0.5)})
+    res = compute_tier3_direction(_hyp("H", ["NCBIGene:1"]), state, _cfg())
+    assert isinstance(res, DirectionResult)
+    assert res.direction == "indeterminate"
+
+
+# --- tier3_direction_map --------------------------------------------------------------
+
+
+def test_map_covers_only_tier3_keyed_by_title():
+    state = _state({"modA": _spine({"genex": _member(0.8)}, corr=0.5)})
+    state["hypotheses"] = [
+        _hyp("T3", ["NCBIGene:1"], tier=3),
+        _hyp("T1", ["NCBIGene:1"], tier=1),  # excluded
+    ]
+    dmap = tier3_direction_map(state, _cfg())
+    assert set(dmap) == {"T3"}
+    assert dmap["T3"].direction == "up"

--- a/backend/tests/test_synthesis_direction_stamp.py
+++ b/backend/tests/test_synthesis_direction_stamp.py
@@ -1,0 +1,101 @@
+"""Axis E Unit 4: post-LLM Direction stamp (authoritative deterministic value).
+
+Plan: docs/plans/2026-07-16-001-feat-tier3-falsifier-direction-awareness-plan.md
+
+The stamp is what makes the direction value synthesis-owned rather than an LLM prompt-hope: whatever
+arrow the LLM wrote (or omitted) is overwritten by the deterministic value, matched by the
+hypothesis-title anchor. Seam-absent hypotheses get no line. A missing anchor or a raised stamp is
+non-fatal — other blocks are still stamped and the report is never blanked.
+"""
+
+from kestrel_backend.graph.nodes.synthesis import DirectionResult, stamp_directions
+
+
+def _up(conf="high"):
+    return DirectionResult("up", conf, computable=True, seam_present=True)
+
+
+def _down(conf="high"):
+    return DirectionResult("down", conf, computable=True, seam_present=True)
+
+
+def _indeterminate():
+    return DirectionResult("indeterminate", None, computable=False, seam_present=True)
+
+
+def _seam_absent():
+    return DirectionResult("indeterminate", None, computable=False, seam_present=False)
+
+
+# Execution note (plan): start from a report where the LLM wrote the WRONG arrow.
+def test_stamp_overwrites_wrong_llm_arrow():
+    report = (
+        "#### MyPred\n"
+        "**Prediction:** X drives Y\n"
+        "**Direction:** ↑ (confidence: low)\n"
+        "**Logic:** ...\n"
+    )
+    out = stamp_directions(report, {"MyPred": _down("high")})
+    assert "**Direction:** ↓ (confidence: high)" in out
+    assert "↑" not in out  # the wrong arrow is gone
+
+
+def test_stamp_inserts_when_llm_omitted_line():
+    report = "#### MyPred\n**Prediction:** X drives Y\n**Logic:** ...\n"
+    out = stamp_directions(report, {"MyPred": _up("moderate")})
+    lines = out.split("\n")
+    assert "**Direction:** ↑ (confidence: moderate)" in lines
+    # inserted immediately after the anchor heading
+    assert lines[lines.index("#### MyPred") + 1].startswith("**Direction:**")
+
+
+def test_stamp_renders_indeterminate():
+    report = "#### MyPred\n**Prediction:** X\n"
+    out = stamp_directions(report, {"MyPred": _indeterminate()})
+    assert "**Direction:** indeterminate" in out
+
+
+def test_seam_absent_inserts_no_line():
+    report = "#### MyPred\n**Prediction:** X\n"
+    out = stamp_directions(report, {"MyPred": _seam_absent()})
+    assert "Direction:" not in out
+    assert out == report  # untouched
+
+
+def test_missing_anchor_still_stamps_other_blocks():
+    report = "#### RealPred\n**Prediction:** X\n"
+    out = stamp_directions(report, {"Ghost": _up(), "RealPred": _down("moderate")})
+    assert "**Direction:** ↓ (confidence: moderate)" in out  # RealPred stamped despite Ghost missing
+
+
+def test_two_blocks_stamped_independently():
+    report = (
+        "#### PredA\n**Prediction:** A\n**Direction:** ↑ (confidence: low)\n"
+        "#### PredB\n**Prediction:** B\n"
+    )
+    out = stamp_directions(report, {"PredA": _down("high"), "PredB": _up("moderate")})
+    assert "**Direction:** ↓ (confidence: high)" in out   # PredA overwritten
+    assert "**Direction:** ↑ (confidence: moderate)" in out  # PredB inserted
+    # PredB's inserted line stays inside PredB's block, not PredA's
+    lines = out.split("\n")
+    assert lines[lines.index("#### PredB") + 1].startswith("**Direction:** ↑")
+
+
+def test_empty_report_or_map_is_noop():
+    assert stamp_directions("", {"X": _up()}) == ""
+    assert stamp_directions("some report", {}) == "some report"
+
+
+def test_anchor_prefers_heading_over_summary_mention():
+    # title appears first in a prose sentence, then as a heading — stamp the heading block
+    report = (
+        "## Executive Summary\n"
+        "We highlight MyPred as the leading signal.\n"
+        "#### MyPred\n"
+        "**Prediction:** X\n"
+    )
+    out = stamp_directions(report, {"MyPred": _up("high")})
+    lines = out.split("\n")
+    # the Direction line sits under the heading, not injected into the summary
+    assert lines[lines.index("#### MyPred") + 1] == "**Direction:** ↑ (confidence: high)"
+    assert "leading signal." in out

--- a/backend/tests/test_synthesis_direction_stamp.py
+++ b/backend/tests/test_synthesis_direction_stamp.py
@@ -99,3 +99,40 @@ def test_anchor_prefers_heading_over_summary_mention():
     # the Direction line sits under the heading, not injected into the summary
     assert lines[lines.index("#### MyPred") + 1] == "**Direction:** ↑ (confidence: high)"
     assert "leading signal." in out
+
+
+def test_anchor_prefers_heading_over_bold_summary_mention():
+    # Greptile P1: a *bold* executive-summary mention (``**MyPred**``) must NOT become the anchor
+    # ahead of the real ``#### MyPred`` prediction heading.
+    report = (
+        "## Executive Summary\n"
+        "**MyPred** is the lead signal this cohort.\n"
+        "#### MyPred\n"
+        "**Prediction:** X drives Y\n"
+    )
+    out = stamp_directions(report, {"MyPred": _up("high")})
+    lines = out.split("\n")
+    # Direction inserted under the heading block, not into the summary sentence.
+    assert lines[lines.index("#### MyPred") + 1] == "**Direction:** ↑ (confidence: high)"
+    summary_idx = lines.index("**MyPred** is the lead signal this cohort.")
+    assert not lines[summary_idx + 1].startswith("**Direction:**")
+
+
+def test_h4_block_boundary_isolates_directions_across_non_stampable_block():
+    # Greptile P1: PredA has no Direction line and PredB (a later, non-stampable ``####`` block) does.
+    # The h4 heading must bound PredA's scan so PredA's value is INSERTED, not written over PredB's
+    # own Direction line.
+    report = (
+        "#### PredA\n"
+        "**Prediction:** A drives outcome\n"
+        "#### PredB\n"
+        "**Prediction:** B drives outcome\n"
+        "**Direction:** ↑ (confidence: low)\n"
+    )
+    out = stamp_directions(report, {"PredA": _down("high")})
+    lines = out.split("\n")
+    # PredA gets its own inserted Direction line, directly under its heading.
+    assert lines[lines.index("#### PredA") + 1] == "**Direction:** ↓ (confidence: high)"
+    # PredB's pre-existing (non-stampable) Direction line is untouched.
+    assert lines[lines.index("#### PredB") + 2] == "**Direction:** ↑ (confidence: low)"
+    assert "↓" in out and out.count("↑") == 1

--- a/backend/tests/test_synthesis_prompt_contract.py
+++ b/backend/tests/test_synthesis_prompt_contract.py
@@ -1,0 +1,104 @@
+"""Axis E Unit 3: prompt contract + direction-hint injection.
+
+Plan: docs/plans/2026-07-16-001-feat-tier3-falsifier-direction-awareness-plan.md
+
+The synthesis prompt must mandate one title-anchored prediction block per Tier-3 hypothesis, a
+substance-guarded falsifier (measurable observable + threshold + null example), a once-per-section
+calibration preamble, and the "Direction is stamped — narrate only" clause. The assembled context
+must inject a title-anchored direction hint per Tier-3 hypothesis when axis A's seam is present, and
+none when it is absent (seam-gating, no indeterminate-everywhere scaffolding).
+"""
+
+from types import SimpleNamespace
+
+from kestrel_backend.graph.nodes.synthesis import (
+    SYNTHESIS_PROMPT,
+    assemble_synthesis_context,
+    format_direction_hints,
+)
+from kestrel_backend.graph.pipeline_config import SynthesisConfig
+from kestrel_backend.graph.state import EntityResolution, Hypothesis
+
+
+def _member(kme, kim=None):
+    return SimpleNamespace(kme=kme, kim=kim)
+
+
+def _spine(members, corr=None):
+    direction = SimpleNamespace(eigengene_trait_correlation=corr) if corr is not None else None
+    return SimpleNamespace(members=members, direction=direction)
+
+
+def _entity(curie, name):
+    return EntityResolution(
+        raw_name=name, curie=curie, resolved_name=name, category="biolink:Gene",
+        confidence=0.9, method="exact",
+    )
+
+
+def _hyp(title, curies, tier=3):
+    return Hypothesis(
+        title=title, tier=tier, claim="c", supporting_entities=curies,
+        structural_logic="logic", validation_steps=["step"],
+    )
+
+
+# --- prompt contract ------------------------------------------------------------------
+
+
+def test_prompt_mandates_per_hypothesis_blocks_and_falsifier():
+    assert "one prediction block per Tier-3 hypothesis" in SYNTHESIS_PROMPT
+    assert "**Falsifier:**" in SYNTHESIS_PROMPT
+    assert "null-result example" in SYNTHESIS_PROMPT
+    # substance guard: a validation restatement is NOT a falsifier
+    assert "restatement of the validation step is NOT a falsifier" in SYNTHESIS_PROMPT
+
+
+def test_prompt_marks_direction_as_stamped_not_invented():
+    assert "stamped" in SYNTHESIS_PROMPT
+    assert "do not invent" in SYNTHESIS_PROMPT
+
+
+def test_prompt_calibration_preamble_has_all_caveats():
+    assert "~18%" in SYNTHESIS_PROMPT
+    assert "n≈13–15" in SYNTHESIS_PROMPT  # Discovery-1 suggestive
+    assert "956" in SYNTHESIS_PROMPT       # Discovery-2 null
+    assert "Arivale" in SYNTHESIS_PROMPT   # wellness-cohort caveat
+    assert "never a probability" in SYNTHESIS_PROMPT
+
+
+# --- direction hint injection ---------------------------------------------------------
+
+
+def _state_with_seam():
+    return {
+        "resolved_entities": [_entity("NCBIGene:1", "GeneX")],
+        "hypotheses": [_hyp("MyPrediction", ["NCBIGene:1"])],
+        "module_spine": {"modA": _spine({"genex": _member(0.8)}, corr=0.5)},
+    }
+
+
+def test_direction_hints_injected_when_seam_present():
+    hints = format_direction_hints(_state_with_seam(), SynthesisConfig())
+    assert "Direction Hints" in hints
+    assert "MyPrediction" in hints
+    assert "↑" in hints
+
+
+def test_no_hints_when_seam_absent():
+    state = _state_with_seam()
+    del state["module_spine"]
+    assert format_direction_hints(state, SynthesisConfig()) == ""
+
+
+def test_assemble_context_includes_hints_when_seam_present():
+    ctx = assemble_synthesis_context(_state_with_seam())
+    assert "Tier-3 Direction Hints" in ctx
+    assert "MyPrediction" in ctx
+
+
+def test_assemble_context_omits_hints_when_seam_absent():
+    state = _state_with_seam()
+    del state["module_spine"]
+    ctx = assemble_synthesis_context(state)
+    assert "Direction Hints" not in ctx

--- a/backend/tests/test_synthesis_tier3_stats.py
+++ b/backend/tests/test_synthesis_tier3_stats.py
@@ -1,0 +1,158 @@
+"""Axis E Unit 5: tier3_prediction_stats telemetry (deterministic + compliance) + fallback parity.
+
+Plan: docs/plans/2026-07-16-001-feat-tier3-falsifier-direction-awareness-plan.md
+
+The block reports a DETERMINISTIC coverage metric (`direction_computable_pct`, from state and
+independent of report text) explicitly separated from COMPLIANCE metrics (`*_rendered_pct`, regex
+over the report), so the compliance markers are never mistaken for falsifiability/coverage of the
+property. The fallback path renders Direction from state and emits stats with `falsifier_rendered=0`.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from kestrel_backend.graph.nodes import synthesis
+from kestrel_backend.graph.nodes.synthesis import (
+    _compute_tier3_stats,
+    _count_wellformed_falsifiers,
+)
+from kestrel_backend.graph.pipeline_config import SynthesisConfig
+from kestrel_backend.graph.state import EntityResolution, Finding, Hypothesis
+
+
+def _member(kme, kim=None):
+    return SimpleNamespace(kme=kme, kim=kim)
+
+
+def _spine(members, corr=None):
+    direction = SimpleNamespace(eigengene_trait_correlation=corr) if corr is not None else None
+    return SimpleNamespace(members=members, direction=direction)
+
+
+def _entity(curie, name):
+    return EntityResolution(
+        raw_name=name, curie=curie, resolved_name=name, category="biolink:Gene",
+        confidence=0.9, method="exact",
+    )
+
+
+def _hyp(title, curies, tier=3):
+    return Hypothesis(
+        title=title, tier=tier, claim="c", supporting_entities=curies,
+        structural_logic="logic", validation_steps=["step"],
+    )
+
+
+def _state_2of3():
+    """3 Tier-3 hypotheses; module_spine gives signed records for exactly 2 of them."""
+    return {
+        "resolved_entities": [
+            _entity("NCBIGene:1", "GeneX"),
+            _entity("NCBIGene:2", "GeneY"),
+            _entity("NCBIGene:3", "GeneZ"),
+        ],
+        "hypotheses": [
+            _hyp("H1", ["NCBIGene:1"]),
+            _hyp("H2", ["NCBIGene:2"]),
+            _hyp("H3", ["NCBIGene:3"]),  # not in module_spine ⇒ not computable
+        ],
+        "module_spine": {
+            "modA": _spine({"genex": _member(0.8), "geney": _member(0.6)}, corr=0.5),
+        },
+        # SynthesisInput requires a non-empty findings channel; irrelevant to the metrics under test.
+        "direct_findings": [
+            Finding(entity="GeneX", claim="c", tier=1, predicate=None, source="direct_kg",
+                    pmids=[], confidence="high", logic_chain=None),
+        ],
+    }
+
+
+# --- deterministic coverage metric ----------------------------------------------------
+
+
+def test_direction_computable_pct_from_state_ignores_report_text():
+    cfg = SynthesisConfig()
+    state = _state_2of3()
+    a = _compute_tier3_stats(state, report="garbage with no markers", cfg=cfg)
+    b = _compute_tier3_stats(state, report="#### H1\n**Direction:** ↑ (confidence: high)\n", cfg=cfg)
+    assert a["total_tier3"] == 3
+    assert a["direction_computable"] == 2
+    assert a["direction_computable_pct"] == pytest.approx(66.7, abs=0.1)
+    # deterministic metric is identical regardless of report content
+    assert a["direction_computable_pct"] == b["direction_computable_pct"]
+    assert a["metric_kind"]["direction_computable_pct"] == "deterministic"
+    assert a["metric_kind"]["falsifier_rendered_pct"] == "compliance"
+
+
+def test_compliance_metrics_count_report_markers():
+    cfg = SynthesisConfig()
+    report = (
+        "#### H1\n**Direction:** ↑ (confidence: high)\n"
+        "**Falsifier:** metabolite X does not decrease by >20% in an independent cohort\n"
+        "#### H2\n**Direction:** ↓ (confidence: moderate)\n"
+        "**Falsifier:** module eigengene correlation with trait is ≥ 0 in validation set\n"
+        "#### H3\n"
+        "**Falsifier:** taxon abundance shows no change (null) across all timepoints\n"
+    )
+    stats = _compute_tier3_stats(_state_2of3(), report, cfg)
+    assert stats["direction_rendered"] == 2
+    assert stats["falsifier_rendered"] == 3
+    assert stats["direction_rendered_pct"] == pytest.approx(66.7, abs=0.1)
+    assert stats["falsifier_rendered_pct"] == pytest.approx(100.0, abs=0.1)
+
+
+def test_indeterminate_tracked_separately():
+    # entity present in module but no module direction ⇒ seam present, indeterminate, not computable
+    state = {
+        "resolved_entities": [_entity("NCBIGene:1", "GeneX")],
+        "hypotheses": [_hyp("H1", ["NCBIGene:1"])],
+        "module_spine": {"modA": _spine({"genex": _member(0.8)}, corr=None)},
+    }
+    stats = _compute_tier3_stats(state, report="", cfg=SynthesisConfig())
+    assert stats["seam_present"] is True
+    assert stats["direction_computable"] == 0
+    assert stats["indeterminate_direction"] == 1
+
+
+def test_zero_tier3_no_division_by_zero():
+    stats = _compute_tier3_stats({"hypotheses": []}, report="", cfg=SynthesisConfig())
+    assert stats["total_tier3"] == 0
+    assert stats["direction_computable_pct"] == 0.0
+    assert stats["falsifier_rendered_pct"] == 0.0
+
+
+# --- well-formed falsifier heuristic --------------------------------------------------
+
+
+def test_validation_restatement_not_counted_wellformed():
+    # a vacuous restatement with no measurable observable / threshold / direction word
+    report = "**Falsifier:** Run the same validation experiment and see what happens.\n"
+    assert _count_wellformed_falsifiers(report) == 0
+
+
+def test_measurable_falsifier_counted():
+    report = "**Falsifier:** if metabolite X does not decrease by >20% in cases, reject the prediction\n"
+    assert _count_wellformed_falsifiers(report) == 1
+
+
+# --- run() emits the field on both paths ----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_emits_tier3_stats_on_fallback_path(monkeypatch):
+    monkeypatch.setattr(synthesis, "HAS_SDK", False)  # deterministic fallback, no LLM
+    result = await synthesis.run(_state_2of3())
+    assert "tier3_prediction_stats" in result
+    stats = result["tier3_prediction_stats"]
+    assert stats["total_tier3"] == 3
+    assert stats["direction_computable"] == 2
+    # R6: fallback renders Direction from state, but authors no falsifiers
+    assert "Tier-3 Prediction Directions" in result["synthesis_report"]
+    assert stats["direction_rendered"] >= 2
+    assert stats["falsifier_rendered"] == 0
+
+
+def test_field_is_not_a_concat_field():
+    from kestrel_backend.main import _get_concat_fields
+    assert "tier3_prediction_stats" not in _get_concat_fields()  # plain dict → last-write-wins


### PR DESCRIPTION
## Summary

Makes every Tier-3 (speculative) prediction in the KRAKEN synthesis report **falsifiable** and **honest about sign**, implemented at the output/contract layer of `graph/nodes/synthesis.py`. This is the output half of the "direction, not hit-rate" north star.

## What changed

- **Unit 1 — deterministic direction helper** (`compute_tier3_direction`): joins a Tier-3 hypothesis to Axis A's signed module weights (`module_spine`) via `resolved_entities` canonical names. `sign = sign(kME) x sign(module→outcome corr)` per record; conflict/absent-direction → `indeterminate` (never a guessed sign); seam absent → omit. Confidence is a capped evidence-strength tier (|kME| bands, kIM floor, small-n cap), never a probability. Adds new `SynthesisConfig` thresholds.
- **Unit 2 — bridge-specificity rendering**: reads Axis C's `specificity_by_bridge` state side-map (keyed by `tuple(entities)`, not the frozen `Bridge`); generic bridges are structurally down-weighted and name their generic intermediates.
- **Unit 3 — `SYNTHESIS_PROMPT` §3 rewrite**: one title-anchored prediction block per Tier-3 hypothesis, substance-guarded falsifier (observable + threshold + null example), report-level ~18%/D1/D2/Arivale calibration preamble, and a "direction is stamped — narrate, don't invent" clause. Seam-gated per-hypothesis direction hints injected into assembled context.
- **Unit 4 — post-LLM Direction stamp**: overwrites/inserts the authoritative deterministic value per Tier-3 block (matched by title anchor), best-effort so a stamp failure never blanks the report. Makes the value synthesis-owned rather than an LLM prompt-hope.
- **Unit 5 — `tier3_prediction_stats` telemetry**: a deterministic coverage metric (`direction_computable_pct`, from state) explicitly separated from compliance metrics (`direction_/falsifier_rendered_pct`, regex over the report); `total_tier3` surfaces the base rate. Fallback path renders Direction from state and emits stats with `falsifier_rendered=0` (R6 parity).

## Seam safety

Both Axis A / Axis C seams are read defensively (absent → omit/indeterminate), so this ships and tests independently of Axes A and C.

## Tests

46 new unit tests + existing synthesis suite green; report-only contract test updated for the new telemetry field.

Files: `synthesis.py`, `pipeline_config.py`, `state.py`, plus new `test_synthesis_bridges.py`, `test_synthesis_direction.py`, `test_synthesis_direction_stamp.py`, `test_synthesis_prompt_contract.py`, `test_synthesis_tier3_stats.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)