### PR TITLE
feat(discovery): entity-semantics guards — rank preservation + sign-coherence (Axis D)

### DIFF
--- a/backend/src/kestrel_backend/evals/biomapper_resolution/run_eval.py
+++ b/backend/src/kestrel_backend/evals/biomapper_resolution/run_eval.py
@@ -34,7 +34,7 @@ _RUNS_DIR = Path(__file__).parent / "runs"
 _DEGRADED_HIT_RATE = 0.3
 
 ResolveFn = Callable[..., Awaitable[dict | None]]
-ReconcileFn = Callable[..., Awaitable[tuple[str, str | None] | None]]
+ReconcileFn = Callable[..., Awaitable[tuple[str, str | None, str | None] | None]]
 
 
 def load_gold(path: Path = _GOLD_PATH) -> list[dict[str, Any]]:

--- a/backend/src/kestrel_backend/graph/nodes/entity_resolution.py
+++ b/backend/src/kestrel_backend/graph/nodes/entity_resolution.py
@@ -29,6 +29,7 @@ from typing import Any
 from ...kestrel_client import call_kestrel_tool
 from ...biomapper_client import resolve_entity as biomapper_resolve, biolink_class_for
 from ...config import get_settings, resolve_biomapper_base_url
+from ..rank_utils import infer_requested_rank, is_rank_collapse
 from ..state import DiscoveryState, EntityResolution
 from ..sdk_utils import HAS_SDK, query_with_usage, ClaudeAgentOptions, chunk
 from ..pipeline_config import get_pipeline_config
