### PR TITLE
feat(triage): intramodular-centrality hub routing (Axis B)

### DIFF
--- a/backend/src/kestrel_backend/graph/nodes/cold_start.py
+++ b/backend/src/kestrel_backend/graph/nodes/cold_start.py
@@ -614,6 +614,22 @@ def score_entity_complexity(edge_count: int) -> float:
     return float(edge_count)
 
 
+# Axis B (Q6 / feasibility P0-1): a rerouted intramodular hub carries a HIGH edge count, so under the
+# plain ascending-edge-count priority it sorts last and is dropped by the MAX_COLD_START cap — giving
+# hubs LESS analysis, the opposite of the inversion's intent. A hub therefore gets a sentinel priority
+# strictly below the 0-edge cold_start entities (0.0), so it survives the cap and is analyzed first.
+HUB_PRIORITY = -1.0
+
+
+def _priority_score(curie: str, edge_count: int, hub_curies: set[str]) -> float:
+    """Cold_start selection priority (lower = higher priority). A rerouted intramodular hub
+    (``curie in hub_curies``) gets ``HUB_PRIORITY`` so it outranks even genuine 0-edge entities;
+    every other entity keeps the ascending-edge-count ordering of ``score_entity_complexity``."""
+    if curie in hub_curies:
+        return HUB_PRIORITY
+    return score_entity_complexity(edge_count)
+
+
 def get_entity_info(
     curie_or_name: str,
     novelty_scores: list[NoveltyScore],
@@ -675,16 +691,21 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
     resolved_entities = state.get("resolved_entities", [])
 
     # Prioritize entities: limit to top 5 sparse + top 3 cold-start by edge count
-    # This reduces SDK serialization overhead while focusing on most important entities
+    # This reduces SDK serialization overhead while focusing on most important entities.
+    # Axis B: a rerouted intramodular hub (is_intramodular_hub on its NoveltyScore) is given top
+    # priority so the MAX_COLD_START cap does not drop it (Q6) — otherwise the inversion is a silent
+    # no-op that gives hubs LESS analysis.
+    hub_curies = {s.curie for s in novelty_scores if getattr(s, "is_intramodular_hub", False)}
+
     sparse_with_scores = []
     for curie in sparse:
         _, _, edge_count = get_entity_info(curie, novelty_scores, resolved_entities)
-        sparse_with_scores.append((curie, score_entity_complexity(edge_count)))
+        sparse_with_scores.append((curie, _priority_score(curie, edge_count, hub_curies)))
 
     cold_start_with_scores = []
     for curie in cold_start:
         _, _, edge_count = get_entity_info(curie, novelty_scores, resolved_entities)
-        cold_start_with_scores.append((curie, score_entity_complexity(edge_count)))
+        cold_start_with_scores.append((curie, _priority_score(curie, edge_count, hub_curies)))
 
     # Sort by complexity score (lower = higher priority)
     sparse_with_scores.sort(key=lambda x: x[1])

--- a/backend/src/kestrel_backend/graph/nodes/triage.py
+++ b/backend/src/kestrel_backend/graph/nodes/triage.py
@@ -24,6 +24,7 @@ to route entities to the appropriate analysis branches (direct_kg or cold_start)
 import asyncio
 import json
 import logging
+import math
 import time
 from typing import Any
 
@@ -157,6 +158,106 @@ def classify_by_edge_count(edge_count: int) -> str:
         return "cold_start"
 
 
+# =============================================================================
+# Axis B: intramodular-centrality hubs + inverted routing (consumes axis A ModuleSpine)
+# Plan: docs/plans/2026-07-16-001-feat-triage-intramodular-centrality-inverted-routing-plan.md
+#
+# Rationale (validation memo 20260716-212442): KG edge-count degree is study bias, not biology
+# (PNAS 2025 10.1073/pnas.2416646122; arXiv 2405.14985) — a degree-bias-only link predictor beats
+# sophisticated models, so the edge-count hub is an artifact. The biologically meaningful hub is the
+# one central WITHIN its WGCNA module (intramodular connectivity). And in validation cold_start beat
+# direct_kg, so high-degree entities we currently trust onto the fast path should get MORE scrutiny.
+# This pass marks the top-k% |kME| members of each module as hubs and inverts their routing.
+# =============================================================================
+
+
+def _normalize_name(name: str) -> str:
+    """Normalized join key: case-insensitive, trimmed. The ModuleSpine ``members`` map is keyed by
+    the canonical analyte name the user uploaded, which is also ``NoveltyScore.raw_name`` — but the
+    spine predates resolution, so we join on the name, not the CURIE (mirror the analyte-upload dedup
+    identity, R10)."""
+    return (name or "").strip().lower()
+
+
+def _spine_get(obj: Any, key: str, default: Any = None) -> Any:
+    """Duck-typed attribute/item access. Axis A owns the ModuleSpine Pydantic type (not importable
+    here); in-process it is a model (attribute access), but after any JSON round-trip it is a dict —
+    so read both. (Q1: coded against L1's shape, joined by name.)"""
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _module_top_k(n_members: int, top_k_pct: float) -> int:
+    """Relative top-k%: ceil(pct/100 * module_size), at least 1. Percentile, never an absolute
+    |kME| threshold — module |kME| distributions vary, so a relative cut is cohort-portable."""
+    return max(1, math.ceil((top_k_pct / 100.0) * n_members))
+
+
+def compute_hub_members(module_spine: Any, cfg: Any) -> dict[str, dict[str, Any]]:
+    """Per-module |kME| top-k% hub detection with kIM veto → ``{normalized_name: entry}``.
+
+    ``entry`` = ``{"kme": float, "kim": float|None, "crowned": bool, "group": str}``. For each module
+    (group), members are ranked by ``abs(kme)`` descending and the top ``ceil(k% * size)`` are hub
+    candidates. A candidate is vetoed (``crowned=False``) only when a ``kim_floor`` is configured AND
+    the member's ``kim`` is present AND below the floor (the low-n kME caveat, R4); a missing ``kim``
+    skips the veto (|kME| alone decides, L4). A member appearing in several modules is ``crowned`` if
+    crowned in ANY; its reported ``kme``/``kim`` are from the module where ``|kME|`` is largest (most
+    representative). Members without a ``kme`` are ignored (they carry no centrality signal).
+    """
+    agg: dict[str, dict[str, Any]] = {}
+    if not module_spine:
+        return agg
+    kim_floor = getattr(cfg, "intramodular_kim_floor", None)
+    top_k_pct = getattr(cfg, "intramodular_hub_top_k_pct", 10.0)
+
+    for group, module in module_spine.items():
+        members = _spine_get(module, "members", {}) or {}
+        parsed: list[tuple[str, float, float | None]] = []
+        for name, mw in members.items():
+            kme = _spine_get(mw, "kme")
+            if kme is None:
+                continue
+            kim = _spine_get(mw, "kim")
+            parsed.append((name, float(kme), None if kim is None else float(kim)))
+        if not parsed:
+            continue
+        parsed.sort(key=lambda t: abs(t[1]), reverse=True)
+        top_k = _module_top_k(len(parsed), top_k_pct)
+        crowned_names = {parsed[i][0] for i in range(min(top_k, len(parsed)))}
+
+        for name, kme, kim in parsed:
+            crowned = name in crowned_names
+            if crowned and kim_floor is not None and kim is not None and kim < kim_floor:
+                crowned = False  # kIM veto: high |kME|, low connectivity = false hub at low n
+            norm = _normalize_name(name)
+            entry = agg.get(norm)
+            if entry is None:
+                agg[norm] = {"kme": kme, "kim": kim, "crowned": crowned, "group": group}
+            else:
+                entry["crowned"] = entry["crowned"] or crowned
+                if abs(kme) > abs(entry["kme"]):
+                    entry.update(kme=kme, kim=kim, group=group)
+    return agg
+
+
+def expected_hub_count(module_spine: Any, cfg: Any) -> int:
+    """Sum over modules of ceil(k% * weighted_module_size) — the count of hubs the top-k% rule would
+    crown before the kIM veto and the name-join. Compared against the actual hub count in the R11
+    hook so a silent name-join failure (actual << expected) is caught, not read as 'a small hub set'.
+    """
+    if not module_spine:
+        return 0
+    top_k_pct = getattr(cfg, "intramodular_hub_top_k_pct", 10.0)
+    total = 0
+    for _group, module in module_spine.items():
+        members = _spine_get(module, "members", {}) or {}
+        n = sum(1 for mw in members.values() if _spine_get(mw, "kme") is not None)
+        if n:
+            total += _module_top_k(n, top_k_pct)
+    return total
+
+
 @validate_state(TriageInput, TriageOutput)
 async def run(state: DiscoveryState) -> dict[str, Any]:
     """
@@ -267,11 +368,46 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
         else:
             final_scores.append(s)
 
-    # Classify into routing buckets
-    well_characterized = [s.curie for s in final_scores if s.classification == "well_characterized"]
-    moderate = [s.curie for s in final_scores if s.classification == "moderate"]
-    sparse = [s.curie for s in final_scores if s.classification == "sparse"]
-    cold_start = [s.curie for s in final_scores if s.classification == "cold_start"]
+    # ========== Axis B: intramodular-centrality hub detection + inverted routing ==========
+    # Flag-gated and consumes axis A's ModuleSpine (read-only). When disabled, or no ModuleSpine, or
+    # no member carries kME → is_intramodular_hub stays False everywhere and bucketing below is
+    # byte-identical to the edge-count baseline (fallback identity). The pass runs AFTER the
+    # measurement-failure→moderate backfill, so a measurement failure is never rescued — it only
+    # gains hub status if it is genuinely a top-k% kME module member (then cold_start = more
+    # scrutiny, the intended safe direction).
+    cfg = get_pipeline_config().triage
+    module_spine = state.get("module_spine")
+    centrality_active = bool(cfg.intramodular_centrality_enabled and module_spine)
+    hub_members: dict[str, dict[str, Any]] = {}
+    if centrality_active:
+        hub_members = compute_hub_members(module_spine, cfg)
+        if hub_members:
+            promoted = []
+            for s in final_scores:
+                m = hub_members.get(_normalize_name(s.raw_name))
+                if m is not None:
+                    s = s.model_copy(update={
+                        "is_intramodular_hub": bool(m["crowned"]),
+                        "kme": m["kme"],
+                        "kim": m["kim"],
+                    })
+                promoted.append(s)
+            final_scores = promoted
+
+    # Classify into routing buckets. An intramodular hub is kept OUT of its edge-count bucket and
+    # placed into cold_start (inversion, R6/R8) — routing keys on the boolean, not the classification,
+    # which is preserved for synthesis/display. When centrality is off, no score is a hub, so this
+    # reduces exactly to the original bucketing.
+    well_characterized = [s.curie for s in final_scores
+                          if s.classification == "well_characterized" and not s.is_intramodular_hub]
+    moderate = [s.curie for s in final_scores
+                if s.classification == "moderate" and not s.is_intramodular_hub]
+    sparse = [s.curie for s in final_scores
+              if s.classification == "sparse" and not s.is_intramodular_hub]
+    cold_start = [s.curie for s in final_scores
+                  if s.classification == "cold_start" and not s.is_intramodular_hub]
+    hub_curies = [s.curie for s in final_scores if s.is_intramodular_hub]
+    cold_start.extend(hub_curies)  # inverted routing: all intramodular hubs → cold_start
 
     # Add failed resolutions to cold_start bucket
     failed_names = [e.raw_name for e in resolved if e.method == "failed"]

--- a/backend/src/kestrel_backend/graph/nodes/triage.py
+++ b/backend/src/kestrel_backend/graph/nodes/triage.py
@@ -427,20 +427,45 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
     # traffic accrues, so the well-characterized latency cost of ground-before-synthesis becomes an
     # evidenced choice. `produces_speculative` is the routing-relevant predicate (sparse OR cold_start
     # entities are what generate cold-start hypotheses). One structured line per run; no new table.
-    logger.info(
-        "triage_outcome %s",
-        json.dumps({
-            "event": "triage_outcome",
-            "well_characterized": len(well_characterized),
-            "moderate": len(moderate),
-            "sparse": len(sparse),
-            "cold_start": len(cold_start),
-            "tier1_ok": tier1_success,
-            "tier1_failed": len(valid_entities) - tier1_success,
-            "produces_speculative": bool(sparse or cold_start),
-            "duration_seconds": round(duration, 2),
-        }),
-    )
+    outcome: dict[str, Any] = {
+        "event": "triage_outcome",
+        "well_characterized": len(well_characterized),
+        "moderate": len(moderate),
+        "sparse": len(sparse),
+        "cold_start": len(cold_start),
+        "tier1_ok": tier1_success,
+        "tier1_failed": len(valid_entities) - tier1_success,
+        "produces_speculative": bool(sparse or cold_start),
+        "duration_seconds": round(duration, 2),
+    }
+    # Axis B measurement hooks (R10-R11) — added ONLY when the centrality pass ran, so the flag-off
+    # line is unchanged. They quantify how the |kME| hub notion diverges from the edge-degree hub
+    # notion (finding #2: KG degree = study bias) and the routing blast radius. `expected_hub_n` vs
+    # `kme_hub_n` is the join-integrity check: a silent name-join failure collapses `kme_hub_n` toward
+    # 0 while `expected_hub_n` stays positive, so the shift-toward-0 is not mistaken for "few hubs".
+    if centrality_active:
+        edge_degree_hub_set = {s.curie for s in final_scores
+                               if s.edge_count >= THRESHOLD_WELL_CHARACTERIZED}
+        kme_hub_set = {s.curie for s in final_scores if s.is_intramodular_hub}
+        union = edge_degree_hub_set | kme_hub_set
+        intersection = edge_degree_hub_set & kme_hub_set
+        outcome.update({
+            "hub_set_jaccard": round(len(intersection) / len(union), 4) if union else 0.0,
+            "edge_degree_hub_n": len(edge_degree_hub_set),                # edge_count >= 200
+            "edge_degree_hub_n_1000": sum(1 for s in final_scores if s.edge_count > 1000),
+            "kme_hub_n": len(kme_hub_set),
+            "hub_set_only_edge_degree_n": len(edge_degree_hub_set - kme_hub_set),
+            "hub_set_only_kme_n": len(kme_hub_set - edge_degree_hub_set),
+            # entities edge-count would have sent to direct_kg (well_characterized/moderate) but are
+            # now hub → cold_start
+            "routing_shift_direct_to_cold": sum(
+                1 for s in final_scores if s.is_intramodular_hub
+                and s.classification in ("well_characterized", "moderate")),
+            # 0 under pure inversion; emitted for auditing (no mechanism moves cold→direct)
+            "routing_shift_cold_to_direct": 0,
+            "expected_hub_n": expected_hub_count(module_spine, cfg),
+        })
+    logger.info("triage_outcome %s", json.dumps(outcome))
 
     result = {
         "novelty_scores": final_scores,

--- a/backend/src/kestrel_backend/graph/pipeline_config.py
+++ b/backend/src/kestrel_backend/graph/pipeline_config.py
@@ -196,6 +196,34 @@ class TriageConfig(BaseModel):
         default=6,
         description="DEPRECATED/unused: legacy batch knob from the removed Tier-2 path.",
     )
+    # === Axis B: intramodular-centrality hubs + inverted routing (consumes axis A ModuleSpine) ===
+    intramodular_centrality_enabled: bool = Field(
+        default=False,
+        description="Default-off flag (A/B gate). When True AND a ModuleSpine with kME is present, "
+        "triage marks the top-k% |kME| members of each module as intramodular hubs and INVERTS "
+        "routing (hub → cold_start instead of direct_kg), on the validated findings that KG degree "
+        "is study bias (PNAS 2025 10.1073/pnas.2416646122) and cold_start beat direct_kg in "
+        "validation. When False, or no ModuleSpine, or no kME → today's edge-count behavior exactly. "
+        "Ships off because the evidence base is thin (n=1 duel); flip is gated on a sign-safety "
+        "retrodiction check.",
+    )
+    intramodular_hub_top_k_pct: float = Field(
+        default=10.0,
+        gt=0.0,
+        le=100.0,
+        description="Percent of each module's members (by |kME|, descending) crowned as hub "
+        "candidates — RELATIVE (per-module percentile), never an absolute |kME| threshold, so the hub "
+        "notion is cohort-portable across differing module |kME| distributions. Default 10% mirrors "
+        "common WGCNA hub analyses; tunable.",
+    )
+    intramodular_kim_floor: float | None = Field(
+        default=None,
+        description="Optional absolute kIM (raw intramodular connectivity) floor for the low-n kME "
+        "caveat: a top-k% |kME| candidate whose kIM is below this is vetoed back to its edge-count "
+        "classification (high |kME| + low connectivity = a false hub at low sample size). None "
+        "disables the veto (|kME| alone decides); a candidate whose kIM is itself missing also skips "
+        "the veto. Scale depends on axis A's kIM units; final value pinned once A's kIM scale is known.",
+    )
 
 
 class ColdStartConfig(BaseModel):

--- a/backend/src/kestrel_backend/graph/state.py
+++ b/backend/src/kestrel_backend/graph/state.py
@@ -51,6 +51,27 @@ class NoveltyScore(BaseModel):
     classification: Literal["cold_start", "sparse", "moderate", "well_characterized"] = Field(
         ..., description="Classification based on edge count thresholds"
     )
+    # === Axis B: intramodular-centrality hub verdict ===
+    # A boolean, NOT a 5th `classification` Literal value: synthesis.py builds a `by_class` dict on
+    # exactly the four Literal keys and would KeyError on a fifth. Hub-ness rides this flag; the
+    # entity keeps its edge-count `classification` for synthesis/display compatibility. When True,
+    # triage reroutes the entity to cold_start (inverted routing) regardless of edge count.
+    is_intramodular_hub: bool = Field(
+        False,
+        description="True if this entity is a top-k% |kME| member of its WGCNA module (axis A "
+        "ModuleSpine), confirmed by the kIM veto. Drives inverted routing (hub → cold_start). "
+        "Default False; only ever True when triage's intramodular-centrality pass is enabled and a "
+        "ModuleSpine with kME is present.",
+    )
+    kme: float | None = Field(
+        None, description="Signed module-eigengene correlation (kME) from the ModuleSpine member the "
+        "entity joined to (most representative module by |kME|); None for classic/single-entity runs "
+        "or entities absent from the spine.",
+    )
+    kim: float | None = Field(
+        None, ge=0.0, description="Raw intramodular connectivity (kIM / kWithin), non-negative; None "
+        "when absent from the spine member or not provided by axis A.",
+    )
 
 
 class Finding(BaseModel):

--- a/backend/tests/test_cold_start_hub_priority.py
+++ b/backend/tests/test_cold_start_hub_priority.py
@@ -1,0 +1,49 @@
+"""Axis B, Unit 4 — cold_start must analyze a rerouted intramodular hub, not drop it (Q6 / P0-1).
+
+Triage reroutes intramodular hubs into cold_start_curies, but they carry a HIGH edge count and
+cold_start prioritizes *ascending* by edge count capped at MAX_COLD_START=3 — so without a carve-out
+a hub sorts last and is silently dropped, giving hubs LESS analysis (the opposite of the axis's
+goal). The fix: a rerouted hub (is_intramodular_hub on its NoveltyScore) gets top priority.
+"""
+
+from kestrel_backend.graph.nodes.cold_start import (
+    HUB_PRIORITY,
+    _priority_score,
+    score_entity_complexity,
+)
+from kestrel_backend.graph.state import NoveltyScore
+
+
+def test_hub_priority_beats_zero_edge_entities():
+    hubs = {"HUB:1"}
+    # a hub (high edge count) must outrank even a genuine 0-edge cold_start entity
+    assert _priority_score("HUB:1", 9999, hubs) == HUB_PRIORITY
+    assert _priority_score("HUB:1", 9999, hubs) < _priority_score("Z:1", 0, hubs)
+    # non-hubs keep the ascending-edge-count ordering
+    assert _priority_score("Z:1", 0, hubs) == score_entity_complexity(0)
+    assert _priority_score("S:1", 15, hubs) == score_entity_complexity(15)
+
+
+def test_hub_survives_the_cap_under_the_real_sort():
+    # Reproduce cold_start's sort+cap: 1 hub (high edge count) + 3 genuine 0-edge entities, MAX=3.
+    hub_curies = {"HUB:1"}
+    pairs = [
+        ("HUB:1", _priority_score("HUB:1", 9999, hub_curies)),
+        ("Z:1", _priority_score("Z:1", 0, hub_curies)),
+        ("Z:2", _priority_score("Z:2", 0, hub_curies)),
+        ("Z:3", _priority_score("Z:3", 0, hub_curies)),
+    ]
+    pairs.sort(key=lambda x: x[1])
+    selected = [c for c, _ in pairs[:3]]
+    assert "HUB:1" in selected, "rerouted hub must survive the MAX_COLD_START cap"
+
+
+def test_hub_curies_derived_from_novelty_scores():
+    # The hub set the fix keys on is exactly the is_intramodular_hub flag from triage's NoveltyScores.
+    scores = [
+        NoveltyScore(curie="HUB:1", raw_name="a", edge_count=800,
+                     classification="well_characterized", is_intramodular_hub=True),
+        NoveltyScore(curie="X:1", raw_name="b", edge_count=0, classification="cold_start"),
+    ]
+    hub_curies = {s.curie for s in scores if s.is_intramodular_hub}
+    assert hub_curies == {"HUB:1"}

--- a/backend/tests/test_triage_intramodular.py
+++ b/backend/tests/test_triage_intramodular.py
@@ -1,0 +1,205 @@
+"""Axis B, Unit 2 — intramodular-centrality classifier + inverted routing in triage.
+
+|kME|-based, per-module, relative top-k% hub detection (with a kIM veto for the low-n kME caveat),
+joined to entities by normalized name, driving inverted routing (hub → cold_start). Flag-gated:
+disabled / no ModuleSpine / no kME → the unchanged edge-count path (fallback identity, T1).
+
+ModuleSpine is axis A's schema (not in this base); we read it duck-typed, so these fixtures use
+lightweight stand-ins shaped like axis A's ModuleSpine/MemberWeight (attribute access) AND dicts.
+"""
+
+import json
+import types
+
+import pytest
+
+from kestrel_backend.graph.nodes import triage
+from kestrel_backend.graph.nodes.triage import compute_hub_members, _normalize_name
+from kestrel_backend.graph.pipeline_config import PipelineConfig, TriageConfig
+from kestrel_backend.graph.state import EntityResolution
+
+
+# --- fixtures --------------------------------------------------------------------------
+
+def _entity(curie, name, method="biomapper"):
+    return EntityResolution(
+        raw_name=name, curie=curie, resolved_name=name,
+        category="biolink:Gene", confidence=0.9, method=method,
+    )
+
+
+def _member(name, kme, kim=None):
+    return types.SimpleNamespace(name=name, kme=kme, kim=kim)
+
+
+def _spine(modules, as_dict=False):
+    """modules: {group: {name: (kme, kim)}} → {group: ModuleSpine-like}."""
+    out = {}
+    for group, mem in modules.items():
+        members = {n: (_member(n, kme, kim) if not as_dict else {"name": n, "kme": kme, "kim": kim})
+                   for n, (kme, kim) in mem.items()}
+        out[group] = (types.SimpleNamespace(group=group, members=members) if not as_dict
+                      else {"group": group, "members": members})
+    return out
+
+
+def _cfg(monkeypatch, **kw):
+    cfg = PipelineConfig(triage=TriageConfig(**kw))
+    monkeypatch.setattr(triage, "get_pipeline_config", lambda: cfg)
+    monkeypatch.setattr(triage, "_RETRY_BACKOFF_S", 0.0)
+    return cfg
+
+
+def _kestrel_counts(counts):
+    """counts: {curie: edge_count}. Returns an async call_kestrel_tool stub."""
+    async def call(tool, args):
+        c = counts.get(args["start_node_ids"], 0)
+        return {"isError": False, "content": [{"text": json.dumps({"results_count": c})}]}
+    return call
+
+
+async def _run(monkeypatch, entities, counts, spine=None, **cfgkw):
+    _cfg(monkeypatch, **cfgkw)
+    monkeypatch.setattr(triage, "call_kestrel_tool", _kestrel_counts(counts))
+    state = {"resolved_entities": entities}
+    if spine is not None:
+        state["module_spine"] = spine
+    return await triage.run(state)
+
+
+# --- T5 (pure): relative top-k% per module, no absolute |kME| leak ---------------------
+
+def test_compute_hub_members_relative_cutoff_per_module():
+    cfg = TriageConfig(intramodular_centrality_enabled=True, intramodular_hub_top_k_pct=10.0)
+    # module M1: 10 members (top-10% → ceil(1.0)=1 hub); M2: 20 members (→ ceil(2.0)=2 hubs)
+    m1 = {f"a{i}": (0.1 * i, None) for i in range(1, 11)}   # a10 has highest |kME|
+    m2 = {f"b{i}": (0.01 * i, None) for i in range(1, 21)}  # b20, b19 highest
+    hubs = compute_hub_members(_spine({"M1": m1, "M2": m2}), cfg)
+    crowned = {n for n, e in hubs.items() if e["crowned"]}
+    assert crowned == {"a10", "b20", "b19"}
+
+
+def test_compute_hub_members_all_low_kme_still_yields_top_k():
+    # A module of uniformly LOW |kME| still yields its top-k% (relative, not absolute threshold).
+    cfg = TriageConfig(intramodular_centrality_enabled=True, intramodular_hub_top_k_pct=10.0)
+    mod = {f"x{i}": (0.001 * i, None) for i in range(1, 11)}
+    hubs = compute_hub_members(_spine({"M": mod}), cfg)
+    assert {n for n, e in hubs.items() if e["crowned"]} == {"x10"}
+
+
+def test_compute_hub_members_uses_absolute_kme_magnitude():
+    # A large NEGATIVE kME is as central as a large positive one (|kME|).
+    cfg = TriageConfig(intramodular_centrality_enabled=True, intramodular_hub_top_k_pct=20.0)
+    mod = {"neg": (-0.9, None), "pos": (0.2, None), "mid": (0.3, None), "low": (0.05, None)}
+    hubs = compute_hub_members(_spine({"M": mod}), cfg)
+    assert hubs[_normalize_name("neg")]["crowned"] is True  # |−0.9| is the top
+
+
+def test_compute_hub_members_dict_shaped_spine():
+    # Duck-typed: a dict-shaped ModuleSpine (post JSON round-trip) works identically.
+    cfg = TriageConfig(intramodular_centrality_enabled=True, intramodular_hub_top_k_pct=50.0)
+    mod = {"h": (0.9, None), "l": (0.1, None)}
+    hubs = compute_hub_members(_spine({"M": mod}, as_dict=True), cfg)
+    assert hubs["h"]["crowned"] is True and hubs["l"]["crowned"] is False
+
+
+# --- T1: fallback identity -------------------------------------------------------------
+
+async def test_no_spine_is_edge_count_baseline(monkeypatch):
+    ents = [_entity("G:1", "alpha"), _entity("G:2", "beta")]
+    counts = {"G:1": 500, "G:2": 5}
+    out = await _run(monkeypatch, ents, counts, spine=None, intramodular_centrality_enabled=True)
+    assert out["well_characterized_curies"] == ["G:1"]
+    assert out["sparse_curies"] == ["G:2"]
+    assert all(s.is_intramodular_hub is False for s in out["novelty_scores"])
+
+
+async def test_flag_off_ignores_spine(monkeypatch):
+    ents = [_entity("G:1", "alpha")]
+    spine = _spine({"M": {"alpha": (0.99, 50.0)}})
+    out = await _run(monkeypatch, ents, {"G:1": 500}, spine=spine,
+                     intramodular_centrality_enabled=False)
+    assert out["well_characterized_curies"] == ["G:1"]  # unchanged; no inversion
+    assert out["cold_start_curies"] == []
+    assert out["novelty_scores"][0].is_intramodular_hub is False
+
+
+# --- T2: hub promotion + inversion -----------------------------------------------------
+
+async def test_hub_promoted_and_rerouted_to_cold_start(monkeypatch):
+    # alpha: high |kME| (module hub) AND high edge_count (would be well_characterized → direct_kg).
+    ents = [_entity("G:1", "alpha"), _entity("G:2", "beta"), _entity("G:3", "gamma")]
+    counts = {"G:1": 800, "G:2": 300, "G:3": 250}
+    spine = _spine({"M": {"alpha": (0.95, None), "beta": (0.2, None), "gamma": (0.15, None)}})
+    out = await _run(monkeypatch, ents, counts, spine=spine,
+                     intramodular_centrality_enabled=True, intramodular_hub_top_k_pct=33.0)
+    # alpha crowned (top 33% of 3 = ceil(0.99) = 1) → out of well_characterized, into cold_start
+    assert "G:1" not in out["well_characterized_curies"]
+    assert "G:1" in out["cold_start_curies"]
+    hub = next(s for s in out["novelty_scores"] if s.curie == "G:1")
+    assert hub.is_intramodular_hub is True
+    assert hub.kme == 0.95
+    assert hub.classification == "well_characterized"  # classification unchanged; hub rides boolean
+    # beta/gamma not hubs → keep their edge-count routing
+    assert "G:2" in out["well_characterized_curies"]  # 300 >= 200
+
+
+# --- T3: kIM veto ----------------------------------------------------------------------
+
+async def test_kim_veto_blocks_false_hub(monkeypatch):
+    ents = [_entity("G:1", "alpha"), _entity("G:2", "beta")]
+    counts = {"G:1": 800, "G:2": 800}
+    # alpha: top |kME| but kIM below floor → vetoed; with floor met it would be crowned.
+    spine = _spine({"M": {"alpha": (0.95, 1.0), "beta": (0.1, 99.0)}})
+    out = await _run(monkeypatch, ents, counts, spine=spine,
+                     intramodular_centrality_enabled=True, intramodular_hub_top_k_pct=50.0,
+                     intramodular_kim_floor=10.0)
+    assert next(s for s in out["novelty_scores"] if s.curie == "G:1").is_intramodular_hub is False
+    assert "G:1" in out["well_characterized_curies"]  # not rerouted
+
+
+async def test_kim_floor_met_crowns(monkeypatch):
+    ents = [_entity("G:1", "alpha"), _entity("G:2", "beta")]
+    counts = {"G:1": 800, "G:2": 800}
+    spine = _spine({"M": {"alpha": (0.95, 50.0), "beta": (0.1, 1.0)}})
+    out = await _run(monkeypatch, ents, counts, spine=spine,
+                     intramodular_centrality_enabled=True, intramodular_hub_top_k_pct=50.0,
+                     intramodular_kim_floor=10.0)
+    assert next(s for s in out["novelty_scores"] if s.curie == "G:1").is_intramodular_hub is True
+    assert "G:1" in out["cold_start_curies"]
+
+
+# --- T4: kIM absent → |kME| alone ------------------------------------------------------
+
+async def test_kim_absent_crowns_on_kme_alone(monkeypatch):
+    ents = [_entity("G:1", "alpha")]
+    spine = _spine({"M": {"alpha": (0.95, None)}})  # kim None
+    out = await _run(monkeypatch, ents, {"G:1": 800}, spine=spine,
+                     intramodular_centrality_enabled=True, intramodular_hub_top_k_pct=100.0,
+                     intramodular_kim_floor=10.0)  # floor set but kim None → veto skipped
+    assert out["novelty_scores"][0].is_intramodular_hub is True
+
+
+# --- T6: measurement-failure interaction preserved -------------------------------------
+
+async def test_measurement_failure_not_rescued_but_hub_reroutes(monkeypatch):
+    # beta's edge count can't be measured (isError forever) → moderate + marker (reliability fix).
+    ents = [_entity("G:1", "alpha"), _entity("G:2", "beta")]
+
+    async def call(tool, args):
+        if args["start_node_ids"] == "G:2":
+            return {"isError": True, "content": []}
+        return {"isError": False, "content": [{"text": json.dumps({"results_count": 800})}]}
+
+    _cfg(monkeypatch, intramodular_centrality_enabled=True, intramodular_hub_top_k_pct=50.0)
+    monkeypatch.setattr(triage, "call_kestrel_tool", call)
+    # beta IS a valid top-k% kME hub (top of its own module) → should reroute to cold_start.
+    spine = _spine({"M1": {"alpha": (0.9, None)}, "M2": {"beta": (0.8, None)}})
+    out = await triage.run({"resolved_entities": ents, "module_spine": spine})
+
+    beta = next(s for s in out["novelty_scores"] if s.curie == "G:2")
+    assert beta.classification == "moderate"  # measurement failure NOT rescued to a real count
+    assert beta.is_intramodular_hub is True   # but it IS a kME hub → cold_start
+    assert "G:2" in out["cold_start_curies"]
+    assert "G:2" not in out["moderate_curies"]
+    assert any("edge-count failed" in e for e in out["errors"])  # visible marker preserved

--- a/backend/tests/test_triage_intramodular_hooks.py
+++ b/backend/tests/test_triage_intramodular_hooks.py
@@ -1,0 +1,100 @@
+"""Axis B, Unit 3 — measurement hooks in the triage_outcome line (R9-R12).
+
+The hooks measure DIVERGENCE (edge-degree hub set vs |kME| hub set) and BLAST RADIUS (routing
+shift), with an `expected_hub_n` so a silent name-join failure (actual << expected) is caught rather
+than read as "a small hub set". Emitted only when the centrality pass runs; the flag-off line is
+unchanged (fallback identity).
+"""
+
+import json
+import logging
+import types
+
+from kestrel_backend.graph.nodes import triage
+from kestrel_backend.graph.pipeline_config import PipelineConfig, TriageConfig
+from kestrel_backend.graph.state import EntityResolution
+
+
+def _entity(curie, name):
+    return EntityResolution(raw_name=name, curie=curie, resolved_name=name,
+                            category="biolink:Gene", confidence=0.9, method="biomapper")
+
+
+def _spine(modules):
+    out = {}
+    for g, mem in modules.items():
+        members = {n: types.SimpleNamespace(name=n, kme=kme, kim=kim) for n, (kme, kim) in mem.items()}
+        out[g] = types.SimpleNamespace(group=g, members=members)
+    return out
+
+
+def _cfg(monkeypatch, **kw):
+    cfg = PipelineConfig(triage=TriageConfig(**kw))
+    monkeypatch.setattr(triage, "get_pipeline_config", lambda: cfg)
+    monkeypatch.setattr(triage, "_RETRY_BACKOFF_S", 0.0)
+
+
+def _kestrel(counts):
+    async def call(tool, args):
+        return {"isError": False, "content": [{"text": json.dumps({"results_count": counts[args["start_node_ids"]]})}]}
+    return call
+
+
+def _outcome_from_logs(caplog):
+    for r in caplog.records:
+        msg = r.getMessage()
+        if msg.startswith("triage_outcome "):
+            return json.loads(msg[len("triage_outcome "):])
+    raise AssertionError("no triage_outcome line emitted")
+
+
+async def test_hooks_emitted_when_active_disjoint_sets(monkeypatch, caplog):
+    # alpha: edge-degree hub (500 >= 200) but LOW kME → not a kME hub.
+    # beta:  moderate edge count (50, NOT an edge-degree hub) but HIGH kME → kME hub.
+    # → hub sets disjoint (Jaccard 0); beta's reroute is a direct→cold shift (moderate would go direct_kg).
+    ents = [_entity("G:1", "alpha"), _entity("G:2", "beta")]
+    _cfg(monkeypatch, intramodular_centrality_enabled=True, intramodular_hub_top_k_pct=50.0)
+    monkeypatch.setattr(triage, "call_kestrel_tool", _kestrel({"G:1": 500, "G:2": 50}))
+    spine = _spine({"M": {"alpha": (0.1, None), "beta": (0.9, None)}})
+
+    with caplog.at_level(logging.INFO, logger="kestrel_backend.graph.nodes.triage"):
+        out = await triage.run({"resolved_entities": ents, "module_spine": spine})
+
+    o = _outcome_from_logs(caplog)
+    assert o["edge_degree_hub_n"] == 1        # {G:1}
+    assert o["kme_hub_n"] == 1                # {G:2}
+    assert o["hub_set_jaccard"] == 0.0        # disjoint
+    assert o["hub_set_only_edge_degree_n"] == 1
+    assert o["hub_set_only_kme_n"] == 1
+    assert o["routing_shift_direct_to_cold"] == 1  # beta (moderate) → cold_start
+    assert o["routing_shift_cold_to_direct"] == 0  # pure inversion
+    assert o["expected_hub_n"] == 1                # ceil(50% * 2)
+    # and the routing actually happened
+    assert "G:2" in out["cold_start_curies"] and "G:2" not in out["moderate_curies"]
+
+
+async def test_hooks_absent_when_flag_off(monkeypatch, caplog):
+    ents = [_entity("G:1", "alpha")]
+    _cfg(monkeypatch, intramodular_centrality_enabled=False)
+    monkeypatch.setattr(triage, "call_kestrel_tool", _kestrel({"G:1": 500}))
+    spine = _spine({"M": {"alpha": (0.9, None)}})
+    with caplog.at_level(logging.INFO, logger="kestrel_backend.graph.nodes.triage"):
+        await triage.run({"resolved_entities": ents, "module_spine": spine})
+    o = _outcome_from_logs(caplog)
+    assert "hub_set_jaccard" not in o          # flag-off line unchanged (fallback identity)
+    assert "routing_shift_direct_to_cold" not in o
+    assert o["well_characterized"] == 1        # base fields still present
+
+
+async def test_expected_vs_actual_mismatch_visible_on_join_failure(monkeypatch, caplog):
+    # ModuleSpine has a hub, but NO entity name matches it (silent mis-join): kme_hub_n=0 while
+    # expected_hub_n=1 — the mismatch is the check that catches the join failure.
+    ents = [_entity("G:1", "alpha")]
+    _cfg(monkeypatch, intramodular_centrality_enabled=True, intramodular_hub_top_k_pct=100.0)
+    monkeypatch.setattr(triage, "call_kestrel_tool", _kestrel({"G:1": 500}))
+    spine = _spine({"M": {"UNMATCHED_NAME": (0.9, None)}})
+    with caplog.at_level(logging.INFO, logger="kestrel_backend.graph.nodes.triage"):
+        await triage.run({"resolved_entities": ents, "module_spine": spine})
+    o = _outcome_from_logs(caplog)
+    assert o["expected_hub_n"] == 1
+    assert o["kme_hub_n"] == 0  # join produced nothing → visible mismatch

--- a/backend/tests/test_triage_intramodular_schema.py
+++ b/backend/tests/test_triage_intramodular_schema.py
@@ -1,0 +1,75 @@
+"""Axis B, Unit 1 — NoveltyScore hub fields + TriageConfig centrality knobs (schema/contract).
+
+The hub verdict rides a boolean field (NOT a new classification Literal — a 5th value would KeyError
+in synthesis.py's by_class dict), plus kme/kim for downstream visibility. Config knobs are default-off.
+"""
+
+from kestrel_backend.graph.pipeline_config import PipelineConfig, TriageConfig
+from kestrel_backend.graph.state import NoveltyScore
+
+
+def test_novelty_score_defaults_are_backward_compatible():
+    # Existing construction (no hub fields) must still work; hub-ness defaults off.
+    s = NoveltyScore(curie="NCBIGene:1", raw_name="A", edge_count=500, classification="well_characterized")
+    assert s.is_intramodular_hub is False
+    assert s.kme is None
+    assert s.kim is None
+
+
+def test_novelty_score_carries_hub_fields():
+    s = NoveltyScore(
+        curie="NCBIGene:1", raw_name="A", edge_count=500, classification="well_characterized",
+        is_intramodular_hub=True, kme=-0.82, kim=14.3,
+    )
+    assert s.is_intramodular_hub is True
+    assert s.kme == -0.82
+    assert s.kim == 14.3
+
+
+def test_classification_literal_unchanged_no_fifth_value():
+    # A 5th classification value would break synthesis.py by_class — hub rides the boolean instead.
+    import pydantic
+    try:
+        NoveltyScore(curie="X:1", raw_name="A", edge_count=1, classification="intramodular_hub")
+    except pydantic.ValidationError:
+        return
+    raise AssertionError("classification must stay a 4-value Literal (no 'intramodular_hub')")
+
+
+def test_kim_floor_ge_zero_on_novelty_score():
+    import pydantic
+    try:
+        NoveltyScore(curie="X:1", raw_name="A", edge_count=1, classification="sparse", kim=-1.0)
+    except pydantic.ValidationError:
+        return
+    raise AssertionError("kim must carry a ge=0 floor (raw connectivity is non-negative)")
+
+
+def test_novelty_score_frozen():
+    s = NoveltyScore(curie="X:1", raw_name="A", edge_count=1, classification="sparse")
+    try:
+        s.is_intramodular_hub = True  # type: ignore[misc]
+    except Exception:
+        return
+    raise AssertionError("NoveltyScore must stay frozen")
+
+
+def test_triage_config_centrality_knobs_default_off():
+    cfg = TriageConfig()
+    assert cfg.intramodular_centrality_enabled is False
+    assert cfg.intramodular_hub_top_k_pct == 10.0
+    assert cfg.intramodular_kim_floor is None
+
+
+def test_triage_config_top_k_pct_bounds():
+    import pydantic
+    for bad in (0.0, -5.0, 150.0):
+        try:
+            TriageConfig(intramodular_hub_top_k_pct=bad)
+        except pydantic.ValidationError:
+            continue
+        raise AssertionError(f"top_k_pct={bad} should be rejected (must be in (0, 100])")
+
+
+def test_pipeline_config_exposes_triage_knobs():
+    assert PipelineConfig().triage.intramodular_centrality_enabled is False


### PR DESCRIPTION
## Summary

Adds intramodular-centrality-aware triage with inverted routing so that WGCNA intramodular hubs are surfaced (rather than deprioritized) through the discovery pipeline. Implemented across four units on Axis B.

## Changes

- **Unit 1** (`f41eddc`): `NoveltyScore` hub fields + `TriageConfig` centrality knobs.
- **Unit 2** (`707ba2f`): intramodular-centrality classifier + inverted routing in triage.
- **Unit 3** (`d0b3326`): hub-divergence + routing-shift measurement hooks in `triage_outcome`.
- **Unit 4** (`3a889b5`): cold_start carve-out giving rerouted intramodular hubs top selection priority.

## Notes

- Targets `dev` per the feature-branch workflow (verify at dev-kraken before promoting to `main`).
- Plan: `docs/plans/2026-07-16-001-feat-triage-intramodular-centrality-inverted-routing-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)