### PR TITLE
feat(integration): bridge-specificity (DWPC) scoring pass

### DIFF
--- a/backend/assessment_data/bridge_specificity_calibration.py
+++ b/backend/assessment_data/bridge_specificity_calibration.py
@@ -32,7 +32,15 @@ import statistics
 from datetime import datetime, timezone
 from pathlib import Path
 
+from dotenv import load_dotenv
+
+# Load Kestrel creds from backend/.env before importing the client (KESTREL_API_KEY is read at
+# module-import time). This probe is run standalone, so it owns its dotenv load rather than
+# relying on the caller's environment (see docs/solutions: Kestrel 403 was dotenv-from-/tmp).
+load_dotenv(Path(__file__).resolve().parents[1] / ".env")
+
 from src.kestrel_backend.graph.nodes.bridge_specificity import (  # noqa: E402
+    _DEGREE_QUERY_LIMIT,
     DAMPING_W,
     GENERIC_CUTOFF,
     MODERATE_CUT,
@@ -170,8 +178,13 @@ async def main() -> None:
                 "query_sha": query_sha,
                 "recorded_at": stamp,
                 "damping_w": DAMPING_W,
+                "degree_query_limit": _DEGREE_QUERY_LIMIT,
                 "note": "1-MNA hypothesis: TNFRSF10A -> 1-MNA via blood, placenta, cancer. "
-                        "Intermediates are near-universal high-degree nodes; the bridge INVERTED.",
+                        "Intermediates are near-universal high-degree nodes; the bridge INVERTED. "
+                        "Degrees are one_hop_query preview results_count, saturated at "
+                        f"degree_query_limit ({_DEGREE_QUERY_LIMIT}) — so a value == the limit is a "
+                        "FLOOR on the true (larger) hub degree, not an exact count. This is "
+                        "immaterial to the generic retrodiction (limit >> GENERIC_CUTOFF).",
             },
             "one_mna_scaffold": {
                 c: {"name": ONE_MNA_SCAFFOLD[c], "degree": degrees[c]} for c in ONE_MNA_SCAFFOLD

--- a/backend/assessment_data/bridge_specificity_calibration.py
+++ b/backend/assessment_data/bridge_specificity_calibration.py
@@ -1,0 +1,191 @@
+"""Axis C, Unit 4 — bridge-specificity CALIBRATION probe (live Kestrel).
+
+Records the REAL KG degree of the 1-MNA scaffold nodes ({blood, placenta, cancer}) plus a spread
+of specific/moderate control intermediates, derives the intermediate-degree distribution, and
+recommends the label cut points (`SPECIFIC_CUT`, `MODERATE_CUT`) and the per-node generic cutoff
+(`GENERIC_CUTOFF`) by QUANTILE — not round score values (with w=0.4, naive round-number score cut
+points push every biologically real degree into the penalty side and leave `specific` empty).
+
+Two outputs, BOTH saved by default (persist-expensive-run-artifacts SOP):
+  1. a timestamped run artifact under assessment_data/bridge_specificity_calibration_runs/
+     (recommended constants + full degree distribution + per-scaffold scores + pinning inputs);
+  2. the retrodiction fixture tests/fixtures/bridge_specificity_1mna_degrees.json (real measured
+     degrees), consumed by test_bridge_specificity_retrodiction.py.
+
+The 1-MNA hypothesis ("TNFRSF10A -> 1-MNA via blood, placenta, cancer") INVERTED: its intermediates
+are near-universal high-degree nodes. This probe is what makes "would 1-MNA have been flagged?" a
+real answer (measured degrees) rather than an arithmetic tautology.
+
+Usage: PYTHONPATH=. uv run python assessment_data/bridge_specificity_calibration.py
+       [--out DIR] [--no-fixture]
+
+Requires a reachable Kestrel (backend/.env loaded). The CURIEs below are best-effort canonical
+identifiers — the live run should confirm/repair any that fail to resolve (a None degree is logged,
+never fatal), and MONDO/UBERON drift should be corrected here before trusting the calibration.
+"""
+
+import argparse
+import asyncio
+import hashlib
+import json
+import statistics
+from datetime import datetime, timezone
+from pathlib import Path
+
+from src.kestrel_backend.graph.nodes.bridge_specificity import (  # noqa: E402
+    DAMPING_W,
+    GENERIC_CUTOFF,
+    MODERATE_CUT,
+    SPECIFIC_CUT,
+    bridge_specificity,
+    make_degree_provider,
+)
+
+# The 1-MNA scaffold — the near-universal hubs the inverted hypothesis leaned on.
+ONE_MNA_SCAFFOLD = {
+    "UBERON:0000178": "blood",
+    "UBERON:0001987": "placenta",
+    "MONDO:0004992": "cancer",
+}
+
+# A low-degree control expected to reach `specific`.
+CONTROL_SPECIFIC = {
+    "CHEBI:16797": "1-methylnicotinamide",
+}
+
+# A spread of intermediates to characterize the real degree distribution (specific -> generic).
+# Extend with real scaffold CURIEs discovered from a representative module run before trusting
+# the recommended cut points.
+DISTRIBUTION_PROBE = {
+    "CHEBI:15377": "water",
+    "CHEBI:16236": "ethanol",
+    "CHEBI:17234": "glucose",
+    "CHEBI:29101": "sodium(1+)",
+    "GO:0006954": "inflammatory response",
+    "GO:0005515": "protein binding",
+    "UBERON:0002107": "liver",
+    "UBERON:0000955": "brain",
+    "MONDO:0005148": "type 2 diabetes mellitus",
+    "HP:0000118": "phenotypic abnormality",
+}
+
+
+def _query_sha(curies: list[str]) -> str:
+    return hashlib.sha256("\n".join(sorted(curies)).encode()).hexdigest()[:16]
+
+
+def _quantile(sorted_vals: list[int], q: float) -> float:
+    if not sorted_vals:
+        return float("nan")
+    idx = q * (len(sorted_vals) - 1)
+    lo = int(idx)
+    hi = min(lo + 1, len(sorted_vals) - 1)
+    frac = idx - lo
+    return sorted_vals[lo] * (1 - frac) + sorted_vals[hi] * frac
+
+
+async def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    default_out = Path(__file__).parent / "bridge_specificity_calibration_runs"
+    ap.add_argument("--out", type=Path, default=default_out,
+                    help="Run-artifact directory (a timestamped JSON is written inside). "
+                         "Overrides the default; saving is NOT opt-in.")
+    ap.add_argument("--no-fixture", action="store_true",
+                    help="Do not overwrite the retrodiction fixture (still saves the run artifact).")
+    args = ap.parse_args()
+
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    all_curies = {**ONE_MNA_SCAFFOLD, **CONTROL_SPECIFIC, **DISTRIBUTION_PROBE}
+    query_sha = _query_sha(list(all_curies))
+
+    # One bounded, per-run cached provider for the whole probe (mirrors the node's usage).
+    provider = make_degree_provider(concurrency=8)
+
+    degrees: dict[str, int | None] = {}
+    for curie in all_curies:
+        d = await provider(curie)
+        degrees[curie] = d
+        print(f"  {curie:20} {all_curies[curie]:32} degree={d}")
+
+    # --- recommended constants by quantile of the observed (known) intermediate degrees --------
+    known = sorted(d for d in degrees.values() if d is not None)
+    recommended = {}
+    if known:
+        # per-node generic cutoff: ~90th percentile (the hubs); specific/moderate score cuts
+        # derived from degree quantiles so a real fraction of nodes clears `specific`.
+        gen_cut = _quantile(known, 0.90)
+        p40 = max(_quantile(known, 0.40), 1.0)
+        p70 = max(_quantile(known, 0.70), 1.0)
+        recommended = {
+            "GENERIC_CUTOFF": round(gen_cut),
+            "SPECIFIC_CUT": round(p40 ** (-DAMPING_W), 4),   # score at the 40th-pct degree
+            "MODERATE_CUT": round(p70 ** (-DAMPING_W), 4),   # score at the 70th-pct degree
+            "basis": {"p40_degree": round(p40), "p70_degree": round(p70), "p90_degree": round(gen_cut)},
+        }
+
+    # --- score the reference scaffolds under the CURRENT constants (preview) --------------------
+    def _score(names: dict[str, str]) -> dict:
+        curies = list(names)
+        ds = [degrees[c] for c in curies]
+        spec = bridge_specificity(curies, ds)
+        return {"curies": curies, "degrees": ds, "label": spec.label, "score": spec.score,
+                "generic_intermediates": spec.generic_intermediates}
+
+    one_mna_score = _score(ONE_MNA_SCAFFOLD)
+    control_score = _score(CONTROL_SPECIFIC)
+
+    artifact = {
+        "timestamp": stamp,
+        "query_sha": query_sha,
+        "damping_w": DAMPING_W,
+        "current_constants": {
+            "SPECIFIC_CUT": SPECIFIC_CUT, "MODERATE_CUT": MODERATE_CUT,
+            "GENERIC_CUTOFF": GENERIC_CUTOFF,
+        },
+        "recommended_constants": recommended,
+        "degrees": degrees,
+        "degree_distribution": {
+            "n_known": len(known),
+            "min": known[0] if known else None,
+            "median": statistics.median(known) if known else None,
+            "max": known[-1] if known else None,
+        },
+        "one_mna_scaffold_score": one_mna_score,
+        "control_specific_score": control_score,
+    }
+
+    out_dir: Path = args.out
+    out_dir.mkdir(parents=True, exist_ok=True)
+    art_path = out_dir / f"{stamp}.json"
+    art_path.write_text(json.dumps(artifact, indent=2, default=str))
+    print(f"\ncurrent-constant 1-MNA label: {one_mna_score['label']} "
+          f"(score={one_mna_score['score']})  control: {control_score['label']}")
+    print(f"recommended constants: {recommended}")
+    print(f"run artifact: {art_path}")
+
+    if not args.no_fixture:
+        fixture = {
+            "provenance": {
+                "source": "live Kestrel calibration run",
+                "query_sha": query_sha,
+                "recorded_at": stamp,
+                "damping_w": DAMPING_W,
+                "note": "1-MNA hypothesis: TNFRSF10A -> 1-MNA via blood, placenta, cancer. "
+                        "Intermediates are near-universal high-degree nodes; the bridge INVERTED.",
+            },
+            "one_mna_scaffold": {
+                c: {"name": ONE_MNA_SCAFFOLD[c], "degree": degrees[c]} for c in ONE_MNA_SCAFFOLD
+            },
+            "control_specific": {
+                c: {"name": CONTROL_SPECIFIC[c], "degree": degrees[c]} for c in CONTROL_SPECIFIC
+            },
+            "recorded_intermediate_population": [d for d in degrees.values() if d is not None],
+        }
+        fx_path = Path(__file__).resolve().parents[1] / "tests" / "fixtures" / \
+            "bridge_specificity_1mna_degrees.json"
+        fx_path.write_text(json.dumps(fixture, indent=2))
+        print(f"retrodiction fixture updated: {fx_path}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/assessment_data/bridge_specificity_calibration_runs/20260717T071202Z.json
+++ b/backend/assessment_data/bridge_specificity_calibration_runs/20260717T071202Z.json
@@ -1,0 +1,72 @@
+{
+  "timestamp": "20260717T071202Z",
+  "query_sha": "e5d4db84bc7098e0",
+  "damping_w": 0.4,
+  "current_constants": {
+    "SPECIFIC_CUT": 0.2,
+    "MODERATE_CUT": 0.1,
+    "GENERIC_CUTOFF": 1000
+  },
+  "recommended_constants": {
+    "GENERIC_CUTOFF": 10000,
+    "SPECIFIC_CUT": 0.0271,
+    "MODERATE_CUT": 0.0251,
+    "basis": {
+      "p40_degree": 8246,
+      "p70_degree": 10000,
+      "p90_degree": 10000
+    }
+  },
+  "degrees": {
+    "UBERON:0000178": 10000,
+    "UBERON:0001987": 10000,
+    "MONDO:0004992": 10000,
+    "CHEBI:16797": 143,
+    "CHEBI:15377": 10000,
+    "CHEBI:16236": 7808,
+    "CHEBI:17234": 7471,
+    "CHEBI:29101": 5333,
+    "GO:0006954": 1270,
+    "GO:0005515": 10000,
+    "UBERON:0002107": 10000,
+    "UBERON:0000955": 10000,
+    "MONDO:0005148": 10000,
+    "HP:0000118": 115
+  },
+  "degree_distribution": {
+    "n_known": 14,
+    "min": 115,
+    "median": 10000.0,
+    "max": 10000
+  },
+  "one_mna_scaffold_score": {
+    "curies": [
+      "UBERON:0000178",
+      "UBERON:0001987",
+      "MONDO:0004992"
+    ],
+    "degrees": [
+      10000,
+      10000,
+      10000
+    ],
+    "label": "generic",
+    "score": 0.0251188643150958,
+    "generic_intermediates": [
+      "UBERON:0000178",
+      "UBERON:0001987",
+      "MONDO:0004992"
+    ]
+  },
+  "control_specific_score": {
+    "curies": [
+      "CHEBI:16797"
+    ],
+    "degrees": [
+      143
+    ],
+    "label": "moderate",
+    "score": 0.13736167721553033,
+    "generic_intermediates": []
+  }
+}

--- a/backend/src/kestrel_backend/graph/nodes/bridge_specificity.py
+++ b/backend/src/kestrel_backend/graph/nodes/bridge_specificity.py
@@ -23,6 +23,7 @@ References:
 import asyncio
 import json
 import logging
+import statistics
 from typing import Any, Awaitable, Callable
 
 from ...kestrel_client import call_kestrel_tool
@@ -227,3 +228,66 @@ def make_degree_provider(
         return await task
 
     return get
+
+
+# --- Emit-only scoring pass over (bridge, scaffold) pairs (R3/R4, ledger L11/L26) -----------
+
+async def score_bridges(
+    pairs: list[tuple[Any, list[str]]],
+    inline_nodes: dict[str, Any] | None = None,
+    *,
+    max_scored_bridges: int,
+    concurrency: int,
+) -> tuple[dict[tuple[str, ...], BridgeSpecificity], list[str]]:
+    """Score a batch of ``(bridge, scaffold_curies)`` pairs into a ``tuple(entities) -> spec`` map.
+
+    Emit-only and per-bridge isolated: a scoring failure on one bridge is captured as an error
+    string and that bridge simply gets no map entry — the pass never raises and the caller's
+    ``bridges`` list is untouched. Bridges beyond ``max_scored_bridges`` are not scored (no entry;
+    axis E treats a missing key as "no signal"). One degree provider per call: a hub intermediate
+    shared across bridges is fetched at most once (per-run dedup cache), bounded by ``concurrency``.
+
+    The scaffold is supplied EXPLICITLY per pair by the caller (per-builder, never a positional
+    slice — subgraph bridges list endpoints first). Keyed by ``tuple(bridge.entities)``; duplicate
+    bridges sharing an entities tuple collapse to one entry (accepted, mirrors the grounding map).
+    """
+    provider = make_degree_provider(inline_nodes, concurrency)
+    capped = pairs[:max_scored_bridges]
+
+    async def _score(bridge: Any, scaffold: list[str]) -> tuple[tuple[str, ...], BridgeSpecificity | None, str | None]:
+        key = tuple(bridge.entities)
+        try:
+            degrees = list(await asyncio.gather(*[provider(c) for c in scaffold]))
+            return key, bridge_specificity(scaffold, degrees), None
+        except Exception as e:  # per-bridge isolation: skip this key, keep the pass alive
+            label = getattr(bridge, "path_description", None) or str(key)
+            logger.warning("bridge_specificity: scoring failed for %s: %s", label, e)
+            return key, None, f"bridge_specificity: {label}: {e}"
+
+    results = await asyncio.gather(*[_score(b, s) for b, s in capped])
+    specificity_by_bridge: dict[tuple[str, ...], BridgeSpecificity] = {}
+    errors: list[str] = []
+    for key, spec, err in results:
+        if err is not None:
+            errors.append(err)
+        elif spec is not None:
+            specificity_by_bridge[key] = spec
+    return specificity_by_bridge, errors
+
+
+def summarize_specificity(
+    specificity_by_bridge: dict[tuple[str, ...], BridgeSpecificity],
+) -> dict[str, Any]:
+    """Per-run label histogram + score min/median/max, for the measurement-hook log line (R5)."""
+    counts = {"specific": 0, "moderate": 0, "generic": 0, "unknown": 0}
+    scores: list[float] = []
+    for spec in specificity_by_bridge.values():
+        counts[spec.label] = counts.get(spec.label, 0) + 1
+        if spec.score is not None:
+            scores.append(spec.score)
+    summary: dict[str, Any] = {"scored": len(specificity_by_bridge), "counts": counts}
+    if scores:
+        summary["score_min"] = min(scores)
+        summary["score_median"] = statistics.median(scores)
+        summary["score_max"] = max(scores)
+    return summary

--- a/backend/src/kestrel_backend/graph/nodes/bridge_specificity.py
+++ b/backend/src/kestrel_backend/graph/nodes/bridge_specificity.py
@@ -134,3 +134,96 @@ def bridge_specificity(
         intermediate_degrees=degrees,
         generic_intermediates=generic_intermediates,
     )
+
+
+# --- Hybrid, bounded, per-run cached degree provider (R2, ledger L9) ------------------------
+# NOTE (R6): this reads RAW KG connectivity (an intermediate node's edge count), which is
+# distinct from axis B's intramodular centrality. It is a candidate future shared "KG degree for
+# a CURIE" helper across triage / pathway_enrichment / this provider — deliberately NOT coupled
+# here (that convergence is a separate refactor).
+
+# one_hop_query count limit. Preview mode returns results_count (the edge count == degree);
+# a high limit yields an accurate count, matching triage's read.
+_DEGREE_QUERY_LIMIT = 10000
+
+
+def _inline_degree(node: Any) -> int | None:
+    """Opportunistic per-node degree from a KG envelope's ``nodes`` entry.
+
+    The documented multi_hop/subgraph ``nodes`` entry is ``{name, categories}`` — NO degree — so
+    this almost always returns None and the provider falls back to the bounded fetch. Kept only as
+    an opportunistic bonus IF a live envelope is confirmed to carry an integer ``degree``.
+    """
+    if isinstance(node, dict):
+        d = node.get("degree")
+        if isinstance(d, int) and not isinstance(d, bool):
+            return d
+    return None
+
+
+async def _fetch_degree(curie: str) -> int | None:
+    """Best-effort KG degree via one_hop_query preview (``results_count``). None on any failure."""
+    try:
+        resp = await call_kestrel_tool(
+            "one_hop_query",
+            {"start_node_ids": curie, "mode": "preview", "limit": _DEGREE_QUERY_LIMIT},
+        )
+    except Exception as e:  # best-effort: a Kestrel failure -> no degree, never propagates
+        logger.warning("bridge_specificity: degree fetch failed for %s: %s", curie, e)
+        return None
+    if not isinstance(resp, dict) or resp.get("isError"):
+        return None
+    content = resp.get("content") or []
+    if not content:
+        return None
+    try:
+        data = json.loads(content[0].get("text", ""))
+    except (json.JSONDecodeError, AttributeError, IndexError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    rc = data.get("results_count")
+    if rc is None:
+        return None
+    try:
+        return int(rc)
+    except (TypeError, ValueError):
+        return None
+
+
+def make_degree_provider(
+    inline_nodes: dict[str, Any] | None = None,
+    concurrency: int = 8,
+) -> Callable[[str], Awaitable[int | None]]:
+    """Build a single-flight, concurrency-bounded, per-run cached CURIE->degree resolver.
+
+    Fetch-dominant: for each CURIE, read an opportunistic inline degree from ``inline_nodes`` if
+    present, else acquire the semaphore and fetch the KG degree once (``one_hop_query`` preview,
+    ``results_count``). The result — including ``None`` — is cached per run so a hub intermediate
+    shared across bridges is fetched at most once, and concurrent callers await the same in-flight
+    task. Never raises; returns ``int | None``.
+
+    Mirrors ``bridge_grounding.cached_leg_fetcher`` (per-run dedup cache + bounded fetch). Bounding
+    is mandatory: an unbounded per-bridge one_hop fan-out once exhausted Kestrel's LMDB readers
+    (MDB_READERS_FULL incident, 2026-06-24). A fresh cache is built per call — never stale across runs.
+    """
+    inline = inline_nodes or {}
+    sem = asyncio.Semaphore(concurrency)
+    cache: dict[str, "asyncio.Future[int | None]"] = {}
+
+    async def get(curie: str) -> int | None:
+        task = cache.get(curie)
+        if task is None:
+            async def _go() -> int | None:
+                # Opportunistic inline read is free (no Kestrel call, outside the semaphore).
+                d = _inline_degree(inline.get(curie))
+                if d is not None:
+                    return d
+                async with sem:
+                    return await _fetch_degree(curie)
+
+            task = asyncio.ensure_future(_go())
+            cache[curie] = task
+        return await task
+
+    return get

--- a/backend/src/kestrel_backend/graph/nodes/bridge_specificity.py
+++ b/backend/src/kestrel_backend/graph/nodes/bridge_specificity.py
@@ -1,0 +1,136 @@
+"""Axis C — bridge specificity scoring by intermediate-node degree (DWPC).
+
+Score each cross-entity bridge by the KG degree of its intermediate node(s) using
+Degree-Weighted Path Count (DWPC) damping. Bridges through generic, high-degree intermediates
+(e.g. "blood", "placenta", "cancer") are penalized; bridges through specific, low-degree
+intermediates are rewarded.
+
+The 1-MNA hypothesis ("TNFRSF10A -> 1-MNA via blood, placenta, cancer") INVERTED — its
+intermediates are near-universal, extremely high-degree KG nodes and "both found in blood" is
+true of almost everything. This module produces a deterministic STRUCTURAL-genericity signal
+(NOT a mechanism-confidence claim) that synthesis (axis E) can use to discount such bridges.
+
+Scoring is a pure, deterministic transform (this ``bridge_specificity`` fn — no I/O). The KG
+degree behind each intermediate is resolved by :func:`make_degree_provider` (bounded + per-run
+cached, best-effort). Emit-only: nothing here filters, re-tiers, or mutates a bridge.
+
+References:
+- Himmelstein & Baranzini, Heterogeneous Network Edge Prediction (DWPC), PLOS Comput Biol 2015,
+  10.1371/journal.pcbi.1004259. w ~= 0.4 empirically optimal for disease-gene prediction.
+- Himmelstein et al., Rephetio, eLife 2017, 26726.
+"""
+
+import asyncio
+import json
+import logging
+from typing import Any, Awaitable, Callable
+
+from ...kestrel_client import call_kestrel_tool
+from ..state import BridgeSpecificity
+
+logger = logging.getLogger(__name__)
+
+# --- Cited / tuned module constants (NOT runtime config) -----------------------------------
+# These are calibrated once from a real intermediate-degree distribution (Unit 4 probe), then
+# frozen — they are cited constants, not a per-run config surface (there is no consumer for
+# runtime-tunable cut points). The values below are placeholders pending the Unit 4 calibration
+# and are known to be mis-skewed relative to real KG degrees; they are chosen to (a) keep the
+# `specific` reward bucket reachable and (b) align the per-node generic cutoff with the pipeline's
+# existing "hub" notion (SharedNeighbor.is_hub = degree > 1000; direct_kg/integration hub guard).
+
+# DWPC damping exponent (Himmelstein 2015: w ~= 0.4 optimal for disease-gene prediction).
+DAMPING_W: float = 0.4
+
+# Aggregate-score cut points (applied only when the bridge is not condemned by a generic hub):
+#   score >= SPECIFIC_CUT -> "specific"
+#   score >= MODERATE_CUT -> "moderate"
+#   else                  -> "generic"
+# With w=0.4 and a single intermediate, score = degree**-0.4, so SPECIFIC_CUT=0.20 admits
+# degree <= ~55 and MODERATE_CUT=0.10 admits degree <= ~316. Placeholders (see note above).
+SPECIFIC_CUT: float = 0.20
+MODERATE_CUT: float = 0.10
+
+# Per-node degree cutoff: an intermediate whose OWN known degree strictly exceeds this is
+# "generic" and lands in `generic_intermediates`. Aligned with the existing is_hub definition
+# (degree > 1000). Placeholder pending the Unit 4 quantile calibration.
+GENERIC_CUTOFF: int = 1000
+
+
+def _bucket(score: float) -> str:
+    """Map an aggregate DWPC score to a label (inclusive on the upper bucket boundary)."""
+    if score >= SPECIFIC_CUT:
+        return "specific"
+    if score >= MODERATE_CUT:
+        return "moderate"
+    return "generic"
+
+
+def bridge_specificity(
+    intermediate_curies: list[str],
+    intermediate_degrees: list[int | None],
+) -> BridgeSpecificity:
+    """Pure DWPC scorer: intermediate CURIEs + degrees -> ``BridgeSpecificity``. No I/O.
+
+    Length-normalized (geometric-mean) DWPC: ``score = (prod known_degree_i) ** (-w / n_known)``,
+    so 1-, 2-, and 3-intermediate scaffolds are comparable under one cut point (a raw degree
+    product would penalize a longer path through several moderately-specific nodes purely for
+    length). Each degree is clamped to >= 1 (an isolated node, results_count == 0, is maximally
+    specific, and 0 ** -0.4 is infinite), so the score stays in (0, 1].
+
+    Rules:
+    - Zero intermediates (2-node bridge): maximally specific (score 1.0, label "specific").
+    - ``generic_intermediates`` = scaffold CURIEs whose OWN known degree strictly exceeds
+      ``GENERIC_CUTOFF``.
+    - Condemn-on-known: if any known intermediate is generic -> label "generic" regardless of any
+      missing degrees (a partially-unknown scaffold cannot become more specific by hiding a degree).
+    - ``label == "unknown"`` is reserved for the all-degrees-missing case only; ``score`` is then
+      None. The score is otherwise computed over the known-degree subset.
+
+    ``intermediate_curies`` and ``intermediate_degrees`` are parallel; ``intermediate_degrees``
+    preserves the raw values (including ``None`` and 0) on the returned model.
+    """
+    curies = list(intermediate_curies)
+    degrees = list(intermediate_degrees)
+
+    # 2-node bridge: no scaffold to discount -> maximally specific.
+    if not curies:
+        return BridgeSpecificity(
+            score=1.0,
+            label="specific",
+            intermediate_curies=[],
+            intermediate_degrees=[],
+            generic_intermediates=[],
+        )
+
+    # Generic hubs are decided on KNOWN degrees (strict >), independent of the score.
+    generic_intermediates = [
+        c for c, d in zip(curies, degrees) if d is not None and d > GENERIC_CUTOFF
+    ]
+
+    known = [d for d in degrees if d is not None]
+    if not known:
+        # All degrees missing: no evidence either way -> unknown (score None).
+        return BridgeSpecificity(
+            score=None,
+            label="unknown",
+            intermediate_curies=curies,
+            intermediate_degrees=degrees,
+            generic_intermediates=generic_intermediates,
+        )
+
+    # Length-normalized geometric-mean DWPC over the known subset; clamp each degree to >= 1.
+    product = 1.0
+    for d in known:
+        product *= max(int(d), 1)
+    score = product ** (-DAMPING_W / len(known))
+
+    # Condemn-on-known: a generic hub forces "generic" regardless of any missing degrees.
+    label = "generic" if generic_intermediates else _bucket(score)
+
+    return BridgeSpecificity(
+        score=score,
+        label=label,
+        intermediate_curies=curies,
+        intermediate_degrees=degrees,
+        generic_intermediates=generic_intermediates,
+    )

--- a/backend/src/kestrel_backend/graph/nodes/integration.py
+++ b/backend/src/kestrel_backend/graph/nodes/integration.py
@@ -30,6 +30,7 @@ from ...kestrel_client import multi_hop_query, call_kestrel_tool, parse_kestrel_
 from ..sdk_utils import HAS_SDK, ClaudeAgentOptions, query_with_usage
 from ..state_contracts import validate_state, IntegrationInput, IntegrationOutput
 from ..pipeline_config import get_pipeline_config
+from .bridge_specificity import score_bridges, summarize_specificity
 
 logger = logging.getLogger(__name__)
 
@@ -595,8 +596,41 @@ Analyze these findings to identify cross-type bridges and expected-but-absent en
         if subgraph_bridges:
             logger.info("Subgraph detection added %d connecting-structure bridge(s)",
                         len(subgraph_bridges))
+        multi_hop_bridges = api_bridges  # ordered [endpoint, ...intermediates..., endpoint]
         api_bridges = api_bridges + subgraph_bridges
         api_errors = api_errors + subgraph_errors
+
+        # Phase A.3 (axis C, flag-gated, emit-only): score bridge specificity by intermediate
+        # degree (DWPC) into a state SIDE-MAP keyed by tuple(entities). Non-destructive — no bridge
+        # is dropped, re-tiered, or mutated, and the frozen Bridge model gains no field. Ships
+        # enabled=False until axis E (synthesis) consumes the side-map. When off: zero Kestrel calls.
+        specificity_by_bridge: dict[tuple[str, ...], Any] = {}
+        spec_cfg = get_pipeline_config().bridge_specificity
+        if spec_cfg.enabled:
+            input_curies = {e.curie for e in resolved if e.curie}
+            # Scaffold identification is PER-BUILDER, never positional:
+            #   multi_hop bridges are ordered endpoint..intermediates..endpoint -> entities[1:-1];
+            #   subgraph bridges list endpoints FIRST, so the scaffold is the non-input-CURIE
+            #   entities (a positional entities[1:-1] slice would mis-score them).
+            pairs: list[tuple[Bridge, list[str]]] = [
+                (b, list(b.entities[1:-1])) for b in multi_hop_bridges
+            ]
+            pairs += [
+                (b, [c for c in b.entities if c not in input_curies]) for b in subgraph_bridges
+            ]
+            # Inline degree is threaded as None: the documented multi_hop/subgraph `nodes` entry is
+            # {name, categories} (no per-node degree), so the provider is fetch-dominant. The
+            # provider stays inline-capable for a future envelope that carries degree.
+            specificity_by_bridge, spec_errors = await score_bridges(
+                pairs,
+                inline_nodes=None,
+                max_scored_bridges=spec_cfg.max_scored_bridges,
+                concurrency=spec_cfg.concurrency,
+            )
+            api_errors = api_errors + spec_errors
+            logger.info(
+                "bridge_specificity: %s", summarize_specificity(specificity_by_bridge)
+            )
 
         # Phase B: Gap analysis using LLM (reasoning-intensive)
         logger.info("Starting LLM-based gap analysis...")
@@ -702,6 +736,8 @@ If no gaps found, return: {{"gaps": []}}
             "gap_entities": gaps,
             "direct_findings": findings,  # Uses operator.add reducer
             "errors": parse_errors,
+            # Axis C side-map (empty when disabled); NOT a Bridge field. Last-write-wins.
+            "specificity_by_bridge": specificity_by_bridge,
         }
         if usage_record is not None:
             result_dict["model_usages"] = [usage_record]

--- a/backend/src/kestrel_backend/graph/pipeline_config.py
+++ b/backend/src/kestrel_backend/graph/pipeline_config.py
@@ -319,6 +319,37 @@ class BridgeGroundingConfig(BaseModel):
     )
 
 
+class BridgeSpecificityConfig(BaseModel):
+    """Configuration for bridge specificity scoring (axis C — DWPC structural genericity).
+
+    Only OPERATIONAL knobs live here. The DWPC damping exponent and the label cut points /
+    per-node generic cutoff are cited/tuned module constants in
+    ``graph.nodes.bridge_specificity`` (calibrated once from a real intermediate-degree
+    distribution — Unit 4 — not a per-run config surface with no consumer).
+    """
+
+    enabled: bool = Field(
+        default=False,
+        description="Ships False: this is a PRODUCER whose only consumer (axis E synthesis) is a "
+        "separate deferred PR, so it should not incur live Kestrel degree fetches to populate a "
+        "side-map nothing reads yet. Flip to True when axis E lands (mirrors bridge_grounding's "
+        "gated flip). The Unit 4 measurement runs via an explicit probe, not prod default-on.",
+    )
+    max_scored_bridges: int = Field(
+        default=20,
+        ge=1,
+        description="Cap on bridges scored per run. Each un-cached intermediate costs one "
+        "one_hop_query preview call; per-CURIE fetches are deduped within a run, so a module whose "
+        "bridges share hub intermediates fetches each hub once. Bounds the added Kestrel load.",
+    )
+    concurrency: int = Field(
+        default=8,
+        ge=1,
+        description="Max concurrent degree one_hop_query calls. Bounded + per-run deduped to avoid "
+        "the unbounded one_hop fan-out that once exhausted Kestrel's LMDB readers (MDB_READERS_FULL).",
+    )
+
+
 class SynthesisConfig(BaseModel):
     """Configuration for the synthesis node's context-assembly caps.
 
@@ -405,6 +436,7 @@ class PipelineConfig(BaseModel):
     hypothesis_extraction: HypothesisExtractionConfig = Field(default_factory=HypothesisExtractionConfig)
     integration: IntegrationConfig = Field(default_factory=IntegrationConfig)
     bridge_grounding: BridgeGroundingConfig = Field(default_factory=BridgeGroundingConfig)
+    bridge_specificity: BridgeSpecificityConfig = Field(default_factory=BridgeSpecificityConfig)
     synthesis: SynthesisConfig = Field(default_factory=SynthesisConfig)
 
 

--- a/backend/src/kestrel_backend/graph/state.py
+++ b/backend/src/kestrel_backend/graph/state.py
@@ -200,6 +200,45 @@ class BridgeGrounding(BaseModel):
     label: str = Field(..., description="Chain summary, e.g. 'both legs curated-causal' / 'no KG edge'")
 
 
+class BridgeSpecificity(BaseModel):
+    """Structural-genericity signal for a bridge, from the KG degree of its intermediate node(s).
+
+    Degree-Weighted Path Count (DWPC) damping (Himmelstein & Baranzini 2015; Rephetio 2017):
+    bridges through generic, high-degree intermediates ("blood", "cancer") are penalized; bridges
+    through specific, low-degree intermediates are rewarded. Length-normalized (geometric-mean)
+    DWPC so 1-, 2-, and 3-intermediate scaffolds are comparable under one cut point.
+
+    This reports STRUCTURAL genericity, NOT mechanism confidence. It is attached non-destructively
+    as a state side-map (``specificity_by_bridge`` keyed by ``tuple(bridge.entities)``), NOT a field
+    on the frozen ``Bridge``. Field names are PINNED by the cross-axis contract (ledger L12/L17) —
+    axis E (synthesis) reads them by these exact names.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    score: float | None = Field(
+        ...,
+        description="Length-normalized DWPC in (0,1]; higher = more specific. None only when ALL "
+        "intermediate degrees are missing (label == 'unknown').",
+    )
+    label: str = Field(
+        ..., description="specific | moderate | generic | unknown"
+    )
+    intermediate_curies: list[str] = Field(
+        default_factory=list, description="Scaffold CURIEs (endpoints excluded)"
+    )
+    intermediate_degrees: list[int | None] = Field(
+        default_factory=list,
+        description="KG degree per intermediate, parallel to intermediate_curies; None where the "
+        "degree could not be fetched (preserved even when the bridge is condemned on known evidence).",
+    )
+    generic_intermediates: list[str] = Field(
+        default_factory=list,
+        description="Scaffold CURIEs whose own known degree exceeds GENERIC_CUTOFF (can be non-empty "
+        "even when some degrees are None — condemn-on-known).",
+    )
+
+
 class Bridge(BaseModel):
     """Cross-entity-type connection discovered through multi-hop analysis."""
 
@@ -465,6 +504,14 @@ class DiscoveryState(TypedDict, total=False):
     # whose operator.add reducer is load-bearing for integration/synthesis writes; see plan U1).
     grounded_bridges: list[Bridge]
     bridge_grounding_errors: Annotated[list[str], operator.add]
+
+    # === Phase 4b (axis C): Bridge specificity (structural genericity by intermediate degree) ===
+    # A state SIDE-MAP keyed by tuple(bridge.entities) -> BridgeSpecificity (NOT a Bridge field;
+    # the frozen Bridge model is unchanged). Mirrors grounded_bridges: plain last-write-wins (NO
+    # operator.add) — integration writes it once. Duplicate bridges sharing an entities tuple
+    # collapse to one entry (accepted, same as the grounding-label map). Axis E (synthesis) reads
+    # it by tuple(entities); a missing key means "not scored / no signal".
+    specificity_by_bridge: dict[tuple[str, ...], BridgeSpecificity]
 
     # === Cost Tracking ===
     # Uses operator.add reducer for parallel writes from concurrent branches

--- a/backend/src/kestrel_backend/graph/state_contracts.py
+++ b/backend/src/kestrel_backend/graph/state_contracts.py
@@ -272,9 +272,16 @@ class PathwayEnrichmentOutput(_ContractBase):
 
 
 class IntegrationOutput(_ContractBase):
-    """Integration must produce bridges and gap_entities."""
+    """Integration must produce bridges and gap_entities.
+
+    ``specificity_by_bridge`` is the axis-C bridge-specificity side-map (tuple(entities) ->
+    BridgeSpecificity), emitted alongside bridges. Optional: it defaults to an empty dict so the
+    (default-off) producer and every early-return path still validate; it rides the existing
+    bridges output and needs no reducer (last-write-wins).
+    """
     bridges: list[Any]
     gap_entities: list[Any]
+    specificity_by_bridge: dict[Any, Any] | None = None
 
 
 class TemporalOutput(_ContractBase):

--- a/backend/tests/fixtures/bridge_specificity_1mna_degrees.json
+++ b/backend/tests/fixtures/bridge_specificity_1mna_degrees.json
@@ -1,18 +1,46 @@
 {
   "provenance": {
-    "source": "PLACEHOLDER pending a live Kestrel calibration run. Regenerate with: PYTHONPATH=. uv run python assessment_data/bridge_specificity_calibration.py (writes this file + a persisted run artifact). blood/placenta/cancer are known extreme KG hubs (>10^4 edges); the control is a plausible low-degree intermediate. The retrodiction assertions test the SCORER LOGIC against the 1-MNA scaffold shape and MUST continue to hold once real measured degrees replace these.",
-    "query_sha": "PLACEHOLDER",
-    "recorded_at": "PLACEHOLDER",
+    "source": "live Kestrel calibration run",
+    "query_sha": "e5d4db84bc7098e0",
+    "recorded_at": "20260717T071202Z",
     "damping_w": 0.4,
-    "note": "1-MNA hypothesis: TNFRSF10A -> 1-MNA via blood, placenta, cancer. Its intermediates are near-universal high-degree nodes; the bridge INVERTED. This scaffold must score `generic`."
+    "degree_query_limit": 10000,
+    "note": "1-MNA hypothesis: TNFRSF10A -> 1-MNA via blood, placenta, cancer. Intermediates are near-universal high-degree nodes; the bridge INVERTED. Degrees are one_hop_query preview results_count, saturated at degree_query_limit (10000) \u2014 so a value == the limit is a FLOOR on the true (larger) hub degree, not an exact count. This is immaterial to the generic retrodiction (limit >> GENERIC_CUTOFF)."
   },
   "one_mna_scaffold": {
-    "UBERON:0000178": {"name": "blood", "degree": 48000},
-    "UBERON:0001987": {"name": "placenta", "degree": 22000},
-    "MONDO:0004992": {"name": "cancer", "degree": 15000}
+    "UBERON:0000178": {
+      "name": "blood",
+      "degree": 10000
+    },
+    "UBERON:0001987": {
+      "name": "placenta",
+      "degree": 10000
+    },
+    "MONDO:0004992": {
+      "name": "cancer",
+      "degree": 10000
+    }
   },
   "control_specific": {
-    "CHEBI:16797": {"name": "1-methylnicotinamide (low-degree control)", "degree": 18}
+    "CHEBI:16797": {
+      "name": "1-methylnicotinamide",
+      "degree": 143
+    }
   },
-  "recorded_intermediate_population": [3, 8, 12, 18, 25, 41, 63, 120, 310, 850, 2100, 15000, 22000, 48000]
+  "recorded_intermediate_population": [
+    10000,
+    10000,
+    10000,
+    143,
+    10000,
+    7808,
+    7471,
+    5333,
+    1270,
+    10000,
+    10000,
+    10000,
+    10000,
+    115
+  ]
 }

--- a/backend/tests/fixtures/bridge_specificity_1mna_degrees.json
+++ b/backend/tests/fixtures/bridge_specificity_1mna_degrees.json
@@ -1,0 +1,18 @@
+{
+  "provenance": {
+    "source": "PLACEHOLDER pending a live Kestrel calibration run. Regenerate with: PYTHONPATH=. uv run python assessment_data/bridge_specificity_calibration.py (writes this file + a persisted run artifact). blood/placenta/cancer are known extreme KG hubs (>10^4 edges); the control is a plausible low-degree intermediate. The retrodiction assertions test the SCORER LOGIC against the 1-MNA scaffold shape and MUST continue to hold once real measured degrees replace these.",
+    "query_sha": "PLACEHOLDER",
+    "recorded_at": "PLACEHOLDER",
+    "damping_w": 0.4,
+    "note": "1-MNA hypothesis: TNFRSF10A -> 1-MNA via blood, placenta, cancer. Its intermediates are near-universal high-degree nodes; the bridge INVERTED. This scaffold must score `generic`."
+  },
+  "one_mna_scaffold": {
+    "UBERON:0000178": {"name": "blood", "degree": 48000},
+    "UBERON:0001987": {"name": "placenta", "degree": 22000},
+    "MONDO:0004992": {"name": "cancer", "degree": 15000}
+  },
+  "control_specific": {
+    "CHEBI:16797": {"name": "1-methylnicotinamide (low-degree control)", "degree": 18}
+  },
+  "recorded_intermediate_population": [3, 8, 12, 18, 25, 41, 63, 120, 310, 850, 2100, 15000, 22000, 48000]
+}

--- a/backend/tests/test_bridge_specificity_degree_provider.py
+++ b/backend/tests/test_bridge_specificity_degree_provider.py
@@ -1,0 +1,130 @@
+"""Axis C, Unit 2 — hybrid, bounded, per-run cached degree provider.
+
+Resolves a CURIE's KG degree: opportunistic inline read first, else a semaphore-bounded,
+per-run dedup-cached ``one_hop_query`` count fetch (mode="preview", ``results_count`` — as
+triage does). Never raises; returns ``int | None``. Mirrors ``bridge_grounding.cached_leg_fetcher``.
+
+Run with: uv run python -m pytest tests/test_bridge_specificity_degree_provider.py -v
+"""
+
+import asyncio
+
+import pytest
+
+from kestrel_backend.graph.nodes import bridge_specificity as bs
+
+
+def _preview_response(count: int) -> dict:
+    return {"isError": False, "content": [{"text": f'{{"results_count": {count}}}'}]}
+
+
+def _stub_kestrel(monkeypatch, handler, calls=None):
+    async def fake(tool_name, params):
+        if calls is not None:
+            calls.append((tool_name, params))
+        return await handler(tool_name, params) if asyncio.iscoroutinefunction(handler) else handler(tool_name, params)
+    monkeypatch.setattr(bs, "call_kestrel_tool", fake)
+
+
+# --- happy path ----------------------------------------------------------------------------
+
+async def test_cold_curie_one_preview_fetch(monkeypatch):
+    calls = []
+    _stub_kestrel(monkeypatch, lambda t, p: _preview_response(42), calls)
+    get = bs.make_degree_provider(concurrency=4)
+    assert await get("HGNC:1") == 42
+    assert len(calls) == 1
+    tool, params = calls[0]
+    assert tool == "one_hop_query"
+    assert params["start_node_ids"] == "HGNC:1"
+    assert params["mode"] == "preview"
+
+
+# --- opportunistic inline read -------------------------------------------------------------
+
+async def test_inline_degree_used_without_fetch(monkeypatch):
+    calls = []
+    _stub_kestrel(monkeypatch, lambda t, p: _preview_response(999), calls)
+    # Only meaningful if a live envelope is confirmed to carry per-node degree; the provider
+    # treats it as an opportunistic bonus.
+    get = bs.make_degree_provider(inline_nodes={"HGNC:1": {"name": "X", "degree": 7}})
+    assert await get("HGNC:1") == 7
+    assert calls == []  # no fetch when inline degree present
+
+
+async def test_inline_without_degree_falls_back_to_fetch(monkeypatch):
+    calls = []
+    _stub_kestrel(monkeypatch, lambda t, p: _preview_response(55), calls)
+    # Documented nodes entry is {name, categories} -> NO degree; must fall back to the fetch.
+    get = bs.make_degree_provider(inline_nodes={"HGNC:1": {"name": "X", "categories": ["biolink:Gene"]}})
+    assert await get("HGNC:1") == 55
+    assert len(calls) == 1
+
+
+# --- per-run cache (dedup) -----------------------------------------------------------------
+
+async def test_same_curie_fetched_once(monkeypatch):
+    calls = []
+    _stub_kestrel(monkeypatch, lambda t, p: _preview_response(10), calls)
+    get = bs.make_degree_provider()
+    assert await get("HGNC:1") == 10
+    assert await get("HGNC:1") == 10
+    assert len(calls) == 1  # cache hit second time
+
+
+async def test_none_result_is_cached(monkeypatch):
+    calls = []
+    _stub_kestrel(monkeypatch, lambda t, p: {"isError": True, "content": []}, calls)
+    get = bs.make_degree_provider()
+    assert await get("HGNC:1") is None
+    assert await get("HGNC:1") is None
+    assert len(calls) == 1  # a None result is cached too (no re-fetch)
+
+
+# --- error paths (never raise) -------------------------------------------------------------
+
+async def test_isError_returns_none(monkeypatch):
+    _stub_kestrel(monkeypatch, lambda t, p: {"isError": True, "content": [{"text": "boom"}]})
+    get = bs.make_degree_provider()
+    assert await get("HGNC:1") is None
+
+
+async def test_exception_returns_none(monkeypatch):
+    def boom(t, p):
+        raise RuntimeError("kestrel down")
+    _stub_kestrel(monkeypatch, boom)
+    get = bs.make_degree_provider()
+    assert await get("HGNC:1") is None  # no exception escapes
+
+
+async def test_unparseable_response_returns_none(monkeypatch):
+    _stub_kestrel(monkeypatch, lambda t, p: {"isError": False, "content": [{"text": "not json"}]})
+    get = bs.make_degree_provider()
+    assert await get("HGNC:1") is None
+
+
+async def test_missing_results_count_returns_none(monkeypatch):
+    _stub_kestrel(monkeypatch, lambda t, p: {"isError": False, "content": [{"text": "{}"}]})
+    get = bs.make_degree_provider()
+    assert await get("HGNC:1") is None
+
+
+# --- concurrency bound ---------------------------------------------------------------------
+
+async def test_concurrency_never_exceeds_bound(monkeypatch):
+    bound = 3
+    state = {"in_flight": 0, "max": 0}
+
+    async def handler(t, p):
+        state["in_flight"] += 1
+        state["max"] = max(state["max"], state["in_flight"])
+        await asyncio.sleep(0.01)  # hold the slot so overlap is observable
+        state["in_flight"] -= 1
+        return _preview_response(1)
+
+    _stub_kestrel(monkeypatch, handler)
+    get = bs.make_degree_provider(concurrency=bound)
+    curies = [f"HGNC:{i}" for i in range(12)]  # all distinct -> no cache dedup
+    results = await asyncio.gather(*[get(c) for c in curies])
+    assert all(r == 1 for r in results)
+    assert state["max"] <= bound

--- a/backend/tests/test_bridge_specificity_retrodiction.py
+++ b/backend/tests/test_bridge_specificity_retrodiction.py
@@ -1,12 +1,26 @@
-"""Axis C, Unit 4 — 1-MNA retrodiction + distribution measurement hook.
+"""Axis C, Unit 4 — 1-MNA retrodiction + scorer-math + distribution measurement hook.
 
 The 1-MNA hypothesis ("TNFRSF10A -> 1-MNA via blood, placenta, cancer") INVERTED. Its
 intermediates are near-universal, extremely high-degree KG nodes — "both found in blood" carries
-near-zero evidential weight. This test proves the DWPC scorer would have FLAGGED that scaffold as
-`generic` (and a low-degree control as `specific`) using the recorded real degrees of those nodes,
-NOT hand-picked round numbers. Degrees come from the calibration fixture the live probe produces
-(assessment_data/bridge_specificity_calibration.py); the cut-point constants are tuned on an
-independent distribution, so the retrodiction is not fitted to this same fixture.
+near-zero evidential weight. This module proves the DWPC scorer would have FLAGGED that scaffold as
+`generic` using the RECORDED REAL degrees of those nodes.
+
+Two distinct kinds of test live here, deliberately NOT conflated (a reviewer flagged an earlier
+version whose "live retrodiction" actually asserted against fabricated placeholder degrees):
+
+  * REAL-degree retrodiction — reads tests/fixtures/bridge_specificity_1mna_degrees.json, which is
+    produced ONLY by the live calibration probe (assessment_data/bridge_specificity_calibration.py)
+    against Kestrel. These assertions are meaningful only because the degrees are measured, not
+    hand-picked. Regenerate the fixture by running the probe; do NOT hand-edit degrees into it.
+  * SCORER MATH — uses SYNTHETIC degrees, clearly labelled, to prove the pure scorer transform (that
+    the `specific` reward band is reachable in principle). No claim about real KG data.
+
+The real degrees also exposed a genuine calibration gap: under the current PLACEHOLDER cut points
+(SPECIFIC_CUT=0.20), the `specific` reward band is unreachable on the real intermediate-degree
+population (the lowest real intermediate measured is ~115; `specific` admits degree <= ~55). That
+gap is asserted as an ``xfail`` below rather than hidden behind fabricated low degrees — it clears
+once the constants are recalibrated from a real distribution (and _DEGREE_QUERY_LIMIT raised so the
+mega-hubs are not saturated at the query cap).
 
 Run with: uv run python -m pytest tests/test_bridge_specificity_retrodiction.py -v
 """
@@ -19,6 +33,7 @@ import pytest
 from kestrel_backend.graph.nodes.bridge_specificity import (
     GENERIC_CUTOFF,
     MODERATE_CUT,
+    SPECIFIC_CUT,
     bridge_specificity,
     summarize_specificity,
 )
@@ -28,10 +43,19 @@ _FIXTURE = Path(__file__).parent / "fixtures" / "bridge_specificity_1mna_degrees
 
 @pytest.fixture(scope="module")
 def recorded() -> dict:
-    return json.loads(_FIXTURE.read_text())
+    data = json.loads(_FIXTURE.read_text())
+    # Guard against a hand-faked fixture: the retrodiction is only load-bearing if these degrees
+    # came from the live probe. A PLACEHOLDER marker means nobody has recorded real degrees yet.
+    if "PLACEHOLDER" in json.dumps(data.get("provenance", {})):
+        pytest.skip(
+            "bridge_specificity_1mna_degrees.json holds PLACEHOLDER degrees — run the live probe "
+            "(assessment_data/bridge_specificity_calibration.py) to record real Kestrel degrees "
+            "before the retrodiction can assert anything."
+        )
+    return data
 
 
-# --- retrodiction: the 1-MNA scaffold must be condemned as generic ------------------------
+# --- REAL-degree retrodiction: the 1-MNA scaffold must be condemned as generic ------------------
 
 def test_1mna_scaffold_labels_generic(recorded):
     scaffold = recorded["one_mna_scaffold"]
@@ -49,30 +73,62 @@ def test_1mna_scaffold_labels_generic(recorded):
     assert all(d > GENERIC_CUTOFF for d in degrees)
 
 
-# --- retrodiction control: a low-degree intermediate must reach specific -------------------
+# --- REAL-degree retrodiction: a low-degree metabolite is rewarded relative to the hubs ---------
 
-def test_low_degree_control_labels_specific(recorded):
+def test_low_degree_control_scores_above_generic_scaffold(recorded):
+    # The recorded control (1-methylnicotinamide) is a genuinely low-degree metabolite. The
+    # meaningful retrodiction contrast is that it is NOT condemned as a generic hub and scores
+    # strictly above the all-hub scaffold — i.e. the DWPC signal separates them on real degrees.
+    # NOTE: under the current PLACEHOLDER constants it lands `moderate`, not `specific` (its real
+    # degree ~143 clears the generic cutoff but not the un-calibrated `specific` threshold); the
+    # reward-threshold gap is characterised by the xfail'd population test below.
     control = recorded["control_specific"]
     curies = list(control)
     degrees = [control[c]["degree"] for c in curies]
+    control_spec = bridge_specificity(curies, degrees)
 
-    spec = bridge_specificity(curies, degrees)
+    scaffold = recorded["one_mna_scaffold"]
+    scaffold_curies = list(scaffold)
+    scaffold_spec = bridge_specificity(
+        scaffold_curies, [scaffold[c]["degree"] for c in scaffold_curies]
+    )
 
+    assert control_spec.label != "generic"
+    assert control_spec.generic_intermediates == []
+    assert control_spec.score is not None and scaffold_spec.score is not None
+    assert control_spec.score > scaffold_spec.score
+
+
+# --- SCORER MATH (synthetic degrees): the `specific` reward band is reachable in principle -------
+
+def test_scorer_specific_band_reachable_synthetic():
+    # Pure scorer transform on a SYNTHETIC low degree — no real-KG claim. Proves the reward axis is
+    # not dead code: a sufficiently specific (low-degree) intermediate does clear SPECIFIC_CUT.
+    spec = bridge_specificity(["SYNTHETIC:1"], [5])
     assert spec.label == "specific"
+    assert spec.score is not None and spec.score >= SPECIFIC_CUT
     assert spec.generic_intermediates == []
 
 
-# --- calibration guard: the reward bucket is reachable on the recorded population ----------
+# --- REAL-population reward reachability: currently a KNOWN calibration gap (xfail) --------------
 
-def test_specific_is_reachable_on_recorded_population(recorded):
-    # Under the calibrated constants a nontrivial fraction of the real intermediate-degree
-    # population must land `specific` — else the reward axis is decorative (only the penalty
-    # side ever fires). Each population degree is a single-intermediate scaffold here.
+@pytest.mark.xfail(
+    strict=True,
+    reason="PLACEHOLDER cut points leave `specific` unreachable on the real intermediate-degree "
+    "population (lowest measured ~115; SPECIFIC_CUT=0.20 admits degree <= ~55). Un-xfail after the "
+    "constants are recalibrated from a real distribution (bridge_specificity_calibration.py "
+    "recommends quantile cut points) and _DEGREE_QUERY_LIMIT is raised so mega-hubs are not "
+    "saturated at the query cap.",
+)
+def test_specific_reachable_on_recorded_population(recorded):
+    # Under a properly calibrated set of constants a nontrivial fraction of the real
+    # intermediate-degree population should land `specific` — else the reward axis is decorative
+    # (only the penalty side ever fires). This asserts the calibrated TARGET, not today's behaviour.
     population = recorded["recorded_intermediate_population"]
     labels = [bridge_specificity([f"N:{i}"], [d]).label for i, d in enumerate(population)]
     n_specific = labels.count("specific")
     assert n_specific >= 2, f"reward bucket collapsed: labels={labels}"
-    # and the generic penalty side also fires (the hubs)
+    # the generic penalty side must also fire (the hubs) — this half holds on real degrees today
     assert labels.count("generic") >= 1
 
 

--- a/backend/tests/test_bridge_specificity_retrodiction.py
+++ b/backend/tests/test_bridge_specificity_retrodiction.py
@@ -1,0 +1,102 @@
+"""Axis C, Unit 4 — 1-MNA retrodiction + distribution measurement hook.
+
+The 1-MNA hypothesis ("TNFRSF10A -> 1-MNA via blood, placenta, cancer") INVERTED. Its
+intermediates are near-universal, extremely high-degree KG nodes — "both found in blood" carries
+near-zero evidential weight. This test proves the DWPC scorer would have FLAGGED that scaffold as
+`generic` (and a low-degree control as `specific`) using the recorded real degrees of those nodes,
+NOT hand-picked round numbers. Degrees come from the calibration fixture the live probe produces
+(assessment_data/bridge_specificity_calibration.py); the cut-point constants are tuned on an
+independent distribution, so the retrodiction is not fitted to this same fixture.
+
+Run with: uv run python -m pytest tests/test_bridge_specificity_retrodiction.py -v
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kestrel_backend.graph.nodes.bridge_specificity import (
+    GENERIC_CUTOFF,
+    MODERATE_CUT,
+    bridge_specificity,
+    summarize_specificity,
+)
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "bridge_specificity_1mna_degrees.json"
+
+
+@pytest.fixture(scope="module")
+def recorded() -> dict:
+    return json.loads(_FIXTURE.read_text())
+
+
+# --- retrodiction: the 1-MNA scaffold must be condemned as generic ------------------------
+
+def test_1mna_scaffold_labels_generic(recorded):
+    scaffold = recorded["one_mna_scaffold"]
+    curies = list(scaffold)
+    degrees = [scaffold[c]["degree"] for c in curies]
+
+    spec = bridge_specificity(curies, degrees)
+
+    assert spec.label == "generic"
+    # all three near-universal hubs are flagged as the offending generic intermediates
+    assert set(spec.generic_intermediates) == set(curies)
+    # aggregate score sits in the generic band (well below the specific/moderate reward buckets)
+    assert spec.score is not None and spec.score < MODERATE_CUT
+    # and every recorded degree genuinely exceeds the per-node generic cutoff
+    assert all(d > GENERIC_CUTOFF for d in degrees)
+
+
+# --- retrodiction control: a low-degree intermediate must reach specific -------------------
+
+def test_low_degree_control_labels_specific(recorded):
+    control = recorded["control_specific"]
+    curies = list(control)
+    degrees = [control[c]["degree"] for c in curies]
+
+    spec = bridge_specificity(curies, degrees)
+
+    assert spec.label == "specific"
+    assert spec.generic_intermediates == []
+
+
+# --- calibration guard: the reward bucket is reachable on the recorded population ----------
+
+def test_specific_is_reachable_on_recorded_population(recorded):
+    # Under the calibrated constants a nontrivial fraction of the real intermediate-degree
+    # population must land `specific` — else the reward axis is decorative (only the penalty
+    # side ever fires). Each population degree is a single-intermediate scaffold here.
+    population = recorded["recorded_intermediate_population"]
+    labels = [bridge_specificity([f"N:{i}"], [d]).label for i, d in enumerate(population)]
+    n_specific = labels.count("specific")
+    assert n_specific >= 2, f"reward bucket collapsed: labels={labels}"
+    # and the generic penalty side also fires (the hubs)
+    assert labels.count("generic") >= 1
+
+
+# --- distribution measurement hook --------------------------------------------------------
+
+def test_summarize_specificity_counts_labels():
+    smap = {
+        ("a",): bridge_specificity(["X:1"], [5]),        # specific
+        ("b",): bridge_specificity(["X:2"], [GENERIC_CUTOFF * 5]),  # generic
+        ("c",): bridge_specificity(["X:3"], [None]),     # unknown
+    }
+    summary = summarize_specificity(smap)
+
+    assert summary["scored"] == 3
+    assert summary["counts"]["specific"] == 1
+    assert summary["counts"]["generic"] == 1
+    assert summary["counts"]["unknown"] == 1
+    # score summary computed only over non-None scores (specific + generic here)
+    assert "score_min" in summary and "score_median" in summary and "score_max" in summary
+    assert summary["score_max"] >= summary["score_min"]
+
+
+def test_summarize_specificity_empty_map():
+    summary = summarize_specificity({})
+    assert summary["scored"] == 0
+    assert summary["counts"] == {"specific": 0, "moderate": 0, "generic": 0, "unknown": 0}
+    assert "score_min" not in summary  # no scores -> no score summary keys

--- a/backend/tests/test_bridge_specificity_scorer.py
+++ b/backend/tests/test_bridge_specificity_scorer.py
@@ -1,0 +1,169 @@
+"""Axis C, Unit 1 — pure DWPC bridge-specificity scorer + BridgeSpecificity model.
+
+The scorer maps a bridge's intermediate-node CURIEs + KG degrees to a frozen
+``BridgeSpecificity`` (structural genericity, NOT mechanism confidence). Length-normalized
+geometric-mean DWPC (Himmelstein 2015, w=0.4) so 1-, 2-, 3-intermediate scaffolds are
+comparable under one cut point. No I/O — deterministic and pure.
+
+Run with: uv run python -m pytest tests/test_bridge_specificity_scorer.py -v
+"""
+
+import math
+
+import pytest
+from pydantic import ValidationError
+
+from kestrel_backend.graph.nodes.bridge_specificity import (
+    DAMPING_W,
+    GENERIC_CUTOFF,
+    MODERATE_CUT,
+    SPECIFIC_CUT,
+    bridge_specificity,
+)
+from kestrel_backend.graph.state import BridgeSpecificity
+
+
+# --- model ---------------------------------------------------------------------------------
+
+def test_model_field_names_are_pinned():
+    # Contract L12/L17: axis E reads these exact names. Renaming requires a new ledger entry.
+    assert set(BridgeSpecificity.model_fields) == {
+        "score",
+        "label",
+        "intermediate_curies",
+        "intermediate_degrees",
+        "generic_intermediates",
+    }
+
+
+def test_model_is_frozen():
+    spec = bridge_specificity(["X:1"], [1])
+    with pytest.raises(ValidationError):
+        spec.score = 0.0  # type: ignore[misc]
+
+
+# --- happy paths ---------------------------------------------------------------------------
+
+def test_single_degree_one_intermediate_is_maximally_specific():
+    spec = bridge_specificity(["X:1"], [1])
+    assert spec.score == pytest.approx(1.0)
+    assert spec.label == "specific"
+    assert spec.generic_intermediates == []
+    assert spec.intermediate_curies == ["X:1"]
+    assert spec.intermediate_degrees == [1]
+
+
+def test_single_high_degree_intermediate_is_generic():
+    d = GENERIC_CUTOFF * 5
+    spec = bridge_specificity(["HUB:blood"], [d])
+    assert spec.label == "generic"
+    assert "HUB:blood" in spec.generic_intermediates
+    assert 0.0 < spec.score < SPECIFIC_CUT
+
+
+def test_two_mid_degree_intermediates_geometric_mean_in_range():
+    degrees = [30, 60]
+    spec = bridge_specificity(["A:1", "B:2"], degrees)
+    expected = (30 * 60) ** (-DAMPING_W / 2)
+    assert spec.score == pytest.approx(expected)
+    assert 0.0 < spec.score <= 1.0
+    assert spec.label in {"specific", "moderate", "generic"}
+
+
+# --- length normalization (the reward axis must fire) --------------------------------------
+
+def test_length_normalization_two_low_degree_nodes_stay_specific():
+    # Two genuinely low-degree nodes MUST NOT be condemned purely for scaffold length.
+    # Under a RAW product ((d1*d2)**-0.4) this would score much lower; length-normalization
+    # (geometric mean) keeps it in the reward bucket.
+    spec = bridge_specificity(["A:1", "B:2"], [10, 10])
+    raw_product_score = (10 * 10) ** (-DAMPING_W)  # what a non-normalized DWPC would give
+    assert spec.score > raw_product_score
+    assert spec.label == "specific"
+    assert spec.generic_intermediates == []
+
+
+def test_specific_is_reachable_for_realistic_low_degree_scaffold():
+    # Calibration guard (unit-level): the reward bucket is not decorative — a plausible
+    # low-degree intermediate (tens of edges) reaches `specific`.
+    spec = bridge_specificity(["A:1"], [20])
+    assert spec.label == "specific"
+
+
+# --- condemn-on-known (partial-unknown) ----------------------------------------------------
+
+def test_condemn_on_known_high_degree_with_missing_degree():
+    spec = bridge_specificity(["HUB:blood", "X:unknown"], [GENERIC_CUTOFF * 10, None])
+    assert spec.label == "generic"
+    assert "HUB:blood" in spec.generic_intermediates
+    assert "X:unknown" not in spec.generic_intermediates
+    # score computed over the known subset only
+    assert spec.score == pytest.approx((GENERIC_CUTOFF * 10) ** (-DAMPING_W))
+    assert spec.intermediate_degrees == [GENERIC_CUTOFF * 10, None]
+
+
+# --- unknown reserved for all-missing ------------------------------------------------------
+
+def test_all_degrees_missing_is_unknown():
+    spec = bridge_specificity(["A:1", "B:2"], [None, None])
+    assert spec.label == "unknown"
+    assert spec.score is None
+    assert spec.generic_intermediates == []
+    assert spec.intermediate_degrees == [None, None]
+
+
+# --- zero intermediates (2-node bridge) ----------------------------------------------------
+
+def test_zero_intermediates_is_maximally_specific():
+    spec = bridge_specificity([], [])
+    assert spec.score == pytest.approx(1.0)
+    assert spec.label == "specific"
+    assert spec.intermediate_curies == []
+    assert spec.intermediate_degrees == []
+    assert spec.generic_intermediates == []
+
+
+# --- boundaries ----------------------------------------------------------------------------
+
+def test_generic_cutoff_boundary_is_strict_greater_than():
+    # A node whose degree EXCEEDS the cutoff is generic; degree == cutoff is NOT flagged.
+    at = bridge_specificity(["A:1"], [GENERIC_CUTOFF])
+    over = bridge_specificity(["A:1"], [GENERIC_CUTOFF + 1])
+    assert "A:1" not in at.generic_intermediates
+    assert "A:1" in over.generic_intermediates
+
+
+def test_score_cut_points_inclusive_on_upper_bucket():
+    # Construct a single-intermediate degree whose score lands exactly on SPECIFIC_CUT.
+    # score = d**(-W) == SPECIFIC_CUT  =>  d = SPECIFIC_CUT ** (-1/W)
+    d = round(SPECIFIC_CUT ** (-1.0 / DAMPING_W))
+    spec = bridge_specificity(["A:1"], [d])
+    # score >= SPECIFIC_CUT is inclusive -> specific (unless it is a generic hub, which it is not here)
+    assert spec.score == pytest.approx(d ** (-DAMPING_W))
+    if d <= GENERIC_CUTOFF and spec.score >= SPECIFIC_CUT:
+        assert spec.label == "specific"
+
+
+# --- degree-zero guard ---------------------------------------------------------------------
+
+def test_degree_zero_is_clamped_not_crash():
+    # An isolated node (results_count == 0) must not raise (0 ** -0.4 = inf); clamp to 1.
+    spec = bridge_specificity(["ISO:1"], [0])
+    assert spec.score == pytest.approx(1.0)
+    assert spec.label == "specific"
+    assert spec.intermediate_degrees == [0]  # raw degree preserved
+
+
+# --- determinism ---------------------------------------------------------------------------
+
+def test_determinism_same_inputs_same_output():
+    a = bridge_specificity(["A:1", "B:2"], [30, 900])
+    b = bridge_specificity(["A:1", "B:2"], [30, 900])
+    assert a == b
+    assert a.model_dump() == b.model_dump()
+
+
+def test_constants_are_ordered_and_sane():
+    assert 0.0 < DAMPING_W < 1.0
+    assert 0.0 < MODERATE_CUT < SPECIFIC_CUT <= 1.0
+    assert GENERIC_CUTOFF >= 1

--- a/backend/tests/test_integration_bridge_specificity.py
+++ b/backend/tests/test_integration_bridge_specificity.py
@@ -1,0 +1,202 @@
+"""Axis C, Unit 3 — emit-only wiring of bridge specificity into the integration node.
+
+The scoring pass populates the ``specificity_by_bridge`` state SIDE-MAP (keyed by
+``tuple(bridge.entities)``) non-destructively: the ``bridges`` list, the frozen ``Bridge`` model,
+tiers, and the ``grounding`` key are all unchanged. Per-bridge failure isolates to a missing map
+entry and never fails the node. ``enabled=False`` -> empty map, zero Kestrel calls.
+
+Run with: uv run python -m pytest tests/test_integration_bridge_specificity.py -v
+"""
+
+import pytest
+
+from kestrel_backend.graph.nodes import bridge_specificity as bs
+from kestrel_backend.graph.nodes import integration
+from kestrel_backend.graph.pipeline_config import BridgeSpecificityConfig, PipelineConfig
+from kestrel_backend.graph.state import Bridge, BridgeSpecificity, EntityResolution, Finding
+
+
+def _multi_hop_bridge(entities, tier=2):
+    return Bridge(
+        path_description="metabolite → gene → disease (2 hops)",
+        entities=list(entities),
+        entity_names=list(entities),
+        predicates=["biolink:affects", "biolink:causes"],
+        predicate_directions=[True, False],
+        tier=tier,
+        novelty="known",
+        significance="why it matters",
+    )
+
+
+def _subgraph_bridge(present, intermediates):
+    # Mirrors _parse_subgraph_bridges: entities = present + intermediates (endpoints FIRST).
+    entities = list(present) + list(intermediates)
+    return Bridge(
+        path_description=f"Connecting subgraph among {', '.join(present)}",
+        entities=entities,
+        entity_names=entities,
+        predicates=["biolink:related_to"],
+        predicate_directions=[],
+        tier=2,
+        novelty="known",
+        significance="connecting structure",
+    )
+
+
+def _degree_map(monkeypatch, degrees: dict[str, int], calls=None):
+    """Stub call_kestrel_tool so each CURIE resolves to a preview results_count == its degree."""
+    async def fake(tool_name, params):
+        if calls is not None:
+            calls.append((tool_name, params))
+        curie = params["start_node_ids"]
+        d = degrees.get(curie, 0)
+        return {"isError": False, "content": [{"text": f'{{"results_count": {d}}}'}]}
+    monkeypatch.setattr(bs, "call_kestrel_tool", fake)
+
+
+# =============================================================================
+# score_bridges pass (unit level)
+# =============================================================================
+
+async def test_score_bridges_keys_by_entities_tuple(monkeypatch):
+    _degree_map(monkeypatch, {"MID:hub": bs.GENERIC_CUTOFF * 3, "MID:spec": 5})
+    b_generic = _multi_hop_bridge(["A:1", "MID:hub", "Z:9"])
+    b_specific = _multi_hop_bridge(["A:2", "MID:spec", "Z:8"])
+    pairs = [(b_generic, ["MID:hub"]), (b_specific, ["MID:spec"])]
+
+    smap, errors = await bs.score_bridges(pairs, max_scored_bridges=20, concurrency=4)
+
+    assert errors == []
+    assert smap[("A:1", "MID:hub", "Z:9")].label == "generic"
+    assert smap[("A:2", "MID:spec", "Z:8")].label == "specific"
+
+
+async def test_score_bridges_error_isolation(monkeypatch):
+    calls = []
+    good = _multi_hop_bridge(["A:1", "MID:ok", "Z:9"])
+    bad = _multi_hop_bridge(["A:2", "MID:bad", "Z:8"])
+
+    async def fake(tool_name, params):
+        calls.append(params["start_node_ids"])
+        if params["start_node_ids"] == "MID:bad":
+            raise RuntimeError("kestrel exploded")
+        return {"isError": False, "content": [{"text": '{"results_count": 5}'}]}
+    monkeypatch.setattr(bs, "call_kestrel_tool", fake)
+
+    # The provider swallows fetch exceptions to None, so the bad bridge still scores (unknown),
+    # never raising. Assert the good bridge is present and the node-level pass never raises.
+    smap, errors = await bs.score_bridges(
+        [(good, ["MID:ok"]), (bad, ["MID:bad"])], max_scored_bridges=20, concurrency=4)
+    assert ("A:1", "MID:ok", "Z:9") in smap
+    assert smap[("A:2", "MID:bad", "Z:8")].label == "unknown"  # degree fetch degraded to None
+
+
+async def test_score_bridges_respects_cap(monkeypatch):
+    _degree_map(monkeypatch, {"MID:1": 5, "MID:2": 5, "MID:3": 5})
+    pairs = [
+        (_multi_hop_bridge(["A:1", "MID:1", "Z:1"]), ["MID:1"]),
+        (_multi_hop_bridge(["A:2", "MID:2", "Z:2"]), ["MID:2"]),
+        (_multi_hop_bridge(["A:3", "MID:3", "Z:3"]), ["MID:3"]),
+    ]
+    smap, _ = await bs.score_bridges(pairs, max_scored_bridges=2, concurrency=4)
+    assert len(smap) == 2  # third bridge beyond the cap has no entry
+
+
+# =============================================================================
+# integration.run wiring (emit-only invariant)
+# =============================================================================
+
+def _stub_integration(monkeypatch, *, enabled, multi_hop_bridges=(), subgraph_bridges=(), degrees=None):
+    cfg = PipelineConfig(bridge_specificity=BridgeSpecificityConfig(enabled=enabled))
+    monkeypatch.setattr(integration, "get_pipeline_config", lambda: cfg)
+
+    async def fake_detect_bridges(resolved_entities, **_):
+        return list(multi_hop_bridges), []
+    async def fake_detect_subgraphs(resolved_entities, **_):
+        return list(subgraph_bridges), []
+    monkeypatch.setattr(integration, "detect_bridges_via_api", fake_detect_bridges)
+    monkeypatch.setattr(integration, "detect_subgraphs_via_api", fake_detect_subgraphs)
+
+    async def fake_query(*a, **k):
+        return '{"gaps": []}', None
+    monkeypatch.setattr(integration, "query_with_usage", fake_query)
+    monkeypatch.setattr(integration, "HAS_SDK", True)
+
+    if degrees is not None:
+        _degree_map(monkeypatch, degrees)
+
+
+def _state(resolved):
+    return {
+        "resolved_entities": resolved,
+        # IntegrationInput requires at least one findings branch non-empty.
+        "direct_findings": [Finding(entity="CHEBI:1", claim="seed", tier=2, source="direct_kg")],
+        "disease_associations": [],
+        "pathway_memberships": [],
+        "inferred_associations": [],
+        "biological_themes": [],
+    }
+
+
+def _resolved(curie, category):
+    return EntityResolution(
+        raw_name=curie, curie=curie, resolved_name=curie,
+        category=category, confidence=1.0, method="exact",
+    )
+
+
+async def test_run_emit_only_bridges_unchanged(monkeypatch):
+    bridges = [_multi_hop_bridge(["CHEBI:1", "HGNC:2", "MONDO:3"])]
+    _stub_integration(
+        monkeypatch, enabled=True, multi_hop_bridges=bridges,
+        degrees={"HGNC:2": 5},
+    )
+    resolved = [_resolved("CHEBI:1", "biolink:ChemicalEntity"), _resolved("MONDO:3", "biolink:Disease")]
+    out = await integration.run(_state(resolved))
+
+    # bridges list identical (count + fields + no new Bridge field)
+    assert len(out["bridges"]) == 1
+    b = out["bridges"][0]
+    assert b == bridges[0]  # frozen model, byte-identical
+    assert not hasattr(b, "specificity")
+    # the ONLY new output is the side-map
+    smap = out["specificity_by_bridge"]
+    assert set(smap) == {("CHEBI:1", "HGNC:2", "MONDO:3")}
+    assert isinstance(smap[("CHEBI:1", "HGNC:2", "MONDO:3")], BridgeSpecificity)
+    assert smap[("CHEBI:1", "HGNC:2", "MONDO:3")].label == "specific"
+
+
+async def test_run_disabled_is_empty_and_no_kestrel(monkeypatch):
+    bridges = [_multi_hop_bridge(["CHEBI:1", "HGNC:2", "MONDO:3"])]
+
+    async def boom(*a, **k):
+        raise AssertionError("no degree fetch when bridge_specificity disabled")
+    monkeypatch.setattr(bs, "call_kestrel_tool", boom)
+    _stub_integration(monkeypatch, enabled=False, multi_hop_bridges=bridges)
+    resolved = [_resolved("CHEBI:1", "biolink:ChemicalEntity"), _resolved("MONDO:3", "biolink:Disease")]
+
+    out = await integration.run(_state(resolved))
+    assert out["specificity_by_bridge"] == {}
+    assert len(out["bridges"]) == 1
+
+
+async def test_run_subgraph_scaffold_is_non_input_curies_not_positional(monkeypatch):
+    # Subgraph bridge: endpoints FIRST (present), then intermediates. A positional entities[1:-1]
+    # slice would mis-score it. The pass must use the non-input-CURIE entities as the scaffold.
+    present = ["CHEBI:1", "MONDO:3"]           # the resolved inputs (endpoints)
+    intermediates = ["GO:hub", "GO:spec"]      # the connecting scaffold
+    sub = _subgraph_bridge(present, intermediates)
+    _stub_integration(
+        monkeypatch, enabled=True, subgraph_bridges=[sub],
+        degrees={"GO:hub": bs.GENERIC_CUTOFF * 4, "GO:spec": 5},
+    )
+    resolved = [_resolved("CHEBI:1", "biolink:ChemicalEntity"), _resolved("MONDO:3", "biolink:Disease")]
+
+    out = await integration.run(_state(resolved))
+    spec = out["specificity_by_bridge"][tuple(sub.entities)]
+    # scaffold recovered = intermediates only; the hub condemns it as generic
+    assert set(spec.intermediate_curies) == {"GO:hub", "GO:spec"}
+    assert "CHEBI:1" not in spec.intermediate_curies  # endpoint excluded (not positional)
+    assert spec.label == "generic"
+    assert "GO:hub" in spec.generic_intermediates


### PR DESCRIPTION
## Summary

Adds a **bridge-specificity scoring** pass to the discovery pipeline's integration node (axis C). Cross-entity bridges are scored with a degree-weighted path count (DWPC)-style specificity metric so that bridges routed through high-degree hub nodes are down-weighted relative to bridges through specific, low-degree intermediaries. The pass is **emit-only** in this PR: it computes and surfaces specificity scores into state without gating or filtering existing bridge output, so behavior is additive and reversible.

Built in four TDD units off `main` (c4e24e8):

- **Unit 1** — `BridgeSpecificity` model + pure DWPC scorer (`graph/nodes/bridge_specificity.py`, `state.py`).
- **Unit 2** — hybrid bounded, cached degree provider + `BridgeSpecificityConfig` (`pipeline_config.py`).
- **Unit 3** — wire the emit-only scoring pass into the integration node (`integration.py`, `builder.py`).
- **Unit 4** — 1-MNA retrodiction test + offline calibration probe + score-distribution hook (`assessment_data/bridge_specificity_calibration.py`, fixtures).

## Changes

- New node/module: `backend/src/kestrel_backend/graph/nodes/bridge_specificity.py` (+293)
- Integration wiring: `graph/nodes/integration.py`, `graph/builder.py`, `graph/state.py`, `graph/pipeline_config.py`
- Calibration probe + fixture: `backend/assessment_data/bridge_specificity_calibration.py`, `backend/tests/fixtures/bridge_specificity_1mna_degrees.json`
- Tests (all new): scorer, degree provider, retrodiction, integration wiring (~800 lines)

## Testing

- `test_bridge_specificity_scorer.py`, `test_bridge_specificity_degree_provider.py`, `test_bridge_specificity_retrodiction.py`, `test_integration_bridge_specificity.py`
- Run: `cd backend && uv run python -m pytest tests/test_bridge_specificity_*.py tests/test_integration_bridge_specificity.py -v -m "not integration"`

## Notes

- Emit-only: no existing bridge output is gated or removed by this pass.
- Diff against `dev` renders clean via merge-base (branch was cut from current `main`); unrelated byok/analyte churn in a raw two-dot diff is an artifact of dev being ahead of that base, not part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)