### PR TITLE
fix(bridge-specificity): calibrate DWPC cut points from real KG degrees + saturation floor

### DIFF
--- a/backend/src/kestrel_backend/graph/nodes/bridge_specificity.py
+++ b/backend/src/kestrel_backend/graph/nodes/bridge_specificity.py
@@ -32,12 +32,13 @@ from ..state import BridgeSpecificity
 logger = logging.getLogger(__name__)
 
 # --- Cited / tuned module constants (NOT runtime config) -----------------------------------
-# These are calibrated once from a real intermediate-degree distribution (Unit 4 probe), then
-# frozen — they are cited constants, not a per-run config surface (there is no consumer for
-# runtime-tunable cut points). The values below are placeholders pending the Unit 4 calibration
-# and are known to be mis-skewed relative to real KG degrees; they are chosen to (a) keep the
-# `specific` reward bucket reachable and (b) align the per-node generic cutoff with the pipeline's
-# existing "hub" notion (SharedNeighbor.is_hub = degree > 1000; direct_kg/integration hub guard).
+# These are calibrated once from a real intermediate-degree distribution (the Unit 4 live-Kestrel
+# probe, tests/fixtures/bridge_specificity_1mna_degrees.json), then frozen — they are cited
+# constants, not a per-run config surface (there is no consumer for runtime-tunable cut points).
+# The values below are chosen from that recorded distribution to (a) keep the `specific` reward
+# bucket reachable on real KG degrees (the genuine-specific cluster {115, 143}), and (b) align the
+# per-node generic cutoff with the pipeline's existing "hub" notion (SharedNeighbor.is_hub =
+# degree > 1000; direct_kg/integration hub guard).
 
 # DWPC damping exponent (Himmelstein 2015: w ~= 0.4 optimal for disease-gene prediction).
 DAMPING_W: float = 0.4
@@ -46,15 +47,28 @@ DAMPING_W: float = 0.4
 #   score >= SPECIFIC_CUT -> "specific"
 #   score >= MODERATE_CUT -> "moderate"
 #   else                  -> "generic"
-# With w=0.4 and a single intermediate, score = degree**-0.4, so SPECIFIC_CUT=0.20 admits
-# degree <= ~55 and MODERATE_CUT=0.10 admits degree <= ~316. Placeholders (see note above).
-SPECIFIC_CUT: float = 0.20
-MODERATE_CUT: float = 0.10
+# Calibrated against the recorded real-KG intermediate-degree distribution
+# (tests/fixtures/bridge_specificity_1mna_degrees.json — n=14 live Kestrel degrees): the population
+# splits into a genuine-specific cluster {115, 143} and a hub cluster {1270, 5333, 7471, 7808,
+# 10000...} with a wide gap between. With w=0.4 and a single intermediate (score = degree**-0.4),
+# the cut points map to degree boundaries: SPECIFIC_CUT=0.12 admits degree <= ~200 (the specific
+# cluster + headroom, still below the gap) and MODERATE_CUT=0.063 admits degree <= ~1000 (which
+# coincides with GENERIC_CUTOFF, so the score-based and degree-based generic boundaries agree).
+# The prior placeholders (0.20 / 0.10 -> degree <= ~55) left the "specific" band unreachable on
+# real data (the lowest real intermediate measured is 115).
+SPECIFIC_CUT: float = 0.12
+MODERATE_CUT: float = 0.063
 
 # Per-node degree cutoff: an intermediate whose OWN known degree strictly exceeds this is
 # "generic" and lands in `generic_intermediates`. Aligned with the existing is_hub definition
-# (degree > 1000). Placeholder pending the Unit 4 quantile calibration.
+# (degree > 1000) and sits in the observed real-degree gap (143 <-> 1270).
 GENERIC_CUTOFF: int = 1000
+
+# one_hop_query preview saturates results_count at this value, so a measured degree == this is a
+# FLOOR on the true (larger) hub degree, not an exact count. A saturated intermediate is therefore
+# always treated as a generic mega-hub, independent of GENERIC_CUTOFF. Mirrored by the provider's
+# _DEGREE_QUERY_LIMIT below.
+SATURATION_DEGREE: int = 10000
 
 
 def _bucket(score: float) -> str:
@@ -103,9 +117,13 @@ def bridge_specificity(
             generic_intermediates=[],
         )
 