@@ -145,6 +146,12 @@ async def resolve_via_api(
                 fallback = await resolve_via_api(entity, category=None)
                 if fallback is None:
                     return None
+                if fallback.curie is None:
+                    # The unconstrained retry itself abstained (e.g. the rank guard fired). Return it
+                    # verbatim so the "failed" sentinel + rank_collapsed marker survive — relabeling a
+                    # curie=None result as method="category-fallback" would strip the sentinel and the
+                    # entity would be silently dropped from every triage bucket.
+                    return fallback
                 return fallback.model_copy(update={
                     "confidence": _config.tier1_fallback_confidence,
                     "method": "category-fallback",
@@ -221,7 +228,7 @@ async def resolve_via_api(
             entity, curie, score, confidence, method
         )
 
-        return EntityResolution(
+        resolution = EntityResolution(
             raw_name=entity,
             curie=curie,
             resolved_name=name,
@@ -229,6 +236,8 @@ async def resolve_via_api(
             confidence=confidence,
             method=method,
         )
+        # Rank-collapse guard (Tier-1, abstain-only). Pass-through for non-taxa / no collapse.
+        return _apply_rank_guard(entity, resolution)
 
     except Exception as e:
         logger.warning("Tier 1 '%s': Exception - %s", entity, str(e))
@@ -282,6 +291,95 @@ def parse_resolution_result(entity: str, result_text: str) -> EntityResolution:
         confidence=0.0,
         method="failed",
     )
+
+
+# ============================ Rank-collapse guard (Axis D, Guard 1) ============================
+# Stops the pipeline from silently accepting a coarser (proper-ancestor) node when the label asked
+# for a finer taxonomic rank — the mechanism by which opposite-sign literature for a species and its
+# genus get averaged into one CURIE. Detection is name-derived (Kestrel node dicts carry no lineage
+# metadata); see rank_utils. Both helpers are pure and no-KG-fan-out. When the label yields no rank
+# (non-taxa, the common case) they are pass-throughs → resolution is byte-identical.
+
+
+def _rank_name(label: str | None) -> str | None:
+    """Lowercase rank name (e.g. 'species') for a label, or None when not taxa — for diagnostics."""
+    rank = infer_requested_rank(label)
+    return rank.name.lower() if rank is not None else None
+
+
+def _rank_abstention(entity: str, resolved_name: str | None) -> EntityResolution:
+    """The abstain result for a rank collapse: the existing ``method="failed"`` sentinel (triage
+    routes it to cold_start) plus the ``rank_collapsed`` diagnostic marker. The coarse CURIE is
+    dropped — never accepted."""
+    return EntityResolution(
+        raw_name=entity,
+        curie=None,
+        resolved_name=None,
+        category=None,
+        confidence=0.0,
+        method="failed",
+        requested_rank=_rank_name(entity),
+        resolved_rank=_rank_name(resolved_name),
+        rank_collapsed=True,
+    )
+
+
+def _apply_rank_guard(entity: str, resolution: EntityResolution) -> EntityResolution:
+    """Tier-1 guard: abstain-only. Tier-1 (`resolve_via_api`, limit=1) has no alternative candidates
+    in scope, so a rank collapse goes straight to abstain (no extra search — reader-pool budget).
+    Returns the input unchanged when there is no collapse."""
+    if resolution.curie is None or resolution.resolved_name is None:
+        return resolution
+    if not is_rank_collapse(entity, resolution.resolved_name):
+        return resolution
+    logger.info(
+        "FALLBACK_EVENT node=entity_resolution reason=rank_collapse tier=1 entity=%s resolved=%s",
+        entity, resolution.resolved_name,
+    )
+    return _rank_abstention(entity, resolution.resolved_name)
+
+
+def _apply_rank_guard_tier2(
+    entity: str, resolution: EntityResolution, candidates: list[dict]
+) -> EntityResolution:
+    """Tier-2 guard: resolve-finer over the in-scope prefetched candidate set, else abstain.
+
+    Scans ``candidates`` for a node at the requested (finer) rank whose genus matches the label; the
+    first such candidate is preferred. If none exists, abstain via the ``method="failed"`` sentinel.
+    Returns the input unchanged when there is no collapse.
+    """
+    if resolution.curie is None or not is_rank_collapse(entity, resolution.resolved_name):
+        return resolution
+    requested = infer_requested_rank(entity)
+    entity_genus = entity.strip().split()[0].lower()
+    for cand in candidates:
+        cname = cand.get("name")
+        if not cname:
+            continue
+        # A finer candidate: at the requested rank, same genus, and not itself a collapse.
+        if (
+            infer_requested_rank(cname) == requested
+            and cname.strip().split()[0].lower() == entity_genus
+            and not is_rank_collapse(entity, cname)
+        ):
+            logger.info(
+                "FALLBACK_EVENT node=entity_resolution reason=rank_resolve_finer tier=2 "
+                "entity=%s finer=%s",
+                entity, cname,
+            )
+            return EntityResolution(
+                raw_name=entity,
+                curie=cand["curie"],
+                resolved_name=cname,
+                category=cand.get("category"),
+                confidence=resolution.confidence,
+                method=resolution.method,
+            )
+    logger.info(
+        "FALLBACK_EVENT node=entity_resolution reason=rank_collapse tier=2 entity=%s resolved=%s",
+        entity, resolution.resolved_name,
+    )
+    return _rank_abstention(entity, resolution.resolved_name)
 
 
 # Max candidates shown to the selector (bounds prompt size; membership is checked
@@ -578,14 +676,19 @@ async def resolve_single_entity(entity: str, is_retry: bool = False) -> tuple[En
         return (failed, usage_record)
 
     # Surface the CANDIDATE's own fields (never the model's emitted strings).
-    return (EntityResolution(
+    resolution = EntityResolution(
         raw_name=entity,
         curie=chosen["curie"],
         resolved_name=chosen["name"],
         category=chosen["category"],
         confidence=parsed.confidence,
         method=parsed.method,
-    ), usage_record)
+    )
+    # Rank-collapse guard (Tier-2): resolve-finer over the in-scope candidate set, else abstain.
+    # ``candidates`` is the full prefetched set (not just the shown cap) so a finer node just outside
+    # the prompt cap is still reachable. Pass-through for non-taxa / no collapse.
+    resolution = _apply_rank_guard_tier2(entity, resolution, candidates)
+    return (resolution, usage_record)
 
 
 
@@ -726,9 +829,13 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
             logger.debug("Tier 1 '%s': Exception - %s", entity, str(result))
             tier1_failed_indices.append(i)
         elif result is not None:
-            # Successfully resolved via API
             all_results[i] = result
-            tier1_resolved += 1
+            if result.curie:
+                # Successfully resolved via API
+                tier1_resolved += 1
+            # else: the rank guard abstained at Tier-1 (curie=None, method="failed"). Leave it as a
+            # terminal failure — do NOT route to Tier-1.5/Tier-2 (the plan's reader-pool budget: a
+            # Tier-1 collapse abstains straight away rather than launching a fresh finer search).
         else:
             # Returned None - needs Tier 1.5 or Tier 2
             tier1_failed_indices.append(i)
@@ -918,9 +1025,20 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
         len(failed), rate
     )
 
+    # Guard-1 measurement hook (Axis D): count rank collapses the guard caught this run. Persisted
+    # by default alongside resolved_entities (not behind a flag). 0 on a run where the guard never
+    # fired — byte-identical semantics for non-taxa modules.
+    rank_collapse_sign_flips = sum(1 for r in final_results if r.rank_collapsed)
+    if rank_collapse_sign_flips:
+        logger.info(
+            "Rank guard: abstained %d entities on rank collapse (finer label → coarser node)",
+            rank_collapse_sign_flips,
+        )
+
     result = {
         "resolved_entities": final_results,
         "errors": errors,
+        "rank_collapse_sign_flips": rank_collapse_sign_flips,
     }
     if model_usages:
         result["model_usages"] = model_usages

--- a/backend/src/kestrel_backend/graph/nodes/entity_resolution.py
+++ b/backend/src/kestrel_backend/graph/nodes/entity_resolution.py
@@ -324,19 +324,29 @@ def _rank_abstention(entity: str, resolved_name: str | None) -> EntityResolution
     )
 
 
-def _apply_rank_guard(entity: str, resolution: EntityResolution) -> EntityResolution:
+def _apply_rank_guard(
+    entity: str, resolution: EntityResolution, *, resolved_name: str | None = None
+) -> EntityResolution:
     """Tier-1 guard: abstain-only. Tier-1 (`resolve_via_api`, limit=1) has no alternative candidates
     in scope, so a rank collapse goes straight to abstain (no extra search — reader-pool budget).
-    Returns the input unchanged when there is no collapse."""
-    if resolution.curie is None or resolution.resolved_name is None:
+    Returns the input unchanged when there is no collapse.
+
+    ``resolved_name`` overrides which name the collapse check compares against. Tier-1 leaves it
+    ``None`` → the guard uses ``resolution.resolved_name`` (unchanged behavior). The biomapper path
+    passes the CONFIRMED Kestrel node name, because ``resolution.resolved_name`` may echo the raw
+    query (the wrapper returns the query verbatim when it has no canonical name) — comparing the
+    query to itself never detects a species→genus collapse.
+    """
+    check_name = resolved_name if resolved_name is not None else resolution.resolved_name
+    if resolution.curie is None or check_name is None:
         return resolution
-    if not is_rank_collapse(entity, resolution.resolved_name):
+    if not is_rank_collapse(entity, check_name):
         return resolution
     logger.info(
         "FALLBACK_EVENT node=entity_resolution reason=rank_collapse tier=1 entity=%s resolved=%s",
-        entity, resolution.resolved_name,
+        entity, check_name,
     )
-    return _rank_abstention(entity, resolution.resolved_name)
+    return _rank_abstention(entity, check_name)
 
 
 def _apply_rank_guard_tier2(
@@ -499,6 +509,18 @@ def _node_category(node: dict) -> str | None:
     return node.get("category")
 
 
+def _node_name(node: dict) -> str | None:
+    """The confirmed Kestrel node's canonical display name, or None when absent/blank.
+
+    Used by the biomapper rank guard: the biomapper wrapper echoes the raw query as
+    ``resolved_name`` when it has no canonical name, so the guard must compare the
+    requested rank against the CONFIRMED node's name (e.g. the genus ``"Ruminococcus"``)
+    instead — otherwise a species→genus collapse is never detected.
+    """
+    name = node.get("name")
+    return name if isinstance(name, str) and name.strip() else None
+
+
 def _biomapper_candidate_curies(biomapper_result: dict, hint: str | None) -> list[str]:
     """Ordered CURIE candidates: primary_curie first, then xrefs by per-class namespace_preference.
 
@@ -530,13 +552,15 @@ def _biomapper_candidate_curies(biomapper_result: dict, hint: str | None) -> lis
 
 async def reconcile_to_kestrel(
     biomapper_result: dict, hint: str | None
-) -> tuple[str, str | None] | None:
-    """Confirm a Biomapper result against the Kestrel KG; return (confirmed_curie, kestrel_category).
+) -> tuple[str, str | None, str | None] | None:
+    """Confirm a Biomapper result against the Kestrel KG; return
+    (confirmed_curie, kestrel_category, confirmed_node_name).
 
     Walks the candidate CURIEs (primary first, then namespace-preferred xrefs), accepting the first
     that ``get_nodes`` confirms. For gene/protein, the confirmed node must carry the HGNC human
     marker (defense-in-depth) or the candidate is skipped. Returns the node's canonical id +
-    Kestrel-native category, or None if nothing confirms (caller falls back to Kestrel tiers).
+    Kestrel-native category + display name (the rank guard needs the confirmed node's real name,
+    not the biomapper query echo), or None if nothing confirms (caller falls back to Kestrel tiers).
     """
     gated = (hint or "").lower() in _HGNC_GATED_CLASSES
     for candidate in _biomapper_candidate_curies(biomapper_result, hint):
@@ -552,7 +576,7 @@ async def reconcile_to_kestrel(
             # Confirmed in Kestrel but no HGNC marker → non-human ortholog; reject (defense-in-depth).
             logger.info("FALLBACK_EVENT node=entity_resolution reason=biomapper_non_human curie=%s", candidate)
             continue
-        return node.get("id") or candidate, _node_category(node)
+        return node.get("id") or candidate, _node_category(node), _node_name(node)
     return None
 
 
@@ -784,7 +808,7 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
                         name,
                     )
                     return idx, None
-                curie, category = reconciled
+                curie, category, node_name = reconciled
                 resolution = EntityResolution(
                     raw_name=name,
                     curie=curie,
@@ -793,12 +817,17 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
                     confidence=_tier_to_confidence(r.get("tier")),
                     method="biomapper",
                 )
-                # Axis-D rank guard (finding #6): a biomapper hit that collapses a species→genus
-                # (or any finer→coarser taxon) must abstain exactly like the Tier-1/2 paths rather
-                # than feeding the coarse CURIE straight into triage via the pre-resolver. Mirror the
-                # Tier-1 guard (abstain-only; no alternative candidates in scope here). On no collapse
-                # (the common non-taxa case) this is a pass-through → byte-identical resolution.
-                return idx, _apply_rank_guard(name, resolution)
+                # Axis-D rank guard (finding #6 / Greptile P1): a biomapper hit that collapses a
+                # species→genus (or any finer→coarser taxon) must abstain exactly like the Tier-1/2
+                # paths rather than feeding the coarse CURIE straight into triage via the pre-resolver.
+                # The biomapper wrapper returns the raw query verbatim as ``resolved_name`` when it has
+                # no canonical display name, so we feed the CONFIRMED KESTREL NODE name (already fetched
+                # during reconciliation — no new query) into the guard; fall back to the surfaced
+                # resolved_name only when the node name is genuinely unavailable. On no collapse (the
+                # common non-taxa case) this is a pass-through → byte-identical resolution.
+                return idx, _apply_rank_guard(
+                    name, resolution, resolved_name=node_name or resolution.resolved_name
+                )
 
             prepass = await asyncio.gather(*[_biomapper_one(i, e) for (i, e) in targets])
             for idx, res in prepass:

--- a/backend/src/kestrel_backend/graph/nodes/entity_resolution.py
+++ b/backend/src/kestrel_backend/graph/nodes/entity_resolution.py
@@ -785,7 +785,7 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
                     )
                     return idx, None
                 curie, category = reconciled
-                return idx, EntityResolution(
+                resolution = EntityResolution(
                     raw_name=name,
                     curie=curie,
                     resolved_name=r.get("resolved_name") or name,
@@ -793,12 +793,25 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
                     confidence=_tier_to_confidence(r.get("tier")),
                     method="biomapper",
                 )
+                # Axis-D rank guard (finding #6): a biomapper hit that collapses a species→genus
+                # (or any finer→coarser taxon) must abstain exactly like the Tier-1/2 paths rather
+                # than feeding the coarse CURIE straight into triage via the pre-resolver. Mirror the
+                # Tier-1 guard (abstain-only; no alternative candidates in scope here). On no collapse
+                # (the common non-taxa case) this is a pass-through → byte-identical resolution.
+                return idx, _apply_rank_guard(name, resolution)
 
             prepass = await asyncio.gather(*[_biomapper_one(i, e) for (i, e) in targets])
             for idx, res in prepass:
-                if res is not None:
-                    all_results[idx] = res
-                    biomapper_confirmed.add(idx)
+                # None → biomapper miss/timeout/unconfirmed: fall through to Tier-1 (Kestrel).
+                if res is None:
+                    continue
+                # A biomapper result (confirmed CURIE OR a rank-collapse abstention) is terminal for
+                # this index — record it and skip Tier-1, exactly like Tier-1's own terminal paths.
+                # Only a real CURIE counts toward biomapper_resolved; an abstention (curie=None,
+                # method="failed", rank_collapsed=True) is carried into triage → cold_start.
+                all_results[idx] = res
+                biomapper_confirmed.add(idx)
+                if res.curie is not None:
                     biomapper_resolved += 1
             logger.info(
                 "Biomapper pre-resolver confirmed %d/%d hinted entities",

--- a/backend/src/kestrel_backend/graph/nodes/synthesis.py
+++ b/backend/src/kestrel_backend/graph/nodes/synthesis.py
@@ -1468,25 +1468,44 @@ def format_literature_evidence(hypotheses: list[Hypothesis]) -> str:
 # assembled context byte-identical.
 
 
-def _spine_member_kme(module_spine: Any) -> dict[str, float | None]:
-    """Adapter: read axis A's ModuleSpine into a flat ``member-name -> signed kME`` map.
+def _member_kme_value(mw: Any) -> float | None:
+    """Read one member's signed kME from a ``MemberWeight`` (``.kme``), its dict serialization
+    (``{"kme": ...}``), or a bare numeric (test/forward-compat). Non-numeric/missing → ``None``."""
+    kme: Any
+    if hasattr(mw, "kme"):
+        kme = mw.kme
+    elif isinstance(mw, dict):
+        kme = mw.get("kme")
+    else:
+        kme = mw  # bare number
+    return float(kme) if isinstance(kme, (int, float)) and not isinstance(kme, bool) else None
 
-    This is the single point of coupling to axis A's ``ModuleSpine`` schema (the plan's "adapter
-    isolates the field-name coupling to one function"), so Guard 2 can be developed and tested
-    against a stub before axis A lands. Accepts the ModuleSpine object (with a ``.members`` mapping),
-    its dict serialization (``{"members": {...}}``), or a bare ``{name: kME}`` map. Non-numeric
-    (or missing) kME becomes ``None`` (sign undefined for that member).
+
+def _spine_group_member_kme(module_spine: Any) -> dict[str, dict[str, float | None]]:
+    """Adapter: read axis A's ``module_spine`` into a module-centric ``{group -> {member-name ->
+    signed kME}}`` map.
+
+    This is the single point of coupling to axis A's schema. The REAL state shape is
+    ``dict[str, ModuleSpine]`` (group -> ModuleSpine), where each ``ModuleSpine`` carries
+    ``members: dict[str, MemberWeight]`` and each ``MemberWeight`` carries a signed ``kme``. kME is
+    kept keyed BY GROUP (never flattened) because a member can belong to multiple modules with a
+    DIFFERENT kME per module — a flat ``name -> kME`` map would collapse that (see ``ModuleSpine``).
+
+    Accepts ``ModuleSpine`` objects (``.members``) or their dict serialization
+    (``{"members": {...}}``); each member value may be a ``MemberWeight`` (``.kme``), a
+    ``{"kme": ...}`` dict, or a bare number. Missing/non-numeric kME → ``None`` (sign undefined).
+    Returns ``{}`` when no ModuleSpine is present (the pre-axis-A / classic path) → inert.
     """
-    if not module_spine:
+    if not module_spine or not isinstance(module_spine, dict):
         return {}
-    members = getattr(module_spine, "members", None)
-    if members is None and isinstance(module_spine, dict):
-        members = module_spine.get("members", module_spine)
-    if not isinstance(members, dict):
-        return {}
-    out: dict[str, float | None] = {}
-    for name, kme in members.items():
-        out[name] = float(kme) if isinstance(kme, (int, float)) and not isinstance(kme, bool) else None
+    out: dict[str, dict[str, float | None]] = {}
+    for group, spine in module_spine.items():
+        members = getattr(spine, "members", None)
+        if members is None and isinstance(spine, dict):
+            members = spine.get("members")
+        if not isinstance(members, dict):
+            continue
+        out[group] = {name: _member_kme_value(mw) for name, mw in members.items()}
     return out
 
 
@@ -1499,9 +1518,9 @@ def compute_sign_splits(state: DiscoveryState) -> tuple[dict[str, SplitResult], 
     Inert (empty) when no ModuleSpine or no entity_groups are present → byte-identical rendering.
     """
     zero = {"groups_sign_split": 0, "groups_split": 0}
-    kme = _spine_member_kme(state.get("module_spine"))
+    group_kme = _spine_group_member_kme(state.get("module_spine"))
     entity_groups = state.get("entity_groups", {}) or {}
-    if not kme or not entity_groups:
+    if not group_kme or not entity_groups:
         return {}, dict(zero)
 
     cfg = get_pipeline_config().synthesis
@@ -1519,7 +1538,10 @@ def compute_sign_splits(state: DiscoveryState) -> tuple[dict[str, SplitResult], 
     splits: dict[str, SplitResult] = {}
     subprograms = 0
     for group, names in groups.items():
-        members_kme = {n: kme[n] for n in names if n in kme}
+        # Module-centric lookup: use THIS group's own per-member kME (a member may carry a
+        # different sign in another module), not a flattened map.
+        member_kme = group_kme.get(group, {})
+        members_kme = {n: member_kme[n] for n in names if n in member_kme}
         if not members_kme:
             continue
         result = detect_sign_split(members_kme, floor=floor, minority_tol=minority_tol)

--- a/backend/src/kestrel_backend/graph/nodes/synthesis.py
+++ b/backend/src/kestrel_backend/graph/nodes/synthesis.py
@@ -1322,6 +1322,16 @@ def fallback_report(state: DiscoveryState) -> str:
     if temporal_section:
         report_lines.append(temporal_section)
 
+    # Guard 2 (Axis D): sign-coherence at the group-fusion boundary — mirror the LLM path so the
+    # degraded fallback report ALSO splits sign-incoherent groups into two sign-coherent sub-programs
+    # instead of fusing opposite-sign members into one disease/pathway/member-table program. Rendered
+    # before the disease/pathway sections so the direction guard frames the coordinated-group reading
+    # that follows. Inert (no section) when no ModuleSpine / no split → byte-identical for coherent
+    # modules, matching assemble_synthesis_context.
+    sign_section = format_sign_coherence(compute_sign_splits(state)[0])
+    if sign_section:
+        report_lines.append(sign_section)
+
     # Disease + pathway (module-aware: aggregation + member table at module scale, per-entity
     # dumps for small queries — keeps the fallback path bounded too)
     report_lines.extend(_disease_pathway_sections(state))

--- a/backend/src/kestrel_backend/graph/nodes/synthesis.py
+++ b/backend/src/kestrel_backend/graph/nodes/synthesis.py
@@ -25,6 +25,7 @@ from ..state import (
 )
 from ...literature_utils import format_pmid_link
 from ..pipeline_config import get_pipeline_config
+from ..sign_coherence import SplitResult, detect_sign_split
 from ..sdk_utils import HAS_SDK, ClaudeAgentOptions, query_with_usage
 from ..state_contracts import validate_state, SynthesisInput, SynthesisOutput
 from ...writing_style import RESEARCH_REGISTER
@@ -904,6 +905,107 @@ def format_literature_evidence(hypotheses: list[Hypothesis]) -> str:
     return "\n".join(lines)
 
 
+# =============================================================================
+# Guard 2 — class-agnostic sign-coherence at the synthesis group-fusion boundary (Axis D)
+# =============================================================================
+# A group about to be treated as one coordinated program is checked against axis A's per-member
+# signed kME; if it splits in sign it is rendered as two sign-coherent sub-programs rather than fused
+# (the mechanism that otherwise averages an opposite-sign signal away). The whole feature is gated on
+# a ModuleSpine being present in state — absent (the state today, before axis A lands) → no section,
+# assembled context byte-identical.
+
+
+def _spine_member_kme(module_spine: Any) -> dict[str, float | None]:
+    """Adapter: read axis A's ModuleSpine into a flat ``member-name -> signed kME`` map.
+
+    This is the single point of coupling to axis A's ``ModuleSpine`` schema (the plan's "adapter
+    isolates the field-name coupling to one function"), so Guard 2 can be developed and tested
+    against a stub before axis A lands. Accepts the ModuleSpine object (with a ``.members`` mapping),
+    its dict serialization (``{"members": {...}}``), or a bare ``{name: kME}`` map. Non-numeric
+    (or missing) kME becomes ``None`` (sign undefined for that member).
+    """
+    if not module_spine:
+        return {}
+    members = getattr(module_spine, "members", None)
+    if members is None and isinstance(module_spine, dict):
+        members = module_spine.get("members", module_spine)
+    if not isinstance(members, dict):
+        return {}
+    out: dict[str, float | None] = {}
+    for name, kme in members.items():
+        out[name] = float(kme) if isinstance(kme, (int, float)) and not isinstance(kme, bool) else None
+    return out
+
+
+def compute_sign_splits(state: DiscoveryState) -> tuple[dict[str, SplitResult], dict[str, int]]:
+    """Per-group sign-coherence over ``entity_groups`` × ``ModuleSpine.members``.
+
+    Returns ``(splits, counts)`` where ``splits`` maps each sign-split group name to its
+    ``SplitResult`` and ``counts`` carries the measurement hooks ``groups_sign_split`` (groups that
+    split in sign) and ``groups_split`` (sign-coherent sub-programs produced — 2 per clean +/- split).
+    Inert (empty) when no ModuleSpine or no entity_groups are present → byte-identical rendering.
+    """
+    zero = {"groups_sign_split": 0, "groups_split": 0}
+    kme = _spine_member_kme(state.get("module_spine"))
+    entity_groups = state.get("entity_groups", {}) or {}
+    if not kme or not entity_groups:
+        return {}, dict(zero)
+
+    cfg = get_pipeline_config().synthesis
+    # Optional config knobs (default 0.0 → no floor / no minority tolerance) so this lands without an
+    # axis-A SynthesisConfig change; getattr keeps it forward-compatible if the knobs are added later.
+    floor = float(getattr(cfg, "sign_coherence_floor", 0.0))
+    minority_tol = float(getattr(cfg, "sign_coherence_minority_tol", 0.0))
+
+    # group value -> member analyte names (from the run-set membership map)
+    groups: dict[str, list[str]] = {}
+    for name, group_values in entity_groups.items():
+        for g in group_values:
+            groups.setdefault(g, []).append(name)
+
+    splits: dict[str, SplitResult] = {}
+    subprograms = 0
+    for group, names in groups.items():
+        members_kme = {n: kme[n] for n in names if n in kme}
+        if not members_kme:
+            continue
+        result = detect_sign_split(members_kme, floor=floor, minority_tol=minority_tol)
+        if result.is_split:
+            splits[group] = result
+            subprograms += sum(1 for part in (result.positive, result.negative) if part)
+
+    return splits, {"groups_sign_split": len(splits), "groups_split": subprograms}
+
+
+def format_sign_coherence(splits: dict[str, SplitResult]) -> str:
+    """Render sign-split groups as two sign-coherent sub-programs each, with a visible annotation.
+
+    Returns ``""`` when nothing split (so the section never appears for coherent modules — the
+    byte-identical path).
+    """
+    if not splits:
+        return ""
+    lines = ["## Sign-coherence (direction guard)\n"]
+    lines.append(
+        "*The following module group(s) split in sign (opposite-direction members) and are shown as "
+        "separate sign-coherent sub-programs — do NOT treat a split group as one coordinated "
+        "program; reason over each sub-program's members separately.*\n"
+    )
+    for group in sorted(splits):
+        result = splits[group]
+        lines.append(
+            f"- **{group}** splits in sign: {len(result.positive)} up (+) / "
+            f"{len(result.negative)} down (−)"
+            + (f"; {len(result.unassigned)} unassigned" if result.unassigned else "")
+        )
+        lines.append(f"  - **{group} (+)**: {', '.join(result.positive)}")
+        lines.append(f"  - **{group} (−)**: {', '.join(result.negative)}")
+        if result.unassigned:
+            lines.append(f"  - *unassigned (no usable sign)*: {', '.join(result.unassigned)}")
+    lines.append("")
+    return "\n".join(lines)
+
+
 def _disease_pathway_sections(state: DiscoveryState) -> list[str]:
     """Disease + pathway sections, module-aware.
 
@@ -1056,6 +1158,17 @@ def assemble_synthesis_context(state: DiscoveryState, stats_out: dict | None = N
     if hub_section:
         sections.append(hub_section)
     
+    # Guard 2 (Axis D): sign-coherence at the group-fusion boundary. A group that splits in sign is
+    # rendered as two sign-coherent sub-programs (never fused). Inert (no section) when no ModuleSpine
+    # is present → assembled context byte-identical. Rendered before the disease/pathway sections so
+    # the direction guard frames the coordinated-group reading that follows.
+    sign_splits, sign_counts = compute_sign_splits(state)
+    sign_section = format_sign_coherence(sign_splits)
+    if sign_section:
+        sections.append(sign_section)
+    if stats_out is not None:
+        stats_out["sign_coherence"] = sign_counts
+
     # Disease associations + pathway memberships (module-aware: aggregation + member table at
     # module scale, per-entity dumps for small queries — these two sections were 38% of the overflow)
     sections.extend(_disease_pathway_sections(state))
@@ -1388,6 +1501,12 @@ async def run(state: DiscoveryState) -> dict[str, Any]:
     # Context-compression telemetry (plan 004) — single-writer plain field, last-write-wins.
     if context_stats:
         result["synthesis_context_stats"] = context_stats
+    # Guard-2 measurement hooks (Axis D) — persisted by default (not behind a flag), pinned alongside
+    # run outputs. Derived once here so the top-level hooks match the section rendered in the context.
+    # Both 0 when no ModuleSpine / no split → byte-identical semantics for coherent modules.
+    _sign_counts = compute_sign_splits(state)[1]
+    result["groups_sign_split"] = _sign_counts["groups_sign_split"]
+    result["groups_split"] = _sign_counts["groups_split"]
     # errors uses an operator.add reducer; only emit on a degraded fallback (Unit 7).
     if fallback_marker:
         result["errors"] = [fallback_marker]

--- a/backend/src/kestrel_backend/graph/rank_utils.py
+++ b/backend/src/kestrel_backend/graph/rank_utils.py
@@ -1,0 +1,96 @@
+"""Rank inference for the entity-resolution rank-collapse guard (Axis D, Guard 1).
+
+v1 is **taxa-only**. A label's requested taxonomic rank is derived purely from its *shape*
+(binomial → species; single capitalized token → genus; ``-aceae`` → family; ``-ales`` → order).
+Non-taxa labels (metabolites, genes, diseases) and ambiguous/garbage input return ``None`` so the
+guard stays inert and the resolution path is byte-identical. No "leaf-vs-broad ontology specificity"
+logic in v1 — deferred until a concrete non-taxa rank-collapse case is documented.
+
+Detection is **name-derived**: the same ``infer_requested_rank`` function is applied to both the
+requested label and the resolved node's name. Kestrel's node dicts carry no taxonomic lineage/rank
+metadata (grep confirms zero ``taxon``/``lineage``/``rank`` handling in ``kestrel_backend``), so a
+rank collapse is inferred by comparing the two name-derived ranks plus a leading-token (genus) match.
+"""
+
+from __future__ import annotations
+
+import re
+from enum import IntEnum
+
+
+class Rank(IntEnum):
+    """Ordered taxonomic ranks; **larger == finer** so "requested finer than resolved" is ``>``."""
+
+    ORDER = 1
+    FAMILY = 2
+    GENUS = 3
+    SPECIES = 4
+
+
+# A single taxon token: a Titlecase alphabetic word (leading upper, remainder lower). This excludes
+# all-caps gene symbols (APOE), mixed-case/alnum symbols (KIF6, IL6), and lowercase common names.
+_TAXON_TOKEN = re.compile(r"^[A-Z][a-z]+$")
+
+
+def _is_taxon_token(tok: str) -> bool:
+    return bool(_TAXON_TOKEN.match(tok))
+
+
+def infer_requested_rank(label: str | None) -> Rank | None:
+    """Infer the taxonomic rank a label *requests* from its shape, or ``None`` when not taxa.
+
+    - ``Genus species`` (Titlecase + lowercase, both alphabetic) → ``SPECIES``
+    - single Titlecase token ending ``-aceae`` → ``FAMILY``
+    - single Titlecase token ending ``-ales`` → ``ORDER``
+    - any other single Titlecase token → ``GENUS``
+    - everything else (metabolites, genes, diseases, empty, garbage) → ``None``
+    """
+    if not label:
+        return None
+    text = label.strip()
+    if not text:
+        return None
+    tokens = text.split()
+
+    if len(tokens) == 2:
+        genus, species = tokens
+        if _is_taxon_token(genus) and species.isalpha() and species.islower():
+            return Rank.SPECIES
+        return None
+
+    if len(tokens) == 1:
+        tok = tokens[0]
+        if not _is_taxon_token(tok):
+            return None
+        low = tok.lower()
+        if low.endswith("aceae"):
+            return Rank.FAMILY
+        if low.endswith("ales"):
+            return Rank.ORDER
+        return Rank.GENUS
+
+    return None
+
+
+def is_rank_collapse(requested_label: str | None, resolved_name: str | None) -> bool:
+    """True when ``resolved_name`` is a *proper ancestor* (coarser rank) of ``requested_label``.
+
+    A rank collapse requires all of:
+      1. both names yield a taxonomic rank (guard inert otherwise),
+      2. the requested rank is **finer** than the resolved-name rank, and
+      3. a leading-token (genus) match — the requested and resolved names share their first token
+         (case-insensitive). This distinguishes a genuine rank collapse
+         (``Ruminococcus gnavus`` → ``Ruminococcus``) from an unrelated mis-resolution
+         (``Ruminococcus gnavus`` → ``Blautia``), which is a different concern.
+    """
+    if not requested_label or not resolved_name:
+        return False
+    req = infer_requested_rank(requested_label)
+    res = infer_requested_rank(resolved_name)
+    if req is None or res is None:
+        return False
+    if req <= res:  # requested not strictly finer than resolved
+        return False
+    req_first = requested_label.strip().split()[0].lower()
+    res_first = resolved_name.strip().split()[0].lower()
+    return req_first == res_first

--- a/backend/src/kestrel_backend/graph/sign_coherence.py
+++ b/backend/src/kestrel_backend/graph/sign_coherence.py
@@ -1,0 +1,100 @@
+"""Class-agnostic sign-coherence detector (Axis D, Guard 2 — CONSUME module-weight-schema).
+
+For any group about to be treated as one coordinated program (e.g. "7 gamma-glutamyl dipeptides as
+one GGT program"), read axis A's per-member signed ``kME`` and, if the group **splits in sign**,
+partition it into sign-coherent subgroups rather than fusing — the mechanism that otherwise averages
+an opposite-sign signal away. The split is decided **purely from the sign** of each member's weight;
+no chemistry/structural-class ontology is consulted (L15).
+
+This module is pure and has no dependency on axis A's concrete ``ModuleSpine`` type — the caller
+(synthesis) owns the adapter that reads ``ModuleSpine.members{name -> kME}`` and hands this function a
+plain ``dict[name -> float | None]``. That isolates the field-name coupling to one place and lets
+Guard 2 be developed and tested before axis A lands.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+
+@dataclass(frozen=True)
+class SplitResult:
+    """Outcome of a sign-coherence check on one group.
+
+    ``is_split`` — whether the group splits in sign (both signs present beyond ``minority_tol``).
+    ``positive`` / ``negative`` — sign-coherent partitions (every member with a defined sign, in
+    input order, including members that were below the decision floor).
+    ``unassigned`` — members with no usable sign (kME ``None`` or exactly 0.0).
+    ``sign_only`` — the group was evaluated in the magnitude-absent graceful-degradation mode.
+    """
+
+    is_split: bool
+    positive: list[str]
+    negative: list[str]
+    unassigned: list[str]
+    sign_only: bool = False
+
+
+def detect_sign_split(
+    members_kme: Mapping[str, float | None],
+    *,
+    floor: float = 0.0,
+    minority_tol: float = 0.0,
+    sign_only: bool = False,
+) -> SplitResult:
+    """Decide whether ``members_kme`` splits in sign and partition it into sign-coherent subgroups.
+
+    Args:
+        members_kme: member name -> signed kME (float in [-1, 1]) or ``None`` when magnitude is
+            absent for that row.
+        floor: magnitude noise-floor; a member votes in the split decision only when
+            ``abs(kME) >= floor``. Ignored when ``sign_only`` is set.
+        minority_tol: tolerate a minority opposite-sign fraction; split only when the smaller side's
+            share of decision-survivors is strictly greater than this.
+        sign_only: graceful-degradation mode (L4) — magnitude absent for the group; the floor is not
+            applied and every nonzero member is counted.
+
+    Partition disposition: the floor affects only the split *decision*. ``positive``/``negative``
+    assign every member with a defined (nonzero, non-None) sign — including floor-below members —
+    while ``None``/zero members are listed as ``unassigned``.
+    """
+    effective_floor = 0.0 if sign_only else floor
+
+    positive: list[str] = []
+    negative: list[str] = []
+    unassigned: list[str] = []
+    pos_votes = 0
+    neg_votes = 0
+
+    for name, kme in members_kme.items():
+        if kme is None or kme == 0.0:
+            unassigned.append(name)
+            continue
+        if kme > 0:
+            positive.append(name)
+        else:
+            negative.append(name)
+        # Voting is floor-gated; partition membership above is not.
+        if abs(kme) >= effective_floor:
+            if kme > 0:
+                pos_votes += 1
+            else:
+                neg_votes += 1
+
+    total_votes = pos_votes + neg_votes
+    minority = min(pos_votes, neg_votes)
+    is_split = (
+        pos_votes > 0
+        and neg_votes > 0
+        and total_votes > 0
+        and (minority / total_votes) > minority_tol
+    )
+
+    return SplitResult(
+        is_split=is_split,
+        positive=positive,
+        negative=negative,
+        unassigned=unassigned,
+        sign_only=sign_only,
+    )

--- a/backend/src/kestrel_backend/graph/state.py
+++ b/backend/src/kestrel_backend/graph/state.py
@@ -38,6 +38,21 @@ class EntityResolution(BaseModel):
         "failed",
         description='Resolution method: "exact"|"fuzzy"|"semantic"|"failed"|"biomapper"|"alias:<name>"',
     )
+    # === resolution-contract (Axis D, Guard 1): rank-collapse diagnostics ===
+    # Additive optionals — default to the inert values so legacy constructions (and equality
+    # between them) are unaffected. Populated only when the rank guard fires (Unit 2): the label's
+    # requested taxonomic rank was finer than the resolved node's, so the coarse CURIE was NOT
+    # accepted. ``rank_collapsed`` is diagnostic-only; routing to cold_start is achieved via the
+    # existing ``method="failed"`` sentinel, not a new triage control-flow.
+    requested_rank: str | None = Field(
+        None, description="Taxonomic rank the label requested (e.g. 'species'); None if not taxa"
+    )
+    resolved_rank: str | None = Field(
+        None, description="Taxonomic rank of the resolved node's name; None if not taxa"
+    )
+    rank_collapsed: bool = Field(
+        False, description="True when the guard detected a coarser (proper-ancestor) resolution"
+    )
 
 
 class NoveltyScore(BaseModel):
@@ -408,6 +423,10 @@ class DiscoveryState(TypedDict, total=False):
     # === Phase 2: Entity Resolution ===
     # Uses operator.add reducer for parallel batch writes
     resolved_entities: Annotated[list[EntityResolution], operator.add]
+    # Guard-1 measurement hook (Axis D): count of rank collapses the resolution guard caught this
+    # run (a coarser proper-ancestor resolution that was abstained/resolved-finer instead of
+    # silently accepted). Single-writer plain int (entity_resolution is serial). Persisted by default.
+    rank_collapse_sign_flips: int
 
     # === Phase 3: Triage & Classification ===
     # Uses operator.add reducer for parallel novelty scoring
@@ -454,6 +473,12 @@ class DiscoveryState(TypedDict, total=False):
 
     # === Phase 5: Output (Updated) ===
     synthesis_report: str
+    # Guard-2 measurement hooks (Axis D): sign-coherence at the synthesis group-fusion boundary.
+    # groups_sign_split = module groups that split in sign; groups_split = sign-coherent sub-programs
+    # produced. Single-writer plain ints (synthesis is terminal). Persisted by default; 0 when no
+    # ModuleSpine / no split → byte-identical for coherent modules.
+    groups_sign_split: int
+    groups_split: int
     # Note: NOT using operator.add - synthesis creates, literature_grounding updates
     hypotheses: list[Hypothesis]
 

--- a/backend/tests/test_entity_resolution_biomapper.py
+++ b/backend/tests/test_entity_resolution_biomapper.py
@@ -80,7 +80,7 @@ class TestReconcile:
             return _gn_envelope(args["curies"], _human_gene_node(args["curies"]))
         monkeypatch.setattr(entity_resolution, "call_kestrel_tool", fake_get_nodes)
         out = await reconcile_to_kestrel(_biomapper_result(), "gene")
-        assert out == ("NCBIGene:7132", "biolink:Gene")
+        assert out == ("NCBIGene:7132", "biolink:Gene", None)
 
     async def test_gene_without_hgnc_rejected(self, monkeypatch):
         # Ortholog confirms in Kestrel but lacks HGNC → defense gate rejects; no other candidate → None.
@@ -101,7 +101,7 @@ class TestReconcile:
         monkeypatch.setattr(entity_resolution, "call_kestrel_tool", fake)
         out = await reconcile_to_kestrel(
             {"curie": "CHEBI:16946", "tier": "high", "xrefs": {}}, "metabolite")
-        assert out == ("CHEBI:16946", "biolink:ChemicalEntity")
+        assert out == ("CHEBI:16946", "biolink:ChemicalEntity", None)
 
     async def test_none_confirm_returns_none(self, monkeypatch):
         async def fake(tool, args):
@@ -120,7 +120,7 @@ class TestReconcile:
             return _gn_envelope(c, None)
         monkeypatch.setattr(entity_resolution, "call_kestrel_tool", fake)
         out = await reconcile_to_kestrel(_biomapper_result(), "gene")
-        assert out == ("NCBIGene:7132", "biolink:Gene")  # node.id, not the queried HGNC curie
+        assert out == ("NCBIGene:7132", "biolink:Gene", None)  # node.id, not the queried HGNC curie
 
     async def test_accepts_list_wrapped_node_envelope(self, monkeypatch):
         # Some Kestrel versions wrap the node as {curie: [node]}; both shapes must parse.
@@ -128,7 +128,19 @@ class TestReconcile:
             return _gn_envelope(args["curies"], _human_gene_node(args["curies"]), as_list=True)
         monkeypatch.setattr(entity_resolution, "call_kestrel_tool", fake)
         out = await reconcile_to_kestrel(_biomapper_result(), "gene")
-        assert out == ("NCBIGene:7132", "biolink:Gene")
+        assert out == ("NCBIGene:7132", "biolink:Gene", None)
+
+    async def test_surfaces_confirmed_node_name(self, monkeypatch):
+        # A genus taxon node carrying a `name` -> reconcile surfaces it as the 3rd tuple element,
+        # so the biomapper rank guard can detect a species->genus collapse (Greptile P1).
+        genus_node = {"id": "NCBITaxon:1263", "name": "Ruminococcus",
+                      "categories": ["biolink:OrganismTaxon"], "equivalent_ids": ["NCBITaxon:1263"]}
+        async def fake(tool, args):
+            return _gn_envelope(args["curies"], genus_node)
+        monkeypatch.setattr(entity_resolution, "call_kestrel_tool", fake)
+        out = await reconcile_to_kestrel(
+            {"curie": "NCBITaxon:1263", "tier": "high", "xrefs": {}}, "metabolite")
+        assert out == ("NCBITaxon:1263", "biolink:OrganismTaxon", "Ruminococcus")
 
     async def test_transport_error_tries_next_candidate(self, monkeypatch):
         calls = {"n": 0}
@@ -226,8 +238,8 @@ class TestRunPrepass:
         monkeypatch.setattr(entity_resolution, "biomapper_resolve", fake_bm)
 
         async def fake_reconcile(r, hint):
-            # Reconciliation confirms the coarse genus CURIE in Kestrel (the pre-fix accept path).
-            return ("NCBITaxon:1263", "biolink:OrganismTaxon")
+            # Reconciliation confirms the coarse genus CURIE + its Kestrel node name ("Ruminococcus").
+            return ("NCBITaxon:1263", "biolink:OrganismTaxon", "Ruminococcus")
         monkeypatch.setattr(entity_resolution, "reconcile_to_kestrel", fake_reconcile)
 
         # A biomapper abstention is terminal for its index: Tier-1 (hybrid_search) must NOT run.
@@ -258,7 +270,7 @@ class TestRunPrepass:
         monkeypatch.setattr(entity_resolution, "biomapper_resolve", fake_bm)
 
         async def fake_reconcile(r, hint):
-            return ("NCBITaxon:33038", "biolink:OrganismTaxon")
+            return ("NCBITaxon:33038", "biolink:OrganismTaxon", "Ruminococcus gnavus")
         monkeypatch.setattr(entity_resolution, "reconcile_to_kestrel", fake_reconcile)
 
         state = {"raw_entities": ["Ruminococcus gnavus"],
@@ -269,3 +281,43 @@ class TestRunPrepass:
         assert r.method == "biomapper"
         assert r.rank_collapsed is False
         assert out["rank_collapse_sign_flips"] == 0
+
+    async def test_flag_on_echoed_query_name_still_abstains_via_confirmed_node(self, monkeypatch):
+        """Greptile P1 (Axis D): the REAL biomapper wrapper returns the raw query VERBATIM as
+        ``resolved_name`` when it has no canonical display name. So for a species query confirmed to
+        a GENUS node, resolved_name == the query ("Ruminococcus gnavus") and requested_rank ==
+        resolved_rank — the rank guard would see NO collapse and wrongly accept the coarse genus
+        CURIE. The guard must instead compare against the CONFIRMED KESTREL NODE name (the genus
+        "Ruminococcus", surfaced by reconcile_to_kestrel) and ABSTAIN. Exercises the REAL reconcile
+        path end-to-end (only get_nodes is mocked)."""
+        _enable_biomapper(monkeypatch)
+        monkeypatch.setattr(entity_resolution, "HAS_SDK", False)
+
+        async def fake_bm(name, hint, base_url=None):
+            # The wrapper ECHOES the raw query as resolved_name (no canonical name available),
+            # while the primary CURIE is the genus node.
+            return {"curie": "NCBITaxon:1263", "tier": "high", "confidence": 2.5,
+                    "resolved_name": "Ruminococcus gnavus", "category": "biolink:OrganismTaxon",
+                    "xrefs": {}}
+        monkeypatch.setattr(entity_resolution, "biomapper_resolve", fake_bm)
+
+        # REAL reconcile_to_kestrel runs; get_nodes confirms the genus CURIE with its Kestrel name.
+        genus_node = {"id": "NCBITaxon:1263", "name": "Ruminococcus",
+                      "categories": ["biolink:OrganismTaxon"], "equivalent_ids": ["NCBITaxon:1263"]}
+        async def fake_kestrel(tool, args):
+            assert tool == "get_nodes", f"Tier-1 must not run for a biomapper-abstained entity (got {tool})"
+            return _gn_envelope(args["curies"], genus_node)
+        monkeypatch.setattr(entity_resolution, "call_kestrel_tool", fake_kestrel)
+
+        # metabolite hint: routes to biomapper (biolink class is non-None) but is NOT HGNC-gated,
+        # so the genus taxon node is accepted by reconcile (the hint is only a routing key here).
+        state = {"raw_entities": ["Ruminococcus gnavus"],
+                 "entity_type_hints": {"Ruminococcus gnavus": "metabolite"}, "entity_aliases": {}}
+        out = await run(state)
+        r = out["resolved_entities"][0]
+        assert r.curie is None                       # coarse genus CURIE dropped despite the echo
+        assert r.method == "failed"                  # routes to cold_start like Tier-1/2 abstain
+        assert r.rank_collapsed is True              # collapse detected via the confirmed node name
+        assert r.raw_name == "Ruminococcus gnavus"
+        assert out["rank_collapse_sign_flips"] == 1  # measurement hook counts it
+

--- a/backend/tests/test_entity_resolution_biomapper.py
+++ b/backend/tests/test_entity_resolution_biomapper.py
@@ -210,3 +210,62 @@ class TestRunPrepass:
         state = {"raw_entities": ["TNFRSF1A"], "entity_type_hints": {"TNFRSF1A": "gene"}, "entity_aliases": {}}
         with pytest.raises(BioMapperAuthError):
             await run(state)
+
+    async def test_flag_on_rank_collapse_abstains_not_accept_genus(self, monkeypatch):
+        """Greptile P1-1: a biomapper hit whose resolved_name collapses a species→genus must pass
+        through the SAME Tier-1 rank guard and ABSTAIN (curie=None, method="failed",
+        rank_collapsed=True) — not feed the coarse genus CURIE straight into triage via the
+        pre-resolver, defeating the Tier-1/2 rank guards (finding #6)."""
+        _enable_biomapper(monkeypatch)
+        monkeypatch.setattr(entity_resolution, "HAS_SDK", False)
+
+        async def fake_bm(name, hint, base_url=None):
+            # Biomapper resolves the raw SPECIES to the GENUS name (the rank collapse).
+            return {"curie": "NCBITaxon:1263", "tier": "high", "confidence": 2.5,
+                    "resolved_name": "Ruminococcus", "category": "biolink:OrganismTaxon", "xrefs": {}}
+        monkeypatch.setattr(entity_resolution, "biomapper_resolve", fake_bm)
+
+        async def fake_reconcile(r, hint):
+            # Reconciliation confirms the coarse genus CURIE in Kestrel (the pre-fix accept path).
+            return ("NCBITaxon:1263", "biolink:OrganismTaxon")
+        monkeypatch.setattr(entity_resolution, "reconcile_to_kestrel", fake_reconcile)
+
+        # A biomapper abstention is terminal for its index: Tier-1 (hybrid_search) must NOT run.
+        async def boom_kestrel(tool, args):
+            raise AssertionError("Tier-1 must not run for a biomapper-abstained entity")
+        monkeypatch.setattr(entity_resolution, "call_kestrel_tool", boom_kestrel)
+
+        state = {"raw_entities": ["Ruminococcus gnavus"],
+                 "entity_type_hints": {"Ruminococcus gnavus": "gene"}, "entity_aliases": {}}
+        out = await run(state)
+        r = out["resolved_entities"][0]
+        assert r.curie is None                       # coarse genus CURIE dropped, never accepted
+        assert r.method == "failed"                  # routes to cold_start like Tier-1/2 abstain
+        assert r.rank_collapsed is True              # diagnostic marker carried into triage
+        assert r.raw_name == "Ruminococcus gnavus"
+        assert out["rank_collapse_sign_flips"] == 1  # measurement hook counts it
+
+    async def test_flag_on_clean_species_hit_still_accepted(self, monkeypatch):
+        """Control: a biomapper hit that does NOT collapse rank (resolved_name is the species) is
+        still accepted verbatim — the guard is a pass-through on non-collapse."""
+        _enable_biomapper(monkeypatch)
+        monkeypatch.setattr(entity_resolution, "HAS_SDK", False)
+
+        async def fake_bm(name, hint, base_url=None):
+            return {"curie": "NCBITaxon:33038", "tier": "high", "confidence": 2.5,
+                    "resolved_name": "Ruminococcus gnavus", "category": "biolink:OrganismTaxon",
+                    "xrefs": {}}
+        monkeypatch.setattr(entity_resolution, "biomapper_resolve", fake_bm)
+
+        async def fake_reconcile(r, hint):
+            return ("NCBITaxon:33038", "biolink:OrganismTaxon")
+        monkeypatch.setattr(entity_resolution, "reconcile_to_kestrel", fake_reconcile)
+
+        state = {"raw_entities": ["Ruminococcus gnavus"],
+                 "entity_type_hints": {"Ruminococcus gnavus": "gene"}, "entity_aliases": {}}
+        out = await run(state)
+        r = out["resolved_entities"][0]
+        assert r.curie == "NCBITaxon:33038"
+        assert r.method == "biomapper"
+        assert r.rank_collapsed is False
+        assert out["rank_collapse_sign_flips"] == 0

--- a/backend/tests/test_entity_resolution_rank_contract.py
+++ b/backend/tests/test_entity_resolution_rank_contract.py
@@ -1,0 +1,47 @@
+"""Unit 3 — resolution-contract: additive optional rank fields on EntityResolution.
+
+The frozen model gains ``requested_rank`` / ``resolved_rank`` / ``rank_collapsed`` as additive
+optionals. Old constructions (which omit them) must be unaffected — defaults apply and equality
+still holds — and the new marker must round-trip via ``model_copy(update=...)``.
+"""
+
+from kestrel_backend.graph.state import EntityResolution
+
+
+def test_defaults_are_inert():
+    r = EntityResolution(raw_name="glucose", curie="CHEBI:17234", method="exact", confidence=0.95)
+    assert r.requested_rank is None
+    assert r.resolved_rank is None
+    assert r.rank_collapsed is False
+
+
+def test_old_construction_equality_unaffected():
+    # Two objects built the legacy way (no rank fields) remain equal — no breaking change to readers
+    # that compare EntityResolution instances.
+    a = EntityResolution(raw_name="x", curie="C:1", method="exact", confidence=0.9)
+    b = EntityResolution(raw_name="x", curie="C:1", method="exact", confidence=0.9)
+    assert a == b
+
+
+def test_marker_round_trips_via_model_copy():
+    base = EntityResolution(raw_name="Ruminococcus gnavus", curie=None, method="failed")
+    flagged = base.model_copy(
+        update={"requested_rank": "species", "resolved_rank": "genus", "rank_collapsed": True}
+    )
+    assert flagged.rank_collapsed is True
+    assert flagged.requested_rank == "species"
+    assert flagged.resolved_rank == "genus"
+    # frozen: original is untouched
+    assert base.rank_collapsed is False
+
+
+def test_direct_construction_with_rank_fields():
+    r = EntityResolution(
+        raw_name="Ruminococcus gnavus",
+        curie=None,
+        method="failed",
+        requested_rank="species",
+        resolved_rank="genus",
+        rank_collapsed=True,
+    )
+    assert r.rank_collapsed is True

--- a/backend/tests/test_entity_resolution_rank_guard.py
+++ b/backend/tests/test_entity_resolution_rank_guard.py
@@ -1,0 +1,158 @@
+"""Unit 2 — rank-collapse guard in entity_resolution (Axis D, Guard 1).
+
+Two seams:
+  * ``_apply_rank_guard`` (Tier-1): abstain-only — no candidate set is in scope at Tier-1, so a
+    species→genus collapse goes straight to method="failed" + rank_collapsed=True (reader budget).
+  * ``_apply_rank_guard_tier2``: resolve-finer when the prefetched candidate set holds a node at the
+    requested rank (same genus), else abstain.
+
+Byte-identical guarantee: when the label yields no rank (non-taxa) the guard is a pass-through.
+"""
+
+import json
+
+import pytest
+
+from kestrel_backend.graph.nodes import entity_resolution
+from kestrel_backend.graph.nodes.entity_resolution import (
+    _apply_rank_guard,
+    _apply_rank_guard_tier2,
+    resolve_via_api,
+)
+from kestrel_backend.graph.state import EntityResolution
+
+
+def _res(raw, curie, name, method="exact", conf=0.95):
+    return EntityResolution(
+        raw_name=raw, curie=curie, resolved_name=name, category="biolink:OrganismTaxon",
+        confidence=conf, method=method,
+    )
+
+
+# ----------------------------- Tier-1 guard (abstain-only) -----------------------------
+
+class TestTier1Guard:
+    def test_species_resolving_to_genus_abstains(self):
+        collapsed = _res("Ruminococcus gnavus", "NCBITaxon:1263", "Ruminococcus")
+        out = _apply_rank_guard("Ruminococcus gnavus", collapsed)
+        assert out.curie is None
+        assert out.method == "failed"
+        assert out.rank_collapsed is True
+        assert out.requested_rank == "species"
+        assert out.resolved_rank == "genus"
+
+    def test_genus_resolving_to_genus_is_untouched(self):
+        clean = _res("Ruminococcus", "NCBITaxon:1263", "Ruminococcus")
+        out = _apply_rank_guard("Ruminococcus", clean)
+        assert out is clean  # pass-through, byte-identical
+
+    def test_non_taxa_is_untouched(self):
+        clean = _res("glucose", "CHEBI:17234", "glucose")
+        out = _apply_rank_guard("glucose", clean)
+        assert out is clean
+
+    def test_already_failed_is_untouched(self):
+        failed = EntityResolution(raw_name="Ruminococcus gnavus", curie=None, method="failed")
+        out = _apply_rank_guard("Ruminococcus gnavus", failed)
+        assert out is failed
+
+
+# ----------------------------- Tier-2 guard (resolve-finer / abstain) -----------------------------
+
+class TestTier2Guard:
+    def test_resolve_finer_prefers_species_candidate(self):
+        chosen = _res("Ruminococcus gnavus", "NCBITaxon:1263", "Ruminococcus")
+        candidates = [
+            {"curie": "NCBITaxon:1263", "name": "Ruminococcus", "category": "biolink:OrganismTaxon", "score": 2.0},
+            {"curie": "NCBITaxon:33038", "name": "Ruminococcus gnavus", "category": "biolink:OrganismTaxon", "score": 1.5},
+        ]
+        out = _apply_rank_guard_tier2("Ruminococcus gnavus", chosen, candidates)
+        assert out.curie == "NCBITaxon:33038"
+        assert out.resolved_name == "Ruminococcus gnavus"
+        assert out.rank_collapsed is False
+
+    def test_abstain_when_no_finer_candidate(self):
+        chosen = _res("Ruminococcus gnavus", "NCBITaxon:1263", "Ruminococcus")
+        candidates = [
+            {"curie": "NCBITaxon:1263", "name": "Ruminococcus", "category": "biolink:OrganismTaxon", "score": 2.0},
+            {"curie": "NCBITaxon:999", "name": "Blautia", "category": "biolink:OrganismTaxon", "score": 1.0},
+        ]
+        out = _apply_rank_guard_tier2("Ruminococcus gnavus", chosen, candidates)
+        assert out.curie is None
+        assert out.method == "failed"
+        assert out.rank_collapsed is True
+
+    def test_no_collapse_is_untouched(self):
+        chosen = _res("Ruminococcus gnavus", "NCBITaxon:33038", "Ruminococcus gnavus")
+        candidates = [{"curie": "NCBITaxon:33038", "name": "Ruminococcus gnavus", "category": None, "score": 2.0}]
+        out = _apply_rank_guard_tier2("Ruminococcus gnavus", chosen, candidates)
+        assert out is chosen
+
+    def test_non_taxa_is_untouched(self):
+        chosen = _res("glucose", "CHEBI:17234", "glucose")
+        out = _apply_rank_guard_tier2("glucose", chosen, [])
+        assert out is chosen
+
+
+# ----------------------------- resolve_via_api integration (Tier-1 wired) -----------------------------
+
+def _hs(search_text, rows):
+    return {"content": [{"type": "text", "text": json.dumps({search_text: rows})}], "isError": False}
+
+
+@pytest.mark.asyncio
+async def test_resolve_via_api_abstains_on_rank_collapse(monkeypatch):
+    genus_node = {
+        "id": "NCBITaxon:1263", "name": "Ruminococcus", "score": 2.5,
+        "categories": ["biolink:OrganismTaxon"],
+    }
+
+    async def fake(tool, args):
+        return _hs(args["search_text"], [genus_node])
+
+    monkeypatch.setattr(entity_resolution, "call_kestrel_tool", fake)
+    out = await resolve_via_api("Ruminococcus gnavus")
+    assert out is not None
+    assert out.curie is None
+    assert out.rank_collapsed is True
+    assert out.method == "failed"
+
+
+@pytest.mark.asyncio
+async def test_category_fallback_preserves_failed_sentinel_on_abstain(monkeypatch):
+    # Constrained call errors → unconstrained retry resolves species→genus → rank guard abstains.
+    # The abstention (curie=None, method="failed") must NOT be relabeled "category-fallback", else it
+    # would be silently dropped from every triage bucket.
+    genus_node = {
+        "id": "NCBITaxon:1263", "name": "Ruminococcus", "score": 2.5,
+        "categories": ["biolink:OrganismTaxon"],
+    }
+
+    async def fake(tool, args):
+        if args.get("category") is not None:
+            return {"content": [], "isError": True}
+        return _hs(args["search_text"], [genus_node])
+
+    monkeypatch.setattr(entity_resolution, "call_kestrel_tool", fake)
+    out = await resolve_via_api("Ruminococcus gnavus", category="biolink:OrganismTaxon")
+    assert out is not None
+    assert out.curie is None
+    assert out.method == "failed"
+    assert out.rank_collapsed is True
+
+
+@pytest.mark.asyncio
+async def test_resolve_via_api_clean_genus_is_unaffected(monkeypatch):
+    genus_node = {
+        "id": "NCBITaxon:1263", "name": "Ruminococcus", "score": 2.5,
+        "categories": ["biolink:OrganismTaxon"],
+    }
+
+    async def fake(tool, args):
+        return _hs(args["search_text"], [genus_node])
+
+    monkeypatch.setattr(entity_resolution, "call_kestrel_tool", fake)
+    out = await resolve_via_api("Ruminococcus")
+    assert out is not None
+    assert out.curie == "NCBITaxon:1263"
+    assert out.rank_collapsed is False

--- a/backend/tests/test_rank_utils.py
+++ b/backend/tests/test_rank_utils.py
@@ -1,0 +1,76 @@
+"""Unit 1 — rank inference from analyte labels (pure).
+
+v1 is taxa-only: a label's requested taxonomic rank is derived from its *shape*
+(binomial / single capitalized token / -aceae / -ales suffix). Non-taxa labels
+(metabolites, genes, diseases) and ambiguous/garbage input return ``None`` so the
+rank guard stays inert and the resolution path is byte-identical.
+"""
+
+import pytest
+
+from kestrel_backend.graph.rank_utils import Rank, infer_requested_rank, is_rank_collapse
+
+
+class TestInferRequestedRank:
+    def test_binomial_is_species(self):
+        assert infer_requested_rank("Ruminococcus gnavus") == Rank.SPECIES
+
+    def test_single_capitalized_token_is_genus(self):
+        assert infer_requested_rank("Ruminococcus") == Rank.GENUS
+
+    def test_aceae_suffix_is_family(self):
+        assert infer_requested_rank("Ruminococcaceae") == Rank.FAMILY
+
+    def test_ales_suffix_is_order(self):
+        assert infer_requested_rank("Clostridiales") == Rank.ORDER
+
+    @pytest.mark.parametrize(
+        "label",
+        [
+            "glucose",                     # lowercase metabolite
+            "N-lactoylphenylalanine",      # chemical name
+            "gamma-glutamylvaline",        # dipeptide
+            "KIF6",                        # gene symbol (all caps + digit)
+            "APOE",                        # gene symbol (all caps)
+            "IL6",                         # gene symbol
+            "vitamin D",                   # two tokens, first lowercase
+        ],
+    )
+    def test_non_taxa_labels_return_none(self, label):
+        assert infer_requested_rank(label) is None
+
+    @pytest.mark.parametrize("label", ["", "   ", None, "123", "!!", "a b c"])
+    def test_empty_or_garbage_returns_none(self, label):
+        assert infer_requested_rank(label) is None
+
+    def test_rank_ordering_species_is_finer_than_genus(self):
+        assert Rank.SPECIES > Rank.GENUS > Rank.FAMILY > Rank.ORDER
+
+    def test_second_binomial_example(self):
+        assert infer_requested_rank("Faecalibacterium prausnitzii") == Rank.SPECIES
+
+
+class TestIsRankCollapse:
+    def test_species_resolving_to_genus_is_collapse(self):
+        assert is_rank_collapse("Ruminococcus gnavus", "Ruminococcus") is True
+
+    def test_genus_resolving_to_genus_is_not_collapse(self):
+        assert is_rank_collapse("Ruminococcus", "Ruminococcus") is False
+
+    def test_species_resolving_to_same_species_is_not_collapse(self):
+        assert is_rank_collapse("Ruminococcus gnavus", "Ruminococcus gnavus") is False
+
+    def test_species_resolving_to_different_genus_is_not_collapse(self):
+        # A wrong-genus resolution is a mis-resolution, not a rank collapse (different concern).
+        assert is_rank_collapse("Ruminococcus gnavus", "Blautia") is False
+
+    def test_non_taxa_never_collapses(self):
+        assert is_rank_collapse("glucose", "glucose-6-phosphate") is False
+
+    def test_none_resolved_name_never_collapses(self):
+        assert is_rank_collapse("Ruminococcus gnavus", None) is False
+
+    def test_lowercase_resolved_name_has_no_rank_so_not_collapse(self):
+        # KG canonical names are Titlecase; a non-canonical lowercase name yields no rank and the
+        # guard stays inert (never a false-positive abstain).
+        assert is_rank_collapse("Ruminococcus gnavus", "ruminococcus") is False

--- a/backend/tests/test_sign_coherence.py
+++ b/backend/tests/test_sign_coherence.py
@@ -1,0 +1,84 @@
+"""Unit 4 — class-agnostic sign-coherence detector (pure, CONSUME module-weight-schema).
+
+``detect_sign_split`` decides whether a group about to be treated as one coordinated program
+actually splits in sign (per-member signed kME). No chemistry/structural-class ontology is used —
+the split is decided purely from the sign of each member's weight (L15). When a split is detected the
+group is partitioned into sign-coherent subgroups so synthesis never fuses a mixed-sign set.
+
+Design decisions (resolving axis-A-dependent unknowns at implementation time):
+  * ``members_kme`` maps member name -> signed kME (float) or ``None`` (magnitude absent for that row).
+  * The magnitude ``floor`` affects only the split *decision* (near-zero members are excluded from
+    the vote); partition membership assigns EVERY member with a defined sign to its subgroup.
+  * ``minority_tol`` tolerates a small opposite-sign minority: split only when the smaller side's
+    fraction of decision-survivors is strictly greater than the tolerance.
+  * ``sign_only=True`` is the graceful-degradation path (magnitude absent for the group): the floor
+    is ignored and every nonzero member is counted.
+"""
+
+from kestrel_backend.graph.sign_coherence import SplitResult, detect_sign_split
+
+
+class TestDetectSignSplit:
+    def test_all_positive_no_split(self):
+        r = detect_sign_split({"a": 0.8, "b": 0.7, "c": 0.9})
+        assert isinstance(r, SplitResult)
+        assert r.is_split is False
+        assert r.positive == ["a", "b", "c"]
+        assert r.negative == []
+
+    def test_clean_mix_splits_into_two_subgroups(self):
+        r = detect_sign_split({"a": 0.8, "b": -0.7, "c": 0.6, "d": -0.9})
+        assert r.is_split is True
+        assert r.positive == ["a", "c"]
+        assert r.negative == ["b", "d"]
+        assert r.unassigned == []
+
+    def test_near_zero_member_excluded_by_floor(self):
+        # c is opposite-sign but below the floor → excluded from the split decision → no split.
+        r = detect_sign_split({"a": 0.8, "b": 0.7, "c": -0.02}, floor=0.1)
+        assert r.is_split is False
+        # partition still assigns c (defined sign) to its subgroup, even though it didn't vote.
+        assert r.negative == ["c"]
+
+    def test_lone_minority_within_tolerance_no_split(self):
+        # 1 of 4 survivors is minority-sign → fraction 0.25, not > tol 0.25 → no split.
+        r = detect_sign_split(
+            {"a": 0.8, "b": 0.7, "c": 0.9, "d": -0.8}, floor=0.1, minority_tol=0.25
+        )
+        assert r.is_split is False
+
+    def test_minority_above_tolerance_splits(self):
+        r = detect_sign_split(
+            {"a": 0.8, "b": 0.7, "c": 0.9, "d": -0.8}, floor=0.1, minority_tol=0.2
+        )
+        assert r.is_split is True
+
+    def test_none_magnitude_member_is_unassigned(self):
+        r = detect_sign_split({"a": 0.8, "b": -0.7, "c": None})
+        assert r.is_split is True
+        assert r.unassigned == ["c"]
+        assert "c" not in r.positive and "c" not in r.negative
+
+    def test_zero_member_is_unassigned(self):
+        r = detect_sign_split({"a": 0.8, "b": -0.7, "c": 0.0})
+        assert r.unassigned == ["c"]
+
+    def test_sign_only_fallback_ignores_floor(self):
+        # sign-only: magnitudes are unit sentinels; floor would normally exclude nothing here, but
+        # the flag guarantees no floor is applied and every nonzero member is counted.
+        r = detect_sign_split(
+            {"a": 1.0, "b": -1.0, "c": 1.0}, floor=0.5, minority_tol=0.0, sign_only=True
+        )
+        assert r.is_split is True
+        assert r.sign_only is True
+        assert r.positive == ["a", "c"]
+        assert r.negative == ["b"]
+
+    def test_empty_group_no_split(self):
+        r = detect_sign_split({})
+        assert r.is_split is False
+        assert r.positive == [] and r.negative == [] and r.unassigned == []
+
+    def test_single_member_no_split(self):
+        r = detect_sign_split({"a": 0.9})
+        assert r.is_split is False

--- a/backend/tests/test_synthesis_sign_coherence.py
+++ b/backend/tests/test_synthesis_sign_coherence.py
@@ -1,0 +1,125 @@
+"""Unit 5 — apply the sign-coherence partition at the synthesis fusion boundary (Axis D, Guard 2).
+
+A group that splits in sign is rendered as two sign-coherent sub-programs (``<group> (+)`` /
+``<group> (−)``) plus a visible annotation, so the "coordinated group" prompt instruction never
+reads a fused mixed-sign set. When no ModuleSpine is present (the state today, before axis A lands)
+the section is absent and the assembled context is byte-identical.
+"""
+
+import pytest
+
+from kestrel_backend.graph.nodes import synthesis
+from kestrel_backend.graph.nodes.synthesis import (
+    assemble_synthesis_context,
+    compute_sign_splits,
+    format_sign_coherence,
+)
+from kestrel_backend.graph.state import Finding
+
+
+def _spine(members: dict) -> dict:
+    """A minimal ModuleSpine-shaped stub: {"members": {name -> kME}}."""
+    return {"members": members}
+
+
+GG_SPLIT_STATE = {
+    "raw_query": "gamma-glutamyl dipeptides",
+    "entity_groups": {
+        "gamma-glutamylvaline": ["GGT dipeptides"],
+        "gamma-glutamylleucine": ["GGT dipeptides"],
+        "gamma-glutamylglutamate": ["GGT dipeptides"],
+        "gamma-glutamylglycine": ["GGT dipeptides"],
+    },
+    "module_spine": _spine(
+        {
+            "gamma-glutamylvaline": 0.8,
+            "gamma-glutamylleucine": 0.7,
+            "gamma-glutamylglutamate": -0.6,
+            "gamma-glutamylglycine": -0.75,
+        }
+    ),
+}
+
+
+class TestComputeSignSplits:
+    def test_split_group_detected_and_counted(self):
+        splits, counts = compute_sign_splits(GG_SPLIT_STATE)
+        assert "GGT dipeptides" in splits
+        assert counts["groups_sign_split"] == 1
+        # two sign-coherent sub-programs produced from the one split group
+        assert counts["groups_split"] == 2
+
+    def test_coherent_group_not_split(self):
+        state = {
+            "entity_groups": {"a": ["mod"], "b": ["mod"]},
+            "module_spine": _spine({"a": 0.8, "b": 0.6}),
+        }
+        splits, counts = compute_sign_splits(state)
+        assert splits == {}
+        assert counts["groups_sign_split"] == 0
+
+    def test_no_module_spine_is_inert(self):
+        state = {"entity_groups": {"a": ["mod"], "b": ["mod"]}}
+        splits, counts = compute_sign_splits(state)
+        assert splits == {}
+        assert counts == {"groups_sign_split": 0, "groups_split": 0}
+
+    def test_group_with_no_spine_entries_skipped(self):
+        state = {
+            "entity_groups": {"x": ["mod"], "y": ["mod"]},
+            "module_spine": _spine({"unrelated": 0.5}),
+        }
+        splits, counts = compute_sign_splits(state)
+        assert splits == {}
+
+
+class TestFormatSignCoherence:
+    def test_split_renders_two_subprograms_and_annotation(self):
+        splits, _ = compute_sign_splits(GG_SPLIT_STATE)
+        section = format_sign_coherence(splits)
+        assert "GGT dipeptides (+)" in section
+        assert "GGT dipeptides (−)" in section  # (−) minus sign
+        assert "gamma-glutamylvaline" in section
+        assert "gamma-glutamylglutamate" in section
+
+    def test_empty_splits_render_nothing(self):
+        assert format_sign_coherence({}) == ""
+
+
+class TestAssembleContextIntegration:
+    def test_split_group_appears_in_assembled_context(self):
+        ctx = assemble_synthesis_context(dict(GG_SPLIT_STATE))
+        assert "GGT dipeptides (+)" in ctx
+        assert "Sign-coherence" in ctx or "sign-coherent" in ctx.lower()
+
+    def test_byte_identical_without_module_spine(self):
+        # Same state minus the module_spine → the sign-coherence section must not appear, and the
+        # assembled context must equal the context assembled when the key is simply absent.
+        base = {k: v for k, v in GG_SPLIT_STATE.items() if k != "module_spine"}
+        ctx = assemble_synthesis_context(dict(base))
+        assert "GGT dipeptides (+)" not in ctx
+        assert "Sign-coherence" not in ctx
+
+
+class TestRunPersistsHooks:
+    # SynthesisInput requires at least one finding to be present; add a trivial one.
+    _FINDING = Finding(entity="x", claim="c", tier=2)
+
+    @pytest.mark.asyncio
+    async def test_run_emits_sign_coherence_measurement_hooks(self, monkeypatch):
+        # Force the deterministic fallback (no LLM) so the node runs offline.
+        monkeypatch.setattr(synthesis, "HAS_SDK", False)
+        state = dict(GG_SPLIT_STATE, direct_findings=[self._FINDING])
+        result = await synthesis.run(state)
+        assert result["groups_sign_split"] == 1
+        assert result["groups_split"] == 2
+        # and the telemetry sub-dict carries them too
+        assert result["synthesis_context_stats"]["sign_coherence"]["groups_sign_split"] == 1
+
+    @pytest.mark.asyncio
+    async def test_run_hooks_zero_without_spine(self, monkeypatch):
+        monkeypatch.setattr(synthesis, "HAS_SDK", False)
+        base = {k: v for k, v in GG_SPLIT_STATE.items() if k != "module_spine"}
+        result = await synthesis.run(dict(base, direct_findings=[self._FINDING]))
+        assert result["groups_sign_split"] == 0
+        assert result["groups_split"] == 0

--- a/backend/tests/test_synthesis_sign_coherence.py
+++ b/backend/tests/test_synthesis_sign_coherence.py
@@ -12,6 +12,7 @@ from kestrel_backend.graph.nodes import synthesis
 from kestrel_backend.graph.nodes.synthesis import (
     assemble_synthesis_context,
     compute_sign_splits,
+    fallback_report,
     format_sign_coherence,
 )
 from kestrel_backend.graph.state import Finding
@@ -99,6 +100,24 @@ class TestAssembleContextIntegration:
         ctx = assemble_synthesis_context(dict(base))
         assert "GGT dipeptides (+)" not in ctx
         assert "Sign-coherence" not in ctx
+
+
+class TestFallbackReportPreservesGuard:
+    """The deterministic fallback must ALSO split sign-incoherent groups (P1 review fix): when the
+    LLM is unavailable or its call falls back, opposite-sign members must not be fused into one
+    program. Mirrors TestAssembleContextIntegration for the degraded path."""
+
+    def test_split_group_appears_in_fallback_report(self):
+        report = fallback_report(dict(GG_SPLIT_STATE))
+        assert "GGT dipeptides (+)" in report
+        assert "GGT dipeptides (−)" in report  # (−) minus sign
+        assert "Sign-coherence" in report or "sign-coherent" in report.lower()
+
+    def test_fallback_report_inert_without_module_spine(self):
+        base = {k: v for k, v in GG_SPLIT_STATE.items() if k != "module_spine"}
+        report = fallback_report(dict(base))
+        assert "GGT dipeptides (+)" not in report
+        assert "Sign-coherence" not in report
 
 
 class TestRunPersistsHooks:

--- a/backend/tests/test_synthesis_sign_coherence.py
+++ b/backend/tests/test_synthesis_sign_coherence.py
@@ -15,12 +15,27 @@ from kestrel_backend.graph.nodes.synthesis import (
     fallback_report,
     format_sign_coherence,
 )
-from kestrel_backend.graph.state import Finding
+from kestrel_backend.graph.state import Finding, MemberWeight, ModuleSpine
 
 
-def _spine(members: dict) -> dict:
-    """A minimal ModuleSpine-shaped stub: {"members": {name -> kME}}."""
-    return {"members": members}
+def _spine(group_members: dict[str, dict[str, float]]) -> dict[str, ModuleSpine]:
+    """Build the REAL ``state.module_spine`` shape: ``dict[group -> ModuleSpine]``, where each
+    ``ModuleSpine`` carries ``.members`` of ``MemberWeight`` with a signed ``kme``.
+
+    This mirrors what the analyte-upload path actually produces. The previous stub was a single
+    ``{"members": {name -> number}}`` dict, which the adapter silently read as group→ModuleSpine
+    with the module objects themselves as kME values (all None) — so the guard NEVER fired on real
+    data (the T-Rex repro). Constructing real Pydantic models here is the permanent regression guard.
+    """
+    return {
+        group: ModuleSpine(
+            group=group,
+            members={
+                name: MemberWeight(name=name, kme=kme) for name, kme in members.items()
+            },
+        )
+        for group, members in group_members.items()
+    }
 
 
 GG_SPLIT_STATE = {
@@ -33,10 +48,12 @@ GG_SPLIT_STATE = {
     },
     "module_spine": _spine(
         {
-            "gamma-glutamylvaline": 0.8,
-            "gamma-glutamylleucine": 0.7,
-            "gamma-glutamylglutamate": -0.6,
-            "gamma-glutamylglycine": -0.75,
+            "GGT dipeptides": {
+                "gamma-glutamylvaline": 0.8,
+                "gamma-glutamylleucine": 0.7,
+                "gamma-glutamylglutamate": -0.6,
+                "gamma-glutamylglycine": -0.75,
+            }
         }
     ),
 }
@@ -50,10 +67,51 @@ class TestComputeSignSplits:
         # two sign-coherent sub-programs produced from the one split group
         assert counts["groups_split"] == 2
 
+    def test_real_moduleSpine_mixed_sign_detected(self):
+        """T-Rex regression: a REAL ModuleSpine of MemberWeight with mixed-sign kME must split.
+
+        Constructed straight from the Pydantic models (not a dict stub) so the adapter is exercised
+        against the exact shape the analyte-upload path produces. Before the adapter fix this
+        returned groups_sign_split == 0 (the guard silently never fired)."""
+        state = {
+            "entity_groups": {"m1": ["ModA"], "m2": ["ModA"], "m3": ["ModA"]},
+            "module_spine": {
+                "ModA": ModuleSpine(
+                    group="ModA",
+                    members={
+                        "m1": MemberWeight(name="m1", kme=0.9),
+                        "m2": MemberWeight(name="m2", kme=-0.85),
+                        "m3": MemberWeight(name="m3", kme=0.7),
+                    },
+                )
+            },
+        }
+        splits, counts = compute_sign_splits(state)
+        assert "ModA" in splits
+        assert counts["groups_sign_split"] == 1
+        assert counts["groups_split"] == 2
+
+    def test_per_module_kme_is_group_scoped(self):
+        """A member in two modules with OPPOSITE kME must be read per-module, not flattened: the
+        split module splits, the coherent module does not (flattening would corrupt one of them)."""
+        state = {
+            "entity_groups": {"shared": ["ModA", "ModB"], "b": ["ModA"], "c": ["ModB"]},
+            "module_spine": _spine(
+                {
+                    "ModA": {"shared": 0.8, "b": -0.7},   # splits
+                    "ModB": {"shared": 0.6, "c": 0.75},   # coherent (shared is + here)
+                }
+            ),
+        }
+        splits, counts = compute_sign_splits(state)
+        assert "ModA" in splits
+        assert "ModB" not in splits
+        assert counts["groups_sign_split"] == 1
+
     def test_coherent_group_not_split(self):
         state = {
             "entity_groups": {"a": ["mod"], "b": ["mod"]},
-            "module_spine": _spine({"a": 0.8, "b": 0.6}),
+            "module_spine": _spine({"mod": {"a": 0.8, "b": 0.6}}),
         }
         splits, counts = compute_sign_splits(state)
         assert splits == {}
@@ -68,7 +126,7 @@ class TestComputeSignSplits:
     def test_group_with_no_spine_entries_skipped(self):
         state = {
             "entity_groups": {"x": ["mod"], "y": ["mod"]},
-            "module_spine": _spine({"unrelated": 0.5}),
+            "module_spine": _spine({"mod": {"unrelated": 0.5}}),
         }
         splits, counts = compute_sign_splits(state)
         assert splits == {}


### PR DESCRIPTION
## Summary

Two guards that stop the discovery pipeline from collapsing distinct biological entities (or distinct sign-programs) into one unit before synthesis reasons over them — the mechanism by which an opposite-sign signal gets silently averaged away.

### Guard 1 — rank preservation (`entity_resolution`)
- New `graph/rank_utils.py`: taxa-only `infer_requested_rank` + `is_rank_collapse` (name-derived; Kestrel nodes carry no lineage metadata).
- Tier-1 abstain-only; Tier-2 resolve-finer over the prefetched candidate set, else abstain via the existing `method="failed"` sentinel (routes to `cold_start`).
- Additive optional `EntityResolution` fields (`requested_rank`/`resolved_rank`/`rank_collapsed`); `rank_collapse_sign_flips` measurement hook.
- Fix: category-fallback no longer relabels a `curie=None` abstention (would strip the failed sentinel and silently drop the entity from every triage bucket).

### Guard 2 — class-agnostic sign-coherence (`synthesis`)
- New `graph/sign_coherence.py`: pure `detect_sign_split` (magnitude floor, minority tolerance, sign-only graceful degradation, partition disposition).
- `synthesis` `compute_sign_splits`/`format_sign_coherence`: a group that splits in sign renders as two sign-coherent sub-programs (`<group> (+)/(−)`) instead of fusing. Adapter isolates the axis-A `ModuleSpine` coupling to one function, so the guard is inert (byte-identical) until a `ModuleSpine` is present in state.
- `groups_sign_split`/`groups_split` measurement hooks persisted by default.

## Safety
Byte-identical when neither guard fires. 57 new tests; full guard + synthesis + resolution + contract suites green.

## Test plan
- `test_rank_utils.py`, `test_entity_resolution_rank_guard.py`, `test_entity_resolution_rank_contract.py`
- `test_sign_coherence.py`, `test_synthesis_sign_coherence.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)