-    # Generic hubs are decided on KNOWN degrees (strict >), independent of the score.
+    # Generic hubs are decided on KNOWN degrees, independent of the score. A degree at/above the
+    # query-saturation floor is only a lower bound on a mega-hub, so it is generic even if
+    # GENERIC_CUTOFF were ever raised above the saturation point.
     generic_intermediates = [
-        c for c, d in zip(curies, degrees) if d is not None and d > GENERIC_CUTOFF
+        c
+        for c, d in zip(curies, degrees)
+        if d is not None and (d > GENERIC_CUTOFF or d >= SATURATION_DEGREE)
     ]
 
     known = [d for d in degrees if d is not None]
@@ -143,9 +161,10 @@ def bridge_specificity(
 # a CURIE" helper across triage / pathway_enrichment / this provider — deliberately NOT coupled
 # here (that convergence is a separate refactor).
 
-# one_hop_query count limit. Preview mode returns results_count (the edge count == degree);
-# a high limit yields an accurate count, matching triage's read.
-_DEGREE_QUERY_LIMIT = 10000
+# one_hop_query count limit. Preview mode returns results_count (the edge count == degree).
+# This IS the saturation point: a returned count == the limit is a floor, not an exact degree, so
+# the scorer force-generics any intermediate at/above SATURATION_DEGREE (which this mirrors).
+_DEGREE_QUERY_LIMIT = SATURATION_DEGREE
 
 
 def _inline_degree(node: Any) -> int | None:

--- a/backend/tests/test_bridge_specificity_retrodiction.py
+++ b/backend/tests/test_bridge_specificity_retrodiction.py
@@ -15,12 +15,12 @@ version whose "live retrodiction" actually asserted against fabricated placehold
   * SCORER MATH — uses SYNTHETIC degrees, clearly labelled, to prove the pure scorer transform (that
     the `specific` reward band is reachable in principle). No claim about real KG data.
 
-The real degrees also exposed a genuine calibration gap: under the current PLACEHOLDER cut points
-(SPECIFIC_CUT=0.20), the `specific` reward band is unreachable on the real intermediate-degree
-population (the lowest real intermediate measured is ~115; `specific` admits degree <= ~55). That
-gap is asserted as an ``xfail`` below rather than hidden behind fabricated low degrees — it clears
-once the constants are recalibrated from a real distribution (and _DEGREE_QUERY_LIMIT raised so the
-mega-hubs are not saturated at the query cap).
+The real degrees drove the cut-point calibration: the population splits into a genuine-specific
+cluster {115, 143} and a hub cluster {1270 .. 10000} with a wide gap, so the constants are set to
+SPECIFIC_CUT=0.12 (single-intermediate degree <= ~200 -> specific) and MODERATE_CUT=0.063
+(degree <= ~1000, coinciding with GENERIC_CUTOFF). Saturated degrees (== the one_hop query cap) are
+treated as a FLOOR and force-generic rather than raising the query cap — a mega-hub is generic
+regardless of its exact degree, so paying for a higher cap buys nothing.
 
 Run with: uv run python -m pytest tests/test_bridge_specificity_retrodiction.py -v
 """
@@ -79,9 +79,8 @@ def test_low_degree_control_scores_above_generic_scaffold(recorded):
     # The recorded control (1-methylnicotinamide) is a genuinely low-degree metabolite. The
     # meaningful retrodiction contrast is that it is NOT condemned as a generic hub and scores
     # strictly above the all-hub scaffold — i.e. the DWPC signal separates them on real degrees.
-    # NOTE: under the current PLACEHOLDER constants it lands `moderate`, not `specific` (its real
-    # degree ~143 clears the generic cutoff but not the un-calibrated `specific` threshold); the
-    # reward-threshold gap is characterised by the xfail'd population test below.
+    # With the calibrated constants the control's real degree (~143) now lands `specific` — a
+    # genuinely low-degree metabolite is rewarded, not merely "not condemned".
     control = recorded["control_specific"]
     curies = list(control)
     degrees = [control[c]["degree"] for c in curies]
@@ -93,7 +92,7 @@ def test_low_degree_control_scores_above_generic_scaffold(recorded):
         scaffold_curies, [scaffold[c]["degree"] for c in scaffold_curies]
     )
 
-    assert control_spec.label != "generic"
+    assert control_spec.label == "specific"
     assert control_spec.generic_intermediates == []
     assert control_spec.score is not None and scaffold_spec.score is not None
     assert control_spec.score > scaffold_spec.score
@@ -110,26 +109,32 @@ def test_scorer_specific_band_reachable_synthetic():
     assert spec.generic_intermediates == []
 
 
-# --- REAL-population reward reachability: currently a KNOWN calibration gap (xfail) --------------
+# --- REAL-population reward reachability: closed by the Unit-4 recalibration ---------------------
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="PLACEHOLDER cut points leave `specific` unreachable on the real intermediate-degree "
-    "population (lowest measured ~115; SPECIFIC_CUT=0.20 admits degree <= ~55). Un-xfail after the "
-    "constants are recalibrated from a real distribution (bridge_specificity_calibration.py "
-    "recommends quantile cut points) and _DEGREE_QUERY_LIMIT is raised so mega-hubs are not "
-    "saturated at the query cap.",
-)
 def test_specific_reachable_on_recorded_population(recorded):
-    # Under a properly calibrated set of constants a nontrivial fraction of the real
-    # intermediate-degree population should land `specific` — else the reward axis is decorative
-    # (only the penalty side ever fires). This asserts the calibrated TARGET, not today's behaviour.
+    # Both label bands must be reachable on the REAL intermediate-degree population — else the
+    # reward axis is decorative (only the penalty side ever fires). Calibrated cut points
+    # (SPECIFIC_CUT=0.12 / MODERATE_CUT=0.063) reward the genuine-specific cluster {115, 143} while
+    # the hubs (>= 1270, incl. saturated) stay generic. This previously xfail'd under the
+    # placeholder constants; the recalibration closes the gap.
     population = recorded["recorded_intermediate_population"]
     labels = [bridge_specificity([f"N:{i}"], [d]).label for i, d in enumerate(population)]
     n_specific = labels.count("specific")
     assert n_specific >= 2, f"reward bucket collapsed: labels={labels}"
-    # the generic penalty side must also fire (the hubs) — this half holds on real degrees today
+    # the generic penalty side must also fire (the hubs)
     assert labels.count("generic") >= 1
+
+
+# --- saturation is treated as a FLOOR -> force-generic -------------------------------------------
+
+def test_saturated_degree_is_forced_generic():
+    from kestrel_backend.graph.nodes.bridge_specificity import SATURATION_DEGREE
+
+    # A degree measured AT the one_hop query cap is a lower bound on a mega-hub, not an exact count,
+    # so the intermediate must be condemned generic regardless of the score-band arithmetic.
+    spec = bridge_specificity(["SAT:1"], [SATURATION_DEGREE])
+    assert spec.label == "generic"
+    assert spec.generic_intermediates == ["SAT:1"]
 
 
 # --- distribution measurement hook --------------------------------------------------------


### PR DESCRIPTION
## Summary
Closes the Axis-C DWPC follow-up from PR #99: the placeholder cut points left the `specific` band **unreachable** on real KG degrees (`SPECIFIC_CUT=0.20` admits single-intermediate degree ≤ ~55, but the lowest real intermediate measured is 115), so labels collapsed to moderate/generic and the reward axis was decorative.

## Calibration (data-driven)
From the recorded real-degree distribution (n=14 live Kestrel degrees, `bridge_specificity_1mna_degrees.json`), which splits into a genuine-specific cluster **{115, 143}** and a hub cluster **{1270..10000}** with a wide gap:

| constant | old | new | meaning |
|---|---|---|---|
| `SPECIFIC_CUT` | 0.20 | **0.12** | single-intermediate degree ≤ ~200 → specific |
| `MODERATE_CUT` | 0.10 | **0.063** | degree ≤ ~1000, coincides with `GENERIC_CUTOFF` |
| `GENERIC_CUTOFF` | 1000 | 1000 | unchanged; sits in the real gap 143 ↔ 1270 |

## Saturation-as-floor
A degree == the `one_hop` query cap (`SATURATION_DEGREE=10000`) is a **floor** on a mega-hub, not an exact count → a saturated intermediate is force-generic independent of `GENERIC_CUTOFF`. Chosen over raising the query cap (a mega-hub is generic regardless of exact degree, so a higher cap buys nothing). `_DEGREE_QUERY_LIMIT` now mirrors `SATURATION_DEGREE`.

## Tests
- Control (143) now labels `specific` (was `moderate`).
- The previously `xfail(strict)` real-population reachability test now **genuinely passes** — xfail removed.
- Added a saturation force-generic test.
- **28 bridge-specificity tests pass.**

Feature remains **flag-off** (`enabled=False`) — this only fixes what happens when it's enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